### PR TITLE
Add difficulty adjustment off-by-one error remark in Ch 14

### DIFF
--- a/chapters/14-proof-of-work.html
+++ b/chapters/14-proof-of-work.html
@@ -260,6 +260,17 @@
                 </p>
             </div>
 
+            <div class="remark">
+                <p class="remark-title">Off-by-one error.</p>
+                <p>
+                    Bitcoin Core's implementation measures
+                    <span class="math">actual_time = timestamp(block[h]) − timestamp(block[h − 2016])</span>,
+                    which spans 2015 inter-block intervals rather than 2016. This makes
+                    difficulty systematically ~0.05% too low. The bug has been preserved
+                    for consensus compatibility.
+                </p>
+            </div>
+
             <div class="theorem">
                 <p class="theorem-title">Theorem 14.2 (Adjustment Bounds)</p>
                 <p>


### PR DESCRIPTION
## Summary
- Added remark noting the well-known off-by-one error in Bitcoin's difficulty adjustment
- The code measures 2015 inter-block intervals instead of 2016, making difficulty ~0.05% too low
- Preserved for consensus compatibility (changing it would be a hard fork)

Fixes #27