### PR TITLE
Renumber remarks sequentially in Ch 28, 29, 36

### DIFF
--- a/chapters/28-segwit-deep-dive.html
+++ b/chapters/28-segwit-deep-dive.html
@@ -126,7 +126,7 @@ Since R'.x = R.x (negation preserves x), both pass.</pre>
             </div>
 
             <div class="remark">
-                <p class="remark-title">Remark 28.1 (Impact of Malleability)</p>
+                <p class="remark-title">Remark 28.2 (Impact of Malleability)</p>
                 <p>
                     Malleability caused real problems:
                 </p>
@@ -449,7 +449,7 @@ where:
             </div>
 
             <div class="remark">
-                <p class="remark-title">Remark 28.4 (SegWit Capacity Increase).</p>
+                <p class="remark-title">Remark 28.3 (SegWit Capacity Increase).</p>
                 <p>
                     SegWit increases effective block capacity:
                 </p>
@@ -465,7 +465,7 @@ where:
             </div>
 
             <div class="remark">
-                <p class="remark-title">Remark 28.2 (Discount Rationale)</p>
+                <p class="remark-title">Remark 28.4 (Discount Rationale)</p>
                 <p>
                     The 75% witness discount serves multiple purposes:
                 </p>
@@ -594,7 +594,7 @@ commitment = SHA256(SHA256(witness_root || witness_nonce))
             </div>
 
             <div class="remark">
-                <p class="remark-title">Remark 28.3 (Policy Protection)</p>
+                <p class="remark-title">Remark 28.5 (Policy Protection)</p>
                 <p>
                     Before SegWit activation, Bitcoin Core made SegWit outputs non-standard
                     as <em>policy</em>. This prevented anyone from claiming "anyone can spend"
@@ -728,7 +728,7 @@ witness:      <sig> <pubkey></pre>
             </div>
 
             <div class="remark">
-                <p class="remark-title">Remark 28.4 (Wrapped vs Native Efficiency)</p>
+                <p class="remark-title">Remark 28.7 (Wrapped vs Native Efficiency)</p>
                 <p>
                     Wrapped SegWit is less efficient than native:
                 </p>
@@ -809,7 +809,7 @@ witness:      <sig> <pubkey></pre>
             </div>
 
             <div class="remark">
-                <p class="remark-title">Remark 28.5 (Adoption Drivers)</p>
+                <p class="remark-title">Remark 28.8 (Adoption Drivers)</p>
                 <p>
                     SegWit adoption accelerated due to:
                 </p>
@@ -847,7 +847,7 @@ witness:      <sig> <pubkey></pre>
             </div>
 
             <div class="remark">
-                <p class="remark-title">Remark 28.6 (Other Layer 2 Benefits)</p>
+                <p class="remark-title">Remark 28.9 (Other Layer 2 Benefits)</p>
                 <p>
                     SegWit enables multiple second-layer constructions:
                 </p>

--- a/chapters/29-taproot-architecture.html
+++ b/chapters/29-taproot-architecture.html
@@ -152,7 +152,7 @@
             </div>
 
             <div class="remark">
-                <p class="remark-title">Remark 29.1 (Batch Verification Speedup)</p>
+                <p class="remark-title">Remark 29.2 (Batch Verification Speedup)</p>
                 <p>
                     Batch verification is approximately 2-3× faster than individual verification
                     for typical block sizes. This significantly reduces block validation time.
@@ -410,7 +410,7 @@ Stack after:  [n] (or [n+1] if valid)
             </div>
 
             <div class="remark">
-                <p class="remark-title">Remark 29.5 (Tapscript Multisig Efficiency).</p>
+                <p class="remark-title">Remark 29.3 (Tapscript Multisig Efficiency).</p>
                 <p>
                     CHECKSIGADD is more efficient than OP_CHECKMULTISIG:
                 </p>
@@ -443,7 +443,7 @@ Stack after:  [n] (or [n+1] if valid)
             </div>
 
             <div class="remark">
-                <p class="remark-title">Remark 29.2 (OP_SUCCESS for Upgrades)</p>
+                <p class="remark-title">Remark 29.4 (OP_SUCCESS for Upgrades)</p>
                 <p>
                     OP_SUCCESSx opcodes (80 of them) make scripts immediately succeed.
                     Future soft forks can redefine them to have new meaning:
@@ -581,7 +581,7 @@ Stack after:  [n] (or [n+1] if valid)
             </div>
 
             <div class="remark">
-                <p class="remark-title">Remark 29.3 (Adaptor vs HTLC)</p>
+                <p class="remark-title">Remark 29.5 (Adaptor vs HTLC)</p>
                 <p>
                     Adaptor signatures vs hash time-locked contracts:
                 </p>
@@ -658,7 +658,7 @@ Stack after:  [n] (or [n+1] if valid)
             </div>
 
             <div class="remark">
-                <p class="remark-title">Remark 29.4 (Taproot Use Cases)</p>
+                <p class="remark-title">Remark 29.6 (Taproot Use Cases)</p>
                 <p>
                     Taproot enables or improves:
                 </p>

--- a/chapters/36-security-threats.html
+++ b/chapters/36-security-threats.html
@@ -346,7 +346,7 @@
             </div>
 
             <div class="remark">
-                <p class="remark-title">Remark 36.4 (Eclipse Attack Consequences).</p>
+                <p class="remark-title">Remark 36.2 (Eclipse Attack Consequences).</p>
                 <p>
                     An eclipsed node can be:
                 </p>
@@ -359,7 +359,7 @@
             </div>
 
             <div class="remark">
-                <p class="remark-title">Remark 36.2 (Eclipse Mitigations)</p>
+                <p class="remark-title">Remark 36.3 (Eclipse Mitigations)</p>
                 <p>
                     Bitcoin Core includes mitigations:
                 </p>
@@ -423,7 +423,7 @@
             <h2>36.6 Attack Economics</h2>
 
             <div class="remark">
-                <p class="remark-title">Remark 36.5 (51% Attack Cost).</p>
+                <p class="remark-title">Remark 36.4 (51% Attack Cost).</p>
                 <p>
                     The cost of a 51% attack includes:
                 </p>


### PR DESCRIPTION
## Summary
PR #76 relabeled several Theorems to Remarks but kept their theorem-sequence numbers, colliding with each chapter's pre-existing remark numbering (two "Remark 28.1", two "Remark 28.4", two "Remark 28.6", two "Remark 29.1", and out-of-order remarks in Ch 36).

This renumbers all remarks sequentially in document order:
- Ch 28: Remarks 28.1–28.9
- Ch 29: Remarks 29.1–29.6
- Ch 36: Remarks 36.1–36.4

No in-text cross-references to these remarks exist, so renumbering is safe. Theorem/Proposition numbering is untouched.

Fixes #85