### PR TITLE
Qualify HTLC atomicity claim in Ch 24 Theorem 24.1

### DIFF
--- a/chapters/24-lightning.html
+++ b/chapters/24-lightning.html
@@ -205,7 +205,7 @@
                 <ul>
                     <li><strong>Complete success:</strong> All HTLCs settle, receiver gets paid, all routing nodes receive fees</li>
                     <li><strong>Complete failure:</strong> All HTLCs timeout, sender loses nothing</li>
-                    <li><strong>No partial state:</strong> Either all or nothing, never some HTLCs settled and others failed</li>
+                    <li><strong>Conditional atomicity:</strong> Assuming sufficient CLTV deltas and timely blockchain access, either all HTLCs settle or all fail. Partial failure <em>is</em> possible under adverse conditions (e.g., blockchain congestion preventing an intermediate node from claiming before its incoming HTLC times out), which is why sufficient timelock margins are critical.</li>
                 </ul>
             </div>
 


### PR DESCRIPTION
## Summary
- Replaced absolute "No partial state" claim with conditional atomicity
- Partial failure IS possible when blockchain congestion prevents an intermediate node from claiming before its incoming HTLC times out
- This is a known issue discussed in Poon/Dryja and is why sufficient CLTV deltas are critical

Fixes #21