### PR TITLE
Fix remaining MEDIUM issues in chapters 4 and 7

### DIFF
--- a/chapters/04-elliptic-curves-finite.html
+++ b/chapters/04-elliptic-curves-finite.html
@@ -498,8 +498,8 @@
                 properly chosen curves.
             </p>
 
-            <div class="theorem">
-                <p class="theorem-title">Theorem 4.4 (Best Known Algorithms for ECDLP)</p>
+            <div class="remark">
+                <p class="remark-title">Best Known Algorithms for ECDLP.</p>
                 <p>
                     For a generic elliptic curve group of order <span class="math">n</span>:
                 </p>

--- a/chapters/07-ecdsa.html
+++ b/chapters/07-ecdsa.html
@@ -571,10 +571,12 @@ Verify(Q, m, (r, s)):
                     and message:
                 </p>
                 <p style="text-align: center;">
-                    <span class="math">k = HMAC(d, H(m))</span>
+                    <span class="math">k = HMAC-DRBG(d, H(m))</span>
                 </p>
                 <p>
-                    This ensures the same message always produces the same signature (eliminating
+                    The actual derivation uses an HMAC-based deterministic random bit generator
+                    with multiple rounds; see RFC 6979 for the full specification. The key
+                    property: the same message always produces the same signature (eliminating
                     randomness errors) while different messages produce different nonces.
                 </p>
             </div>


### PR DESCRIPTION
## Summary
- Ch 4: Reclassify "Theorem 4.4" (Best Known ECDLP Algorithms) to Remark — empirical observation, not a proven theorem
- Ch 7: Correct RFC 6979 formula from schematic `HMAC(d, H(m))` to `HMAC-DRBG(d, H(m))` with clarifying note about multi-round derivation

## Test plan
- [ ] Verify remark styling renders correctly in Ch 4
- [ ] Verify Ch 7 RFC 6979 description is clear

Fixes #77