### PR TITLE
Fix probability tables in Ch 14, 17, 36 with Nakamoto formula

### DIFF
--- a/chapters/14-proof-of-work.html
+++ b/chapters/14-proof-of-work.html
@@ -560,27 +560,27 @@ Daily profit = $7.20 - $3.60 = $3.60</pre>
                 <tbody>
                     <tr>
                         <td>10%</td>
-                        <td>20.4%</td>
+                        <td>20.5%</td>
                         <td>1.3%</td>
                         <td>0.02%</td>
                     </tr>
                     <tr>
                         <td>25%</td>
-                        <td>43.7%</td>
-                        <td>12.9%</td>
-                        <td>2.4%</td>
+                        <td>52.2%</td>
+                        <td>19.6%</td>
+                        <td>5.0%</td>
                     </tr>
                     <tr>
                         <td>33%</td>
-                        <td>55.6%</td>
-                        <td>25.7%</td>
-                        <td>9.1%</td>
+                        <td>69.0%</td>
+                        <td>41.7%</td>
+                        <td>21.3%</td>
                     </tr>
                     <tr>
                         <td>45%</td>
-                        <td>73.3%</td>
-                        <td>51.0%</td>
-                        <td>33.5%</td>
+                        <td>92.0%</td>
+                        <td>84.4%</td>
+                        <td>76.6%</td>
                     </tr>
                 </tbody>
             </table>

--- a/chapters/17-spv-theory.html
+++ b/chapters/17-spv-theory.html
@@ -468,7 +468,11 @@
                     confirmations decreases exponentially with <span class="math">k</span>:
                 </p>
                 <p class="math-block">
-                    P(reversal) ≈ (q/p)^k where p = 1 - q
+                    P(reversal) = 1 − Σₘ₌₀ᵏ [λᵐe^(−λ)/m! × (1 − (q/p)^(k−m))]
+                </p>
+                <p>
+                    where <span class="math">λ = k(q/p)</span> and <span class="math">p = 1 − q</span>
+                    (the Nakamoto formula from Section 11 of the Bitcoin whitepaper).
                 </p>
             </div>
 
@@ -484,27 +488,27 @@
                 <tbody>
                     <tr>
                         <td>1</td>
-                        <td>20.4%</td>
-                        <td>43.7%</td>
-                        <td>66.7%</td>
+                        <td>20.5%</td>
+                        <td>52.2%</td>
+                        <td>82.9%</td>
                     </tr>
                     <tr>
                         <td>3</td>
                         <td>1.3%</td>
-                        <td>12.9%</td>
-                        <td>35.6%</td>
+                        <td>19.6%</td>
+                        <td>66.4%</td>
                     </tr>
                     <tr>
                         <td>6</td>
                         <td>0.02%</td>
-                        <td>2.4%</td>
-                        <td>15.4%</td>
+                        <td>5.0%</td>
+                        <td>50.4%</td>
                     </tr>
                     <tr>
                         <td>12</td>
                         <td>~0%</td>
-                        <td>0.08%</td>
-                        <td>3.0%</td>
+                        <td>0.4%</td>
+                        <td>30.6%</td>
                     </tr>
                 </tbody>
             </table>

--- a/chapters/36-security-threats.html
+++ b/chapters/36-security-threats.html
@@ -163,23 +163,23 @@
                     <tr>
                         <td>10%</td>
                         <td>20%</td>
-                        <td>1.2%</td>
+                        <td>1%</td>
                         <td>0.02%</td>
                         <td>~0%</td>
                     </tr>
                     <tr>
                         <td>25%</td>
-                        <td>43%</td>
-                        <td>13%</td>
-                        <td>2.4%</td>
-                        <td>0.06%</td>
+                        <td>52%</td>
+                        <td>20%</td>
+                        <td>5%</td>
+                        <td>0.4%</td>
                     </tr>
                     <tr>
                         <td>40%</td>
-                        <td>67%</td>
-                        <td>40%</td>
-                        <td>20%</td>
-                        <td>4%</td>
+                        <td>83%</td>
+                        <td>66%</td>
+                        <td>50%</td>
+                        <td>31%</td>
                     </tr>
                     <tr>
                         <td>50%</td>


### PR DESCRIPTION
## Summary
- Replaced incorrect (q/p)^k approximation with the full Nakamoto formula from Bitcoin whitepaper Section 11 in probability tables across three chapters
- Fixed Ch 17 to display the correct formula (was showing the simplified approximation as if it were exact)
- The old values dramatically underestimated attack probability for q ≥ 25% (e.g., q=45% z=6 was shown as 33.5%, correct value is 76.6%)

## Chapters affected
- **Ch 14** (Proof of Work): Table 14.3 — 9 values corrected
- **Ch 17** (SPV Theory): Formula display fixed + Table 17.2 — 9 values corrected
- **Ch 36** (Security Threats): Table 36.1 — 9 values corrected

## Verification
Values computed using Python's `math` module with the exact Nakamoto formula:
`P = 1 - sum(poisson_pmf(m, lambda) * (1 - (q/p)**(z-m)) for m in range(z+1))`
where `lambda = z * q / p`

Fixes #49