### PR TITLE
Fix BIP-66/BIP-65 activation mechanism in soft fork table

### DIFF
--- a/chapters/16-soft-forks.html
+++ b/chapters/16-soft-forks.html
@@ -344,13 +344,13 @@
                         <td>BIP-66 (Strict DER)</td>
                         <td>66</td>
                         <td>July 2015</td>
-                        <td>BIP-9</td>
+                        <td>IsSuperMajority (BIP-34 style)</td>
                     </tr>
                     <tr>
                         <td>BIP-65 (CHECKLOCKTIMEVERIFY)</td>
                         <td>65</td>
                         <td>December 2015</td>
-                        <td>BIP-9</td>
+                        <td>IsSuperMajority (BIP-34 style)</td>
                     </tr>
                     <tr>
                         <td>BIP-68/112/113 (Relative Locks)</td>


### PR DESCRIPTION
## Summary
- Changed activation mechanism for BIP-66 and BIP-65 from "BIP-9" to "IsSuperMajority (BIP-34 style)"
- Both soft forks used nVersion field incrementing, not version bits
- BIP-9 was first used for CSV (BIP-68/112/113) in July 2016

Fixes #18