### PR TITLE
Fix adaptor signature nonce point in Ch 29

### DIFF
--- a/chapters/29-taproot-architecture.html
+++ b/chapters/29-taproot-architecture.html
@@ -560,7 +560,7 @@ Stack after:  [n] (or [n+1] if valid)
                 <ul>
                     <li>Adaptor point: T = t·G (public)</li>
                     <li>Adaptor signature: σ' = (R + T, s')</li>
-                    <li>When t is revealed: σ = (R, s' + t) is valid</li>
+                    <li>When t is revealed: σ = (R + T, s' + t) is valid</li>
                 </ul>
             </div>
 
@@ -571,7 +571,7 @@ Stack after:  [n] (or [n+1] if valid)
                 </p>
                 <ol>
                     <li>Alice gives Bob adaptor σ' (valid when combined with secret t)</li>
-                    <li>Bob broadcasts transaction with σ = (R, s' + t)</li>
+                    <li>Bob broadcasts transaction with σ = (R + T, s' + t)</li>
                     <li>Alice learns t from the broadcast signature: t = s - s'</li>
                     <li>Alice uses t to complete her side of the swap</li>
                 </ol>


### PR DESCRIPTION
## Summary
- Completed adaptor signature was `σ = (R, s' + t)` — wrong nonce point
- Correct form: `σ = (R + T, s' + t)` — the nonce point R' = R + T is the same in both pre-signature and completed signature; the secret t is absorbed into the scalar, not stripped from the nonce
- Fixed in both Definition 29.12 and Theorem 29.7

Fixes #59