### PR TITLE
Fix false positive days calculation and variable naming in Ch 19

### DIFF
--- a/chapters/19-compact-filters.html
+++ b/chapters/19-compact-filters.html
@@ -571,7 +571,8 @@
                 </ol>
                 <p>
                     Expected false positive rate: 1/784931 per scriptPubKey per block.
-                    With 50 addresses: ~1/15698 per block ≈ one false positive every ~2.3 days.
+                    With 50 addresses: ~50/784931 ≈ 1/15699 per block ≈ one false positive every ~109 days
+                    (at 144 blocks/day).
                 </p>
             </div>
         </section>
@@ -814,10 +815,10 @@
                     of at least one false positive is:
                 </p>
                 <div class="formula">
-                    P(false positive) = 1 - (1 - 1/M)<sup>Q</sup> ≈ Q/M
+                    P(false positive) = 1 - (1 - 1/F)<sup>Q</sup> ≈ Q/F
                 </div>
                 <p>
-                    With M = 784931, a wallet with 100 addresses has approximately 1/7849
+                    With F = 784931, a wallet with 100 addresses has approximately 1/7849
                     chance of false positive per block.
                 </p>
             </div>


### PR DESCRIPTION
## Summary
- **Example 19.3**: False positive interval was wrong by 47x. With 50 addresses and F=784931: per-block FP rate is 50/784931 ≈ 1/15699, giving one false positive every ~109 days (at 144 blocks/day), not ~2.3 days as stated.
- **Theorem 19.4**: Used variable `M` (already defined in Def 19.1 as Golomb parameter = 2^P = 524288) where `F` (false positive parameter = 784931, defined in Def 19.5) was intended.

The 2.3 days figure likely came from confusing BIP-158 compact filters (F=784931) with BIP-37 Bloom filters (typical f≈0.01).

Fixes #55