### PR TITLE
Fix Ch 1-5 review findings

### DIFF
--- a/chapters/01-groups.html
+++ b/chapters/01-groups.html
@@ -497,7 +497,7 @@
             </div>
 
             <div class="theorem">
-                <p class="theorem-title">Proposition 1.2 (Subgroup Test)</p>
+                <p class="theorem-title">Proposition 1.1 (Subgroup Test)</p>
                 <p>
                     A nonempty subset <span class="math">H</span> of a group <span class="math">G</span>
                     is a subgroup if and only if for all <span class="math">a, b ∈ H</span>:
@@ -529,7 +529,7 @@
             </div>
 
             <div class="theorem">
-                <p class="theorem-title">Theorem 1.3 (Lagrange's Theorem)</p>
+                <p class="theorem-title">Theorem 1.2 (Lagrange's Theorem)</p>
                 <p>
                     If <span class="math">H</span> is a subgroup of a finite group <span class="math">G</span>,
                     then <span class="math">|H|</span> divides <span class="math">|G|</span>.

--- a/chapters/02-finite-fields.html
+++ b/chapters/02-finite-fields.html
@@ -576,7 +576,7 @@ function power_mod(a, k, n):
                 <p class="remark-title">Looking Ahead.</p>
                 <p>
                     Repeated squaring is the multiplicative cousin of <em>double-and-add</em>, the
-                    algorithm used to compute scalar multiplication on elliptic curves (Chapter 5).
+                    algorithm used to compute scalar multiplication on elliptic curves (Chapter 3).
                     The same principle applies: replace squaring with point doubling, and multiplication
                     with point addition.
                 </p>

--- a/chapters/03-elliptic-curves-real.html
+++ b/chapters/03-elliptic-curves-real.html
@@ -743,7 +743,8 @@ function scalar_multiply(n, P):
             <div class="exercise">
                 <span class="exercise-number">3.2.</span>
                 On the curve <span class="math">y² = x³ − 7x + 10</span>, compute
-                <span class="math">2P</span> where <span class="math">P = (1, 2)</span>.
+                <span class="math">3P</span> where <span class="math">P = (1, 2)</span>.
+                (Hint: use the value of <span class="math">2P</span> from Example 3.3.)
             </div>
 
             <div class="exercise">

--- a/chapters/05-secp256k1.html
+++ b/chapters/05-secp256k1.html
@@ -28,7 +28,7 @@
         <h1 class="chapter-title">The secp256k1 Curve</h1>
         <p class="chapter-epigraph">
             "Simplicity is the ultimate sophistication."
-            <br>&mdash; Leonardo da Vinci
+            <br>&mdash; Attributed to Leonardo da Vinci
         </p>
     </header>
 
@@ -625,8 +625,11 @@ FD17B448 A6855419 9C47D08F FB10D4B8</pre>
                         so the MOV attack doesn't apply.
                     </li>
                     <li>
-                        <strong>Twist security:</strong> The quadratic twist of secp256k1 also
-                        has near-prime order, providing resistance to twist attacks.
+                        <strong>Twist security:</strong> The quadratic twist of secp256k1 has
+                        a large prime-order subgroup (its order is
+                        <span class="math">3&#178; &#183; 13&#178; &#183; 3319 &#183; 22639</span> times a 220-bit prime),
+                        so an attack via the twist still costs about <span class="math">2&#185;&#185;&#8304;</span>
+                        operations, providing resistance to twist attacks.
                     </li>
                 </ul>
             </div>
@@ -711,7 +714,7 @@ FD17B448 A6855419 9C47D08F FB10D4B8</pre>
             <div class="exercise">
                 <span class="exercise-number">5.8.</span>
                 <em>(Research)</em> What is the "twist" of an elliptic curve? Why is it
-                important for security that the twist of secp256k1 also has near-prime order?
+                important for security that the twist of secp256k1 has a large prime-order subgroup?
             </div>
         </section>
 


### PR DESCRIPTION
## Summary
Five fixes from a computational re-review of chapters 1-5 (all arithmetic in these chapters was verified; only these items were wrong):

- **Ch 1**: renumbered Proposition 1.2 → 1.1 and Theorem 1.3 → 1.2 so Ch 1 uses separate counters per kind, matching the convention in Ch 2, 5, and 18. No external references existed.
- **Ch 2**: double-and-add cross-reference corrected from Chapter 5 to Chapter 3 (Algorithm 3.1).
- **Ch 3**: Exercise 3.2 was identical to worked Example 3.3 on the same page; it now asks for 3P (answer (9, −26), verified on the curve).
- **Ch 5**: the quadratic twist of secp256k1 does **not** have near-prime order — its order is 3²·13²·3319·22639 × (220-bit prime), verified computationally. Restated twist security via the large prime-order subgroup (~2¹¹⁰ attack cost) and aligned Exercise 5.8.
- **Ch 5**: epigraph "Simplicity is the ultimate sophistication" marked as *Attributed to* Leonardo da Vinci (well-documented misattribution).

Fixes #87