### PR TITLE
Fix SHA-256 collision resistance claim in Ch 25

### DIFF
--- a/chapters/25-debunking-myths.html
+++ b/chapters/25-debunking-myths.html
@@ -416,9 +416,9 @@
                     As of 2024:
                 </p>
                 <ul>
-                    <li><strong>Collision resistance:</strong> Best attack reduces 256-bit to ~250-bit equivalent (still infeasible)</li>
-                    <li><strong>Preimage resistance:</strong> No attacks better than brute force</li>
-                    <li><strong>Second preimage:</strong> No practical attacks</li>
+                    <li><strong>Collision resistance:</strong> 2<sup>128</sup> operations (birthday bound); no attacks on full SHA-256 significantly better than this</li>
+                    <li><strong>Preimage resistance:</strong> 2<sup>256</sup> operations; no attacks better than brute force</li>
+                    <li><strong>Second preimage:</strong> 2<sup>256</sup> operations; no practical attacks</li>
                 </ul>
                 <p>
                     Even if SHA-256 were weakened to 128-bit security, this provides


### PR DESCRIPTION
## Summary
- Collision resistance was stated as "256-bit reduced to ~250-bit" — wrong. SHA-256 collision resistance is 2^128 (birthday bound = 2^(n/2)), not 2^256
- The 256-bit figure applies to preimage resistance, not collision resistance
- Added explicit security levels for all three hash properties: collision (2^128), preimage (2^256), second preimage (2^256)

Fixes #63