### PR TITLE
Add motivating paragraph to Chapter 1 opening

### DIFF
--- a/chapters/01-groups.html
+++ b/chapters/01-groups.html
@@ -37,6 +37,13 @@
     <main>
         <section>
             <p>
+                When you send Bitcoin, your wallet takes a secret number&mdash;known only to you&mdash;and
+                multiplies it by a special point on a curve, publishing the result for all the world to see.
+                The remarkable fact that nobody can reverse this operation, even with all the world&rsquo;s
+                computers working until the heat death of the universe, is not a matter of engineering
+                but of mathematics. It rests on the properties of an algebraic structure called a <em>group</em>.
+            </p>
+            <p>
                 Before we can understand the elegant machinery that secures Bitcoin, we must first
                 build a foundation in abstract algebra. The concepts introduced in this chapter&mdash;sets,
                 operations, and groups&mdash;may seem far removed from cryptocurrency, yet they form
@@ -44,7 +51,7 @@
             </p>
             <p>
                 We shall proceed methodically, defining each concept with precision and illuminating
-                it with examples both familiar and novel. By the chapter's end, the reader will possess
+                it with examples both familiar and novel. By the chapter&rsquo;s end, the reader will possess
                 the vocabulary necessary to speak of elliptic curves with mathematical rigor.
             </p>
         </section>


### PR DESCRIPTION
## Summary
- Prepend a concrete Bitcoin hook before the existing abstract introduction in Chapter 1
- The reader now learns *why* group theory matters (your wallet multiplies a secret number by a point on a curve, and nobody can reverse it) before being asked to learn the definitions
- Existing prose preserved — the new paragraph flows into the original opening

Closes #3

## Context
Comparing against Pinter (*A Book of Abstract Algebra*), Artin (*Algebra*), and Koblitz (*A Course in Number Theory and Cryptography*), the single highest-impact difference was that great textbooks open with something concrete that makes the reader *want* the abstraction.

## Test plan
- [ ] Read the opening three paragraphs in sequence — they should flow naturally
- [ ] The motivating paragraph should be accessible to someone with no math background
- [ ] No existing content was removed or reworded (except minor apostrophe consistency)