### PR TITLE
Fix "a elegant" → "an elegant" in Ch 8 and 12

### DIFF
--- a/chapters/08-schnorr.html
+++ b/chapters/08-schnorr.html
@@ -37,7 +37,7 @@
             <p>
                 In 2021, the Bitcoin network activated <em>Taproot</em>, the most significant
                 upgrade since SegWit. At its cryptographic heart lies the <strong>Schnorr
-                signature scheme</strong>&mdash;a elegant algorithm that predates ECDSA yet
+                signature scheme</strong>&mdash;an elegant algorithm that predates ECDSA yet
                 offers superior properties.
             </p>
             <p>

--- a/chapters/12-merkle-trees.html
+++ b/chapters/12-merkle-trees.html
@@ -39,7 +39,7 @@
         <section>
             <p class="chapter-intro">
                 How can we prove that a specific transaction is included in a block without
-                revealing all other transactions? The answer lies in a elegant data structure
+                revealing all other transactions? The answer lies in an elegant data structure
                 invented by Ralph Merkle in 1979: the hash tree, now universally known as the
                 Merkle tree. This structure enables Bitcoin's crucial ability to verify
                 transaction inclusion with logarithmic efficiency.


### PR DESCRIPTION
## Summary
- Ch 8 line 40: "a elegant algorithm" → "an elegant algorithm"
- Ch 12 line 42: "a elegant data structure" → "an elegant data structure"

Fixes #83