### PR TITLE
Update block subsidy from 6.25 to 3.125 BTC in Ch 25

### DIFF
--- a/chapters/25-debunking-myths.html
+++ b/chapters/25-debunking-myths.html
@@ -138,7 +138,7 @@
                 </p>
                 <p>
                     Attack scenario: Miners controlling 51% of hashrate create an invalid block
-                    giving themselves 1000 BTC subsidy instead of 6.25 BTC. Full nodes reject this
+                    giving themselves 1000 BTC subsidy instead of 3.125 BTC. Full nodes reject this
                     block. SPV clients accept it because it has the most work.
                 </p>
                 <p>
@@ -533,7 +533,7 @@
                 <h4>Myth: "Bitcoin can't work when block subsidy goes to zero"</h4>
                 <p>
                     Without block rewards, miners won't mine, and Bitcoin will fail.
-                    The fee market can't possibly replace 6.25 BTC per block.
+                    The fee market can't possibly replace 3.125 BTC per block.
                 </p>
             </div>
 


### PR DESCRIPTION
## Summary
Updated two references to the block subsidy from 6.25 BTC to 3.125 BTC following the April 2024 halving.

Fixes #65