### PR TITLE
Fix 𝔽₂₆ → ℤ₂₆ notation in Example 2.4

### DIFF
--- a/chapters/02-finite-fields.html
+++ b/chapters/02-finite-fields.html
@@ -407,7 +407,7 @@ function extended_gcd(a, b):
             </div>
 
             <div class="example">
-                <p class="example-title">Example 2.4 (Finding 11⁻¹ in 𝔽₂₆)</p>
+                <p class="example-title">Example 2.4 (Finding 11⁻¹ in ℤ₂₆)</p>
                 <p>
                     Although 26 is not prime, let us trace through the algorithm for illustration.
                     We seek <span class="math">x</span> such that <span class="math">11x ≡ 1 (mod 26)</span>.


### PR DESCRIPTION
## Summary
Fix notation error: 26 is not prime, so 𝔽₂₆ doesn't exist as a prime field. Changed to ℤ₂₆.

Closes #9