### PR TITLE
Update block subsidy in Ch 14 mining example

### DIFF
--- a/chapters/14-proof-of-work.html
+++ b/chapters/14-proof-of-work.html
@@ -505,10 +505,10 @@ If network hashrate = 500 EH/s:
   Share of blocks = 100 TH / 500 EH = 0.00002%
   Expected daily blocks = 144 × 0.0000002 = 0.0000288
 
-Daily revenue (at 6.25 BTC subsidy, $40,000/BTC):
-  = 0.0000288 × 6.25 × $40,000 = $7.20
+Daily revenue (at 3.125 BTC subsidy, $40,000/BTC):
+  = 0.0000288 × 3.125 × $40,000 = $3.60
 
-Daily profit = $7.20 - $3.60 = $3.60</pre>
+Daily profit = $3.60 - $3.60 = $0.00</pre>
             </div>
         </section>
 


### PR DESCRIPTION
## Summary
Updated mining revenue example from 6.25 to 3.125 BTC subsidy with recalculated values. The Ch 38 reference to 6.25 BTC is in a historical halving table (2020 epoch) and is correct.

Fixes #69