### PR TITLE
Fix theorem label misuses in chapter 25

### DIFF
--- a/chapters/25-debunking-myths.html
+++ b/chapters/25-debunking-myths.html
@@ -109,8 +109,8 @@
                 <h4>Reality: SPV trusts miners not to commit fraud; full nodes detect it</h4>
             </div>
 
-            <div class="theorem">
-                <p><strong>Theorem 25.1</strong> (SPV Trust Model)</p>
+            <div class="remark">
+                <p><strong>Remark 25.1</strong> (SPV Trust Model)</p>
                 <p>
                     An SPV client accepts a transaction as valid if:
                 </p>
@@ -172,8 +172,8 @@
                 <h4>Reality: Fraud proofs help but have fundamental limitations</h4>
             </div>
 
-            <div class="theorem">
-                <p><strong>Theorem 25.2</strong> (Fraud Proof Limitations)</p>
+            <div class="remark">
+                <p><strong>Remark 25.2</strong> (Fraud Proof Limitations)</p>
                 <p>
                     Effective fraud proofs require:
                 </p>
@@ -211,8 +211,8 @@
                 <h4>Reality: On-chain scaling has diminishing returns; layer 2 scales multiplicatively</h4>
             </div>
 
-            <div class="theorem">
-                <p><strong>Theorem 25.3</strong> (Scaling Approaches)</p>
+            <div class="remark">
+                <p><strong>Remark 25.3</strong> (Scaling Approaches)</p>
                 <p>
                     On-chain scaling (larger blocks):
                 </p>
@@ -279,7 +279,7 @@
             </div>
 
             <div class="theorem">
-                <p><strong>Theorem 25.4</strong> (Lightning Ownership)</p>
+                <p><strong>Proposition 25.4</strong> (Lightning Ownership)</p>
                 <p>
                     In a Lightning channel:
                 </p>
@@ -326,8 +326,8 @@
                 <h4>Reality: Watchtowers and reasonable timelocks mitigate this concern</h4>
             </div>
 
-            <div class="theorem">
-                <p><strong>Theorem 25.5</strong> (Liveness Requirements)</p>
+            <div class="remark">
+                <p><strong>Remark 25.5</strong> (Liveness Requirements)</p>
                 <p>
                     With an LN-Penalty channel:
                 </p>
@@ -360,8 +360,8 @@
                 <h4>Reality: Quantum threats are real but manageable with known mitigations</h4>
             </div>
 
-            <div class="theorem">
-                <p><strong>Theorem 25.6</strong> (Quantum Threat Analysis)</p>
+            <div class="remark">
+                <p><strong>Remark 25.6</strong> (Quantum Threat Analysis)</p>
                 <p>
                     Quantum computers threaten Bitcoin in two ways:
                 </p>
@@ -410,8 +410,8 @@
                 <h4>Reality: No practical attacks on SHA-256 exist; theoretical weaknesses don't threaten Bitcoin</h4>
             </div>
 
-            <div class="theorem">
-                <p><strong>Theorem 25.7</strong> (SHA-256 Security Status)</p>
+            <div class="remark">
+                <p><strong>Remark 25.7</strong> (SHA-256 Security Status)</p>
                 <p>
                     As of 2024:
                 </p>
@@ -449,7 +449,7 @@
             </div>
 
             <div class="theorem">
-                <p><strong>Theorem 25.8</strong> (51% Attack Capabilities)</p>
+                <p><strong>Proposition 25.8</strong> (51% Attack Capabilities)</p>
                 <p>
                     An attacker with majority hashrate CAN:
                 </p>
@@ -499,8 +499,8 @@
                 <h4>Reality: Full nodes enforce rules; miners just select valid transactions</h4>
             </div>
 
-            <div class="theorem">
-                <p><strong>Theorem 25.9</strong> (Rule Enforcement Hierarchy)</p>
+            <div class="remark">
+                <p><strong>Remark 25.9</strong> (Rule Enforcement Hierarchy)</p>
                 <p>
                     Bitcoin rule enforcement:
                 </p>
@@ -541,8 +541,8 @@
                 <h4>Reality: Fee revenue is already significant and scales with economic activity</h4>
             </div>
 
-            <div class="theorem">
-                <p><strong>Theorem 25.10</strong> (Long-Term Security Budget)</p>
+            <div class="remark">
+                <p><strong>Remark 25.10</strong> (Long-Term Security Budget)</p>
                 <p>
                     Security budget sustainability requires:
                 </p>
@@ -600,8 +600,8 @@
                 <h4>Reality: Energy consumption provides security; "waste" is subjective</h4>
             </div>
 
-            <div class="theorem">
-                <p><strong>Theorem 25.11</strong> (Energy-Security Relationship)</p>
+            <div class="remark">
+                <p><strong>Remark 25.11</strong> (Energy-Security Relationship)</p>
                 <p>
                     The cost to attack Bitcoin ≈ mining hardware + energy cost to produce
                     equivalent hashrate. High energy consumption directly creates high
@@ -636,8 +636,8 @@
                 <h4>Reality: Protocol-level blacklisting is technically impossible</h4>
             </div>
 
-            <div class="theorem">
-                <p><strong>Theorem 25.12</strong> (Censorship Properties)</p>
+            <div class="remark">
+                <p><strong>Remark 25.12</strong> (Censorship Properties)</p>
                 <p>
                     Bitcoin addresses are pseudonymous identifiers with no protocol-level identity:
                 </p>
@@ -668,8 +668,8 @@
                 <h4>Reality: Full nodes enforce rules and give users sovereignty</h4>
             </div>
 
-            <div class="theorem">
-                <p><strong>Theorem 25.13</strong> (Full Node Value)</p>
+            <div class="remark">
+                <p><strong>Remark 25.13</strong> (Full Node Value)</p>
                 <p>
                     A full node provides its operator:
                 </p>


### PR DESCRIPTION
## Summary
- Relabel 13 misused "Theorem" labels in Ch 25 (Debunking Myths)
- 2 items with proofs (25.4, 25.8) → Proposition
- 11 items without proofs (descriptive lists, analyses) → Remark
- Changes `class="theorem"` to `class="remark"` for the 11 remark items

## Test plan
- [ ] Verify remark styling renders correctly
- [ ] Confirm proposition items retain theorem-box styling (class unchanged)

Fixes #73