### PR TITLE
Fix theorem label misuses in chapters 28, 29, 35, 36

### DIFF
--- a/chapters/28-segwit-deep-dive.html
+++ b/chapters/28-segwit-deep-dive.html
@@ -55,8 +55,8 @@
                 </ul>
             </div>
 
-            <div class="theorem">
-                <p class="theorem-title">Theorem 28.1 (Pre-SegWit Malleability Sources)</p>
+            <div class="remark">
+                <p class="remark-title">Remark 28.1 (Pre-SegWit Malleability Sources).</p>
                 <p>
                     In pre-SegWit Bitcoin, the txid was computed over the entire transaction
                     including signatures. Several malleability vectors existed:
@@ -448,8 +448,8 @@ where:
                 </p>
             </div>
 
-            <div class="theorem">
-                <p class="theorem-title">Theorem 28.4 (SegWit Capacity Increase)</p>
+            <div class="remark">
+                <p class="remark-title">Remark 28.4 (SegWit Capacity Increase).</p>
                 <p>
                     SegWit increases effective block capacity:
                 </p>
@@ -677,8 +677,8 @@ SHA256d(
 )</pre>
             </div>
 
-            <div class="theorem">
-                <p class="theorem-title">Theorem 28.6 (BIP-143 Improvements)</p>
+            <div class="remark">
+                <p class="remark-title">Remark 28.6 (BIP-143 Improvements).</p>
                 <p>
                     BIP-143 sighash fixes multiple issues:
                 </p>

--- a/chapters/29-taproot-architecture.html
+++ b/chapters/29-taproot-architecture.html
@@ -123,8 +123,8 @@
                 </ul>
             </div>
 
-            <div class="theorem">
-                <p class="theorem-title">Theorem 29.1 (X-Only Savings)</p>
+            <div class="remark">
+                <p class="remark-title">Remark 29.1 (X-Only Savings).</p>
                 <p>
                     X-only keys save 1 byte per public key. For a Taproot output:
                 </p>
@@ -409,8 +409,8 @@ Stack after:  [n] (or [n+1] if valid)
   2 OP_NUMEQUAL</pre>
             </div>
 
-            <div class="theorem">
-                <p class="theorem-title">Theorem 29.5 (Tapscript Multisig Efficiency)</p>
+            <div class="remark">
+                <p class="remark-title">Remark 29.5 (Tapscript Multisig Efficiency).</p>
                 <p>
                     CHECKSIGADD is more efficient than OP_CHECKMULTISIG:
                 </p>

--- a/chapters/35-consensus-cleanup.html
+++ b/chapters/35-consensus-cleanup.html
@@ -384,7 +384,7 @@ Different blocks, same merkle root → attack vector</pre>
             </div>
 
             <div class="theorem">
-                <p class="theorem-title">Theorem 35.3 (Block Validation Attack)</p>
+                <p class="theorem-title">Proposition 35.3 (Block Validation Attack)</p>
                 <p>
                     An attacker with sufficient hashrate could:
                 </p>
@@ -427,7 +427,7 @@ Different blocks, same merkle root → attack vector</pre>
             </div>
 
             <div class="theorem">
-                <p class="theorem-title">Theorem 35.4 (Soft Fork Compatibility)</p>
+                <p class="theorem-title">Proposition 35.4 (Soft Fork Compatibility)</p>
                 <p>
                     All proposed fixes are soft forks because they:
                 </p>

--- a/chapters/36-security-threats.html
+++ b/chapters/36-security-threats.html
@@ -239,7 +239,7 @@
             </div>
 
             <div class="theorem">
-                <p class="theorem-title">Theorem 36.2 (Reorg Probability)</p>
+                <p class="theorem-title">Proposition 36.2 (Reorg Probability)</p>
                 <p>
                     Under honest mining with network delay δ and block time T:
                 </p>
@@ -345,8 +345,8 @@
                 </ol>
             </div>
 
-            <div class="theorem">
-                <p class="theorem-title">Theorem 36.4 (Eclipse Attack Consequences)</p>
+            <div class="remark">
+                <p class="remark-title">Remark 36.4 (Eclipse Attack Consequences).</p>
                 <p>
                     An eclipsed node can be:
                 </p>
@@ -422,8 +422,8 @@
         <section>
             <h2>36.6 Attack Economics</h2>
 
-            <div class="theorem">
-                <p class="theorem-title">Theorem 36.5 (51% Attack Cost)</p>
+            <div class="remark">
+                <p class="remark-title">Remark 36.5 (51% Attack Cost).</p>
                 <p>
                     The cost of a 51% attack includes:
                 </p>


### PR DESCRIPTION
## Summary
- Reclassify 10 mislabeled "Theorem" items across 4 chapters
- 5 property lists/enumerations → Remark (Ch 28: 28.1, 28.4, 28.6; Ch 29: 29.1, 29.5)
- 3 logical claims without formal proofs → Proposition (Ch 35: 35.3, 35.4; Ch 36: 36.2)
- 2 consequence/cost lists → Remark (Ch 36: 36.4, 36.5)

## Test plan
- [ ] Verify remark/proposition styling renders correctly on affected pages

Fixes #75