### PR TITLE
Fix theorem div misuses in chapters 4-8

### DIFF
--- a/chapters/04-elliptic-curves-finite.html
+++ b/chapters/04-elliptic-curves-finite.html
@@ -563,8 +563,8 @@
                 the selection of cryptographic curves:
             </p>
 
-            <div class="theorem">
-                <p class="theorem-title">Criteria for Cryptographic Curves</p>
+            <div class="remark">
+                <p class="remark-title">Criteria for Cryptographic Curves.</p>
                 <ol>
                     <li><strong>Large prime order subgroup:</strong> The curve should have a
                         subgroup of order <span class="math">n</span> where <span class="math">n</span>

--- a/chapters/05-secp256k1.html
+++ b/chapters/05-secp256k1.html
@@ -566,8 +566,8 @@ FD17B448 A6855419 9C47D08F FB10D4B8</pre>
                 common NIST curves. Several factors likely influenced this decision:
             </p>
 
-            <div class="theorem">
-                <p class="theorem-title">Advantages of secp256k1</p>
+            <div class="remark">
+                <p class="remark-title">Advantages of secp256k1.</p>
                 <ol>
                     <li>
                         <strong>Efficiency:</strong> The special form of <span class="math">p</span>
@@ -609,8 +609,8 @@ FD17B448 A6855419 9C47D08F FB10D4B8</pre>
                 for well-implemented systems, the curve provides excellent security.
             </p>
 
-            <div class="theorem">
-                <p class="theorem-title">Security Properties of secp256k1</p>
+            <div class="remark">
+                <p class="remark-title">Security Properties of secp256k1.</p>
                 <ul>
                     <li>
                         <strong>ECDLP hardness:</strong> No algorithm better than

--- a/chapters/06-hash-functions.html
+++ b/chapters/06-hash-functions.html
@@ -195,8 +195,8 @@
                 </p>
             </div>
 
-            <div class="theorem">
-                <p class="theorem-title">The Avalanche Effect</p>
+            <div class="remark">
+                <p class="remark-title">The Avalanche Effect.</p>
                 <p>
                     A good hash function exhibits the <strong>avalanche effect</strong>: changing
                     a single bit of input changes approximately 50% of the output bits. This
@@ -399,8 +399,8 @@
                 sign its hash. This approach offers several advantages:
             </p>
 
-            <div class="theorem">
-                <p class="theorem-title">Why Hash Before Signing?</p>
+            <div class="remark">
+                <p class="remark-title">Why Hash Before Signing?</p>
                 <ol>
                     <li>
                         <strong>Fixed input size:</strong> The signature algorithm operates on

--- a/chapters/07-ecdsa.html
+++ b/chapters/07-ecdsa.html
@@ -148,8 +148,8 @@
                 <figcaption>Figure 7.1: The signing and verification process in a digital signature scheme.</figcaption>
             </figure>
 
-            <div class="theorem">
-                <p class="theorem-title">Security Properties of Digital Signatures</p>
+            <div class="remark">
+                <p class="remark-title">Security Properties of Digital Signatures.</p>
                 <p>A secure signature scheme must satisfy:</p>
                 <ol>
                     <li>

--- a/chapters/08-schnorr.html
+++ b/chapters/08-schnorr.html
@@ -60,8 +60,8 @@
                 Schnorr signatures alongside ECDSA rather than replacing it entirely.
             </p>
 
-            <div class="theorem">
-                <p class="theorem-title">Advantages of Schnorr over ECDSA</p>
+            <div class="remark">
+                <p class="remark-title">Advantages of Schnorr over ECDSA.</p>
                 <ol>
                     <li>
                         <strong>Provable security:</strong> Schnorr has a formal security proof


### PR DESCRIPTION
## Summary
- Reclassify 7 non-theorem items from `class="theorem"` to `class="remark"` across chapters 4-8
- These items are property lists, advantage lists, and criteria descriptions — not provable mathematical statements
- Affected: Ch 4 (1), Ch 5 (2), Ch 6 (2), Ch 7 (1), Ch 8 (1)

## Test plan
- [ ] Verify remark styling renders correctly on each affected page
- [ ] Confirm no numbered theorem references are broken

Fixes #71