### PR TITLE
Fix 10x arithmetic error in Ch 14 Example 14.4

### DIFF
--- a/chapters/14-proof-of-work.html
+++ b/chapters/14-proof-of-work.html
@@ -491,13 +491,13 @@ new_difficulty = old_difficulty / 0.857
                 <pre class="code-block">Daily electricity cost = 3 kW × 24h × $0.05 = $3.60
 
 If network hashrate = 500 EH/s:
-  Share of blocks = 100 TH / 500 EH = 0.0002%
-  Expected daily blocks = 144 × 0.000002 = 0.000288
+  Share of blocks = 100 TH / 500 EH = 0.00002%
+  Expected daily blocks = 144 × 0.0000002 = 0.0000288
 
 Daily revenue (at 6.25 BTC subsidy, $40,000/BTC):
-  = 0.000288 × 6.25 × $40,000 = $72
+  = 0.0000288 × 6.25 × $40,000 = $7.20
 
-Daily profit = $72 - $3.60 = $68.40</pre>
+Daily profit = $7.20 - $3.60 = $3.60</pre>
             </div>
         </section>
 


### PR DESCRIPTION
## Summary
- Fixed hash share: 100 TH / 500 EH = 0.00002% (was incorrectly 0.0002%)
- Recomputed all downstream values: expected daily blocks (0.0000288), daily revenue ($7.20), daily profit ($3.60)
- The original values were uniformly 10x too high

Fixes #17