### PR TITLE
Fix Ch 6-9 review findings

### DIFF
--- a/chapters/06-hash-functions.html
+++ b/chapters/06-hash-functions.html
@@ -178,15 +178,15 @@
                     </tr>
                     <tr>
                         <td><code>""</code> (empty)</td>
-                        <td><code style="font-size: 0.7rem;">e3b0c44298fc1c14...9bce4dbf</code></td>
+                        <td><code style="font-size: 0.7rem;">e3b0c44298fc1c14...7852b855</code></td>
                     </tr>
                     <tr>
                         <td><code>"Bitcoin"</code></td>
-                        <td><code style="font-size: 0.7rem;">b4056df6691f8dc7...a2f9a1f6</code></td>
+                        <td><code style="font-size: 0.7rem;">b4056df6691f8dc7...4eb63aa4</code></td>
                     </tr>
                     <tr>
                         <td><code>"bitcoin"</code></td>
-                        <td><code style="font-size: 0.7rem;">6b88c087247aa2f0...dd43f3f3</code></td>
+                        <td><code style="font-size: 0.7rem;">6b88c087247aa2f0...05ca107b</code></td>
                     </tr>
                 </table>
                 <p style="margin-top: 1rem;">
@@ -229,7 +229,7 @@
 
                     <!-- Output 2 (completely different) -->
                     <rect x="190" y="110" width="220" height="30" fill="#f8f5f0" stroke="#8b4513" stroke-width="1"/>
-                    <text x="300" y="130" text-anchor="middle" font-family="monospace" font-size="9">4c716d4cf07c0495...</text>
+                    <text x="300" y="130" text-anchor="middle" font-family="monospace" font-size="9">2113cd4a7aebc3a4...</text>
 
                     <!-- Annotation showing difference -->
                     <text x="80" y="155" text-anchor="middle" font-family="Georgia" font-size="9" fill="#c44">1 char change</text>

--- a/chapters/07-ecdsa.html
+++ b/chapters/07-ecdsa.html
@@ -501,7 +501,7 @@ Verify(P, m, (r, s)):
                     Once <span class="math">k</span> is known, the private key follows:
                 </p>
                 <p style="text-align: center;">
-                    <span class="math">d = r⁻¹(sk - z) mod n</span>
+                    <span class="math">d = r⁻¹(s₁k - z₁) mod n</span>
                     <span class="qed"></span>
                 </p>
             </div>
@@ -623,9 +623,11 @@ Verify(P, m, (r, s)):
             <div class="remark">
                 <p class="remark-title">Bitcoin's Low-S Rule.</p>
                 <p>
-                    To mitigate malleability, Bitcoin enforces that <span class="math">s ≤ n/2</span>.
-                    If a signature has <span class="math">s > n/2</span>, nodes reject it. This
-                    makes each valid signature unique.
+                    To mitigate malleability, Bitcoin requires that <span class="math">s ≤ n/2</span>
+                    as a standardness (relay) policy: nodes will not relay transactions whose
+                    signatures have <span class="math">s > n/2</span>. This makes each relayed
+                    signature unique, though high-<span class="math">s</span> signatures remain
+                    valid by consensus in legacy scripts.
                 </p>
             </div>
         </section>

--- a/chapters/08-schnorr.html
+++ b/chapters/08-schnorr.html
@@ -127,7 +127,7 @@
             <p>
                 At its heart, a Schnorr signature is a <em>non-interactive zero-knowledge proof</em>
                 that the signer knows the discrete logarithm of their public key. The signer
-                proves they know <span class="math">d</span> (where <span class="math">Q = dG</span>)
+                proves they know <span class="math">d</span> (where <span class="math">P = dG</span>)
                 without revealing <span class="math">d</span> itself.
             </p>
 
@@ -140,7 +140,7 @@
                     <li><strong>Commitment:</strong> Prover chooses random <span class="math">k</span>, sends <span class="math">R = kG</span></li>
                     <li><strong>Challenge:</strong> Verifier sends random <span class="math">e</span></li>
                     <li><strong>Response:</strong> Prover sends <span class="math">s = k + ed</span></li>
-                    <li><strong>Verify:</strong> Verifier checks <span class="math">sG = R + eQ</span></li>
+                    <li><strong>Verify:</strong> Verifier checks <span class="math">sG = R + eP</span></li>
                 </ol>
             </div>
 
@@ -154,7 +154,7 @@
 
                     <!-- Verifier -->
                     <rect x="340" y="50" width="120" height="30" fill="#f5f8f0" stroke="#5a8f5a" stroke-width="1.5"/>
-                    <text x="400" y="70" text-anchor="middle" font-family="Georgia" font-size="12">Verifier (knows Q)</text>
+                    <text x="400" y="70" text-anchor="middle" font-family="Georgia" font-size="12">Verifier (knows P)</text>
 
                     <!-- Step 1: R -->
                     <path d="M 160 100 L 340 100" stroke="#4a90d9" stroke-width="1.5" marker-end="url(#arr8b)"/>
@@ -173,7 +173,7 @@
                     <!-- Verification -->
                     <rect x="330" y="200" width="140" height="35" fill="#f8f5f0" stroke="#8b4513" stroke-width="1.5" rx="4"/>
                     <text x="400" y="215" text-anchor="middle" font-family="Georgia" font-size="10">Check:</text>
-                    <text x="400" y="228" text-anchor="middle" font-family="Georgia" font-size="11" font-style="italic">sG = R + eQ ?</text>
+                    <text x="400" y="228" text-anchor="middle" font-family="Georgia" font-size="11" font-style="italic">sG = R + eP ?</text>
 
                     <defs>
                         <marker id="arr8b" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
@@ -190,7 +190,7 @@
             <div class="proof">
                 <p class="proof-title">Why verification works</p>
                 <p>
-                    <span class="math">sG = (k + ed)G = kG + edG = R + e(dG) = R + eQ</span>
+                    <span class="math">sG = (k + ed)G = kG + edG = R + e(dG) = R + eP</span>
                     <span class="qed"></span>
                 </p>
             </div>
@@ -287,12 +287,12 @@ Sign(d, m):
     // Ensure private key produces even-y public key
     1. Compute P = dG
     2. If y(P) is odd, set d = n - d       // Negate if needed
-    3. Let p = x(P)                        // x-coordinate (public key)
+    3. Let pk = x(P)                       // x-coordinate (public key)
 
     // Generate deterministic nonce
     4. Let a = bytes(d)                    // 32 bytes
     5. Let t = a XOR H_aux(aux_rand)       // Optional auxiliary randomness
-    6. Let rand = H_nonce(t || p || m)
+    6. Let rand = H_nonce(t || pk || m)
     7. Let k' = int(rand) mod n
     8. If k' = 0, fail
 
@@ -302,7 +302,7 @@ Sign(d, m):
     11. Let r = x(R)                       // x-coordinate of R
 
     // Compute challenge and signature
-    12. Let e = int(H_challenge(r || p || m)) mod n
+    12. Let e = int(H_challenge(r || pk || m)) mod n
     13. Let s = (k + ed) mod n
 
     // Return 64-byte signature
@@ -346,7 +346,7 @@ Sign(d, m):
 
                     <!-- Challenge e -->
                     <rect x="280" y="150" width="150" height="40" fill="#fff" stroke="#666" stroke-width="1.5" rx="4"/>
-                    <text x="355" y="168" text-anchor="middle" font-family="Georgia" font-size="10">e = H(r || p || m)</text>
+                    <text x="355" y="168" text-anchor="middle" font-family="Georgia" font-size="10">e = H(r || pk || m)</text>
                     <text x="355" y="183" text-anchor="middle" font-family="Georgia" font-size="9" fill="#666">challenge</text>
 
                     <!-- Arrows to challenge -->
@@ -400,16 +400,16 @@ Sign(d, m):
             <div class="definition">
                 <p class="definition-title">Algorithm 8.2 (BIP-340 Schnorr Verification)</p>
                 <pre>
-Verify(p, m, sig):
+Verify(pk, m, sig):
     // Parse inputs
-    1. Let P = lift_x(p)               // Recover point with even y
+    1. Let P = lift_x(pk)              // Recover point with even y
        If P is invalid, return false
     2. Let r = int(sig[0:32])
     3. Let s = int(sig[32:64])
-    4. If r ≥ p or s ≥ n, return false
+    4. If r ≥ p or s ≥ n, return false // p = field prime, n = group order
 
     // Compute challenge
-    5. Let e = int(H_challenge(bytes(r) || p || m)) mod n
+    5. Let e = int(H_challenge(bytes(r) || pk || m)) mod n
 
     // Verify equation: sG = R + eP
     6. Let R = sG - eP
@@ -602,8 +602,9 @@ Verify(p, m, sig):
                     <span class="math">P = a₁P₁ + a₂P₂ + ... + aₙPₙ</span>
                 </p>
                 <p>
-                    Each party must prove knowledge of their discrete log before their key
-                    affects the aggregate.
+                    The coefficients <span class="math">aᵢ</span> make it infeasible to choose
+                    a rogue key that cancels honest keys, so&mdash;unlike earlier
+                    schemes&mdash;no party needs to prove knowledge of their discrete log.
                 </p>
             </div>
 

--- a/chapters/09-keys-addresses.html
+++ b/chapters/09-keys-addresses.html
@@ -162,7 +162,7 @@
                     is the elliptic curve point:
                 </p>
                 <p class="math-block">
-                    K = d · G
+                    P = d · G
                 </p>
                 <p>
                     where <span class="math">G</span> is the generator point of secp256k1.
@@ -171,10 +171,10 @@
 
             <p>
                 This computation is the "easy direction" of the trapdoor function we studied
-                in Chapter 1. Given <span class="math">d</span>, computing <span class="math">K</span>
+                in Chapter 1. Given <span class="math">d</span>, computing <span class="math">P</span>
                 requires only <span class="math">O(log d)</span> group operations via the
                 double-and-add algorithm. The reverse—finding <span class="math">d</span> given
-                <span class="math">K</span>—is the elliptic curve discrete logarithm problem (ECDLP),
+                <span class="math">P</span>—is the elliptic curve discrete logarithm problem (ECDLP),
                 believed to be computationally infeasible.
             </p>
 
@@ -192,7 +192,7 @@
 
                     <!-- Public key box -->
                     <rect x="220" y="45" width="100" height="50" rx="8" fill="#f5f8f0" stroke="#5a8f5a" stroke-width="2"/>
-                    <text x="270" y="70" text-anchor="middle" font-family="Georgia" font-size="14" font-style="italic">K = (x, y)</text>
+                    <text x="270" y="70" text-anchor="middle" font-family="Georgia" font-size="14" font-style="italic">P = (x, y)</text>
                     <text x="270" y="87" text-anchor="middle" font-family="Georgia" font-size="11">(public key)</text>
 
                     <!-- Security note -->
@@ -211,7 +211,7 @@
             <h3>9.2.1 Public Key Serialization</h3>
 
             <p>
-                A public key is a point <span class="math">K = (x, y)</span> on the secp256k1 curve.
+                A public key is a point <span class="math">P = (x, y)</span> on the secp256k1 curve.
                 Both coordinates are 256-bit integers, so the full representation requires 64 bytes
                 (512 bits). However, Bitcoin supports two serialization formats.
             </p>
@@ -902,14 +902,14 @@
                         <td><code>1</code></td>
                         <td>Base58Check</td>
                         <td>20-byte pubkey hash</td>
-                        <td>25–34 chars</td>
+                        <td>26–34 chars</td>
                     </tr>
                     <tr>
                         <td>P2SH</td>
                         <td><code>3</code></td>
                         <td>Base58Check</td>
                         <td>20-byte script hash</td>
-                        <td>25–34 chars</td>
+                        <td>34 chars</td>
                     </tr>
                     <tr>
                         <td>P2WPKH</td>

--- a/chapters/26-fork-theory.html
+++ b/chapters/26-fork-theory.html
@@ -1,0 +1,842 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Chapter 26: Fork Theory | Elementary Bitcoin</title>
+    <meta name="description" content="Chapter 26: Fork Theory - Mathematical foundations of chain divergence, split dynamics, and consensus stability">
+    <link rel="stylesheet" href="../style.css">
+</head>
+<body>
+    <nav class="chapter-nav">
+        <a href="../index.html">Contents</a>
+        <span class="nav-separator">·</span>
+        <span class="volume-indicator">Volume IV: Forks and Futures</span>
+    </nav>
+
+    <header class="chapter-header">
+        <p class="chapter-number">Chapter 26</p>
+        <h1>Fork Theory</h1>
+        <p class="chapter-subtitle">The Mathematics of Chain Divergence</p>
+    </header>
+
+    <main class="chapter-content">
+        <section>
+            <p class="chapter-intro">
+                When nodes disagree about which blocks are valid, the network faces a fundamental
+                crisis: a <em>fork</em>. This chapter develops the mathematical theory of chain
+                divergence—temporary forks that resolve naturally, intentional hard forks that
+                create new currencies, and soft forks that tighten rules while maintaining
+                compatibility. We analyze fork dynamics through game theory, information theory,
+                and network economics.
+            </p>
+        </section>
+
+        <section>
+            <h2>26.1 Defining Forks Formally</h2>
+
+            <p>
+                The term "fork" is overloaded in Bitcoin discourse. We begin with precise definitions.
+            </p>
+
+            <div class="definition">
+                <p class="definition-title">Definition 26.1 (Blockchain Fork)</p>
+                <p>
+                    A <strong>fork</strong> occurs when two or more valid blocks share the same
+                    parent block, creating divergent chain histories. Let B<sub>p</sub> be a block
+                    and B<sub>1</sub>, B<sub>2</sub> be distinct blocks such that:
+                </p>
+                <p style="text-align: center; font-family: 'Times New Roman', serif;">
+                    prev_hash(B<sub>1</sub>) = prev_hash(B<sub>2</sub>) = hash(B<sub>p</sub>)
+                </p>
+                <p>
+                    Then blocks B<sub>1</sub> and B<sub>2</sub> constitute a fork at height h(B<sub>p</sub>) + 1.
+                </p>
+            </div>
+
+            <div class="definition">
+                <p class="definition-title">Definition 26.2 (Fork Types by Cause)</p>
+                <p>
+                    Forks are classified by their origin:
+                </p>
+                <ul>
+                    <li><strong>Natural fork:</strong> Two miners find valid blocks nearly simultaneously</li>
+                    <li><strong>Intentional fork:</strong> Deliberate protocol change creates incompatible rules</li>
+                    <li><strong>Attack fork:</strong> Malicious attempt to reverse transactions</li>
+                </ul>
+            </div>
+
+            <figure>
+                <svg class="diagram" width="520" height="220" viewBox="0 0 520 220">
+                    <!-- Main chain -->
+                    <rect x="30" y="90" width="60" height="40" rx="4" fill="#e8f4e8" stroke="#5a8f5a" stroke-width="1.5"/>
+                    <text x="60" y="115" text-anchor="middle" font-family="Georgia" font-size="10">B<tspan baseline-shift="sub" font-size="8">n-1</tspan></text>
+
+                    <rect x="110" y="90" width="60" height="40" rx="4" fill="#e8f4e8" stroke="#5a8f5a" stroke-width="1.5"/>
+                    <text x="140" y="115" text-anchor="middle" font-family="Georgia" font-size="10">B<tspan baseline-shift="sub" font-size="8">n</tspan></text>
+
+                    <!-- Fork point -->
+                    <line x1="90" y1="110" x2="110" y2="110" stroke="#5a8f5a" stroke-width="1.5"/>
+
+                    <!-- Upper branch -->
+                    <rect x="200" y="40" width="60" height="40" rx="4" fill="#e8f4e8" stroke="#5a8f5a" stroke-width="1.5"/>
+                    <text x="230" y="65" text-anchor="middle" font-family="Georgia" font-size="10">B<tspan baseline-shift="sub" font-size="8">n+1</tspan></text>
+
+                    <rect x="280" y="40" width="60" height="40" rx="4" fill="#e8f4e8" stroke="#5a8f5a" stroke-width="1.5"/>
+                    <text x="310" y="65" text-anchor="middle" font-family="Georgia" font-size="10">B<tspan baseline-shift="sub" font-size="8">n+2</tspan></text>
+
+                    <rect x="360" y="40" width="60" height="40" rx="4" fill="#e8f4e8" stroke="#5a8f5a" stroke-width="1.5"/>
+                    <text x="390" y="65" text-anchor="middle" font-family="Georgia" font-size="10">B<tspan baseline-shift="sub" font-size="8">n+3</tspan></text>
+
+                    <!-- Lower branch (orphaned) -->
+                    <rect x="200" y="140" width="60" height="40" rx="4" fill="#ffe8e8" stroke="#c44" stroke-width="1.5" stroke-dasharray="4,2"/>
+                    <text x="230" y="165" text-anchor="middle" font-family="Georgia" font-size="10">B'<tspan baseline-shift="sub" font-size="8">n+1</tspan></text>
+
+                    <!-- Connections -->
+                    <path d="M 170 100 Q 185 70 200 60" stroke="#5a8f5a" stroke-width="1.5" fill="none"/>
+                    <path d="M 170 120 Q 185 150 200 160" stroke="#c44" stroke-width="1.5" stroke-dasharray="4,2" fill="none"/>
+
+                    <line x1="260" y1="60" x2="280" y2="60" stroke="#5a8f5a" stroke-width="1.5"/>
+                    <line x1="340" y1="60" x2="360" y2="60" stroke="#5a8f5a" stroke-width="1.5"/>
+
+                    <!-- Labels -->
+                    <text x="440" y="65" font-family="Georgia" font-size="10" fill="#5a8f5a">Winner</text>
+                    <text x="280" y="185" font-family="Georgia" font-size="10" fill="#c44">Orphaned (stale)</text>
+
+                    <!-- Fork point marker -->
+                    <circle cx="170" cy="110" r="8" fill="#f39c12" stroke="#c87f0a" stroke-width="1.5"/>
+                    <text x="170" y="200" text-anchor="middle" font-family="Georgia" font-size="9" fill="#c87f0a">Fork Point</text>
+                </svg>
+                <figcaption>Figure 26.1: A natural fork resolves when one branch gains more cumulative work.</figcaption>
+            </figure>
+
+            <div class="definition">
+                <p class="definition-title">Definition 26.3 (Fork Resolution)</p>
+                <p>
+                    A fork is <strong>resolved</strong> when all honest nodes converge on the same
+                    chain tip. For natural forks, this occurs when one branch accumulates strictly
+                    more work:
+                </p>
+                <p style="text-align: center; font-family: 'Times New Roman', serif;">
+                    W(chain<sub>1</sub>) > W(chain<sub>2</sub>) ⟹ nodes adopt chain<sub>1</sub>
+                </p>
+                <p>
+                    where W(·) denotes cumulative proof-of-work.
+                </p>
+            </div>
+        </section>
+
+        <section>
+            <h2>26.2 Natural Fork Probability</h2>
+
+            <p>
+                Natural forks occur when network latency allows multiple miners to find blocks
+                before hearing about each other's discoveries.
+            </p>
+
+            <div class="theorem">
+                <p class="theorem-title">Theorem 26.1 (Fork Probability Bound)</p>
+                <p>
+                    Let λ be the block arrival rate (blocks per second), δ be the network
+                    propagation delay, and n be the number of miners. The probability of a
+                    natural fork is approximately:
+                </p>
+                <p style="text-align: center; font-family: 'Times New Roman', serif;">
+                    P(fork) ≈ 1 - e<sup>-λδ</sup> ≈ λδ for small λδ
+                </p>
+            </div>
+
+            <div class="proof">
+                <p class="proof-title">Proof sketch.</p>
+                <p>
+                    After a block is found, another block might be found before propagation
+                    completes. The inter-arrival time follows an exponential distribution with
+                    rate λ. The probability that another block arrives within time δ is:
+                </p>
+                <p style="text-align: center; font-family: 'Times New Roman', serif;">
+                    P(T ≤ δ) = 1 - e<sup>-λδ</sup>
+                </p>
+                <p>
+                    For Bitcoin, λ ≈ 1/600 blocks/second and δ ≈ 1-10 seconds, giving
+                    P(fork) ≈ 0.2% - 1.7%. □
+                </p>
+            </div>
+
+            <div class="example">
+                <p class="example-title">Example 26.1 (Observed Fork Rates)</p>
+                <p>
+                    Historical data from Bitcoin's mainnet shows:
+                </p>
+                <table class="data-table">
+                    <thead>
+                        <tr>
+                            <th>Period</th>
+                            <th>Blocks</th>
+                            <th>Observed Stales</th>
+                            <th>Rate</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>2015</td>
+                            <td>~54,000</td>
+                            <td>~500</td>
+                            <td>~0.9%</td>
+                        </tr>
+                        <tr>
+                            <td>2017 (peak)</td>
+                            <td>~54,000</td>
+                            <td>~800</td>
+                            <td>~1.5%</td>
+                        </tr>
+                        <tr>
+                            <td>2023</td>
+                            <td>~52,000</td>
+                            <td>~200</td>
+                            <td>~0.4%</td>
+                        </tr>
+                    </tbody>
+                </table>
+                <p>
+                    The decrease reflects improved block propagation (compact blocks, FIBRE network).
+                </p>
+            </div>
+
+            <div class="definition">
+                <p class="definition-title">Definition 26.4 (Stale Block / Orphan)</p>
+                <p>
+                    A <strong>stale block</strong> (historically called "orphan") is a valid block
+                    that is not part of the best chain. The miner who found it receives no reward.
+                </p>
+            </div>
+
+            <div class="remark">
+                <p class="remark-title">Remark 26.1 (Terminology Clarification)</p>
+                <p>
+                    "Orphan block" technically means a block whose parent is unknown (not yet
+                    received). "Stale block" means a valid block not on the best chain. The
+                    community often conflates these terms.
+                </p>
+            </div>
+        </section>
+
+        <section>
+            <h2>26.3 The Rule Compatibility Hierarchy</h2>
+
+            <p>
+                Protocol changes are classified by their compatibility properties with existing nodes.
+            </p>
+
+            <div class="definition">
+                <p class="definition-title">Definition 26.5 (Rule Sets)</p>
+                <p>
+                    Let R<sub>old</sub> and R<sub>new</sub> be sets of blocks considered valid
+                    under old and new rules respectively:
+                </p>
+                <ul>
+                    <li><strong>Soft fork:</strong> R<sub>new</sub> ⊂ R<sub>old</sub> (new rules are stricter)</li>
+                    <li><strong>Hard fork:</strong> R<sub>old</sub> ⊂ R<sub>new</sub> (new rules are looser)</li>
+                    <li><strong>Bilateral fork:</strong> R<sub>old</sub> ∩ R<sub>new</sub> ≠ ∅ but neither is subset of other</li>
+                </ul>
+            </div>
+
+            <figure>
+                <svg class="diagram" width="520" height="200" viewBox="0 0 520 200">
+                    <!-- Soft Fork -->
+                    <text x="90" y="20" text-anchor="middle" font-family="Georgia" font-size="11" font-weight="bold">Soft Fork</text>
+                    <ellipse cx="90" cy="100" rx="70" ry="60" fill="#e8f4e8" stroke="#5a8f5a" stroke-width="1.5"/>
+                    <ellipse cx="90" cy="95" rx="45" ry="35" fill="#d4ecd4" stroke="#3a6f3a" stroke-width="2"/>
+                    <text x="90" y="100" text-anchor="middle" font-family="Georgia" font-size="9">R<tspan baseline-shift="sub" font-size="7">new</tspan></text>
+                    <text x="90" y="145" text-anchor="middle" font-family="Georgia" font-size="9">R<tspan baseline-shift="sub" font-size="7">old</tspan></text>
+                    <text x="90" y="180" text-anchor="middle" font-family="Georgia" font-size="8" fill="#666">R<tspan baseline-shift="sub" font-size="6">new</tspan> ⊂ R<tspan baseline-shift="sub" font-size="6">old</tspan></text>
+
+                    <!-- Hard Fork -->
+                    <text x="260" y="20" text-anchor="middle" font-family="Georgia" font-size="11" font-weight="bold">Hard Fork</text>
+                    <ellipse cx="260" cy="100" rx="70" ry="60" fill="#ffe8e8" stroke="#c44" stroke-width="1.5"/>
+                    <ellipse cx="260" cy="105" rx="45" ry="35" fill="#ffcccc" stroke="#a33" stroke-width="2"/>
+                    <text x="260" y="60" text-anchor="middle" font-family="Georgia" font-size="9">R<tspan baseline-shift="sub" font-size="7">new</tspan></text>
+                    <text x="260" y="110" text-anchor="middle" font-family="Georgia" font-size="9">R<tspan baseline-shift="sub" font-size="7">old</tspan></text>
+                    <text x="260" y="180" text-anchor="middle" font-family="Georgia" font-size="8" fill="#666">R<tspan baseline-shift="sub" font-size="6">old</tspan> ⊂ R<tspan baseline-shift="sub" font-size="6">new</tspan></text>
+
+                    <!-- Bilateral Fork -->
+                    <text x="430" y="20" text-anchor="middle" font-family="Georgia" font-size="11" font-weight="bold">Bilateral Fork</text>
+                    <ellipse cx="400" cy="100" rx="55" ry="50" fill="#e8f4e8" stroke="#5a8f5a" stroke-width="1.5"/>
+                    <ellipse cx="460" cy="100" rx="55" ry="50" fill="#ffe8e8" stroke="#c44" stroke-width="1.5"/>
+                    <text x="385" y="100" text-anchor="middle" font-family="Georgia" font-size="9">R<tspan baseline-shift="sub" font-size="7">old</tspan></text>
+                    <text x="475" y="100" text-anchor="middle" font-family="Georgia" font-size="9">R<tspan baseline-shift="sub" font-size="7">new</tspan></text>
+                    <text x="430" y="180" text-anchor="middle" font-family="Georgia" font-size="8" fill="#666">Incompatible</text>
+                </svg>
+                <figcaption>Figure 26.2: Venn diagrams of rule set relationships for different fork types.</figcaption>
+            </figure>
+
+            <div class="theorem">
+                <p class="theorem-title">Theorem 26.2 (Soft Fork Safety)</p>
+                <p>
+                    If a soft fork activates with fraction f > 0.5 of hash power enforcing
+                    new rules R<sub>new</sub>, then:
+                </p>
+                <ol>
+                    <li>The longest chain follows R<sub>new</sub> rules with high probability</li>
+                    <li>Nodes following R<sub>old</sub> remain on this chain (since R<sub>new</sub> ⊂ R<sub>old</sub>)</li>
+                    <li>No permanent chain split occurs</li>
+                </ol>
+            </div>
+
+            <div class="proof">
+                <p class="proof-title">Proof.</p>
+                <p>
+                    Blocks valid under R<sub>new</sub> are valid under R<sub>old</sub> by definition.
+                    Thus, the chain built by the majority (enforcing R<sub>new</sub>) is accepted
+                    by all nodes. Any competing chain violating R<sub>new</sub> will be shorter
+                    in expectation (built by minority hash power) and rejected by upgraded nodes.
+                    Old nodes might temporarily follow the invalid chain during propagation delays,
+                    but will converge once they see the longer valid chain. □
+                </p>
+            </div>
+
+            <div class="theorem">
+                <p class="theorem-title">Theorem 26.3 (Hard Fork Necessity)</p>
+                <p>
+                    A hard fork causes a permanent chain split unless 100% of nodes upgrade.
+                    Old nodes will reject blocks valid only under R<sub>new</sub>, following
+                    their own (potentially stagnant) chain.
+                </p>
+            </div>
+        </section>
+
+        <section>
+            <h2>26.4 Game Theory of Fork Adoption</h2>
+
+            <p>
+                Fork adoption decisions can be modeled as coordination games with network effects.
+            </p>
+
+            <div class="definition">
+                <p class="definition-title">Definition 26.6 (Fork Adoption Game)</p>
+                <p>
+                    Consider n players who must choose between chains A and B. Let v<sub>A</sub>(k)
+                    and v<sub>B</sub>(n-k) be the value of holding coins on chain A (with k adopters)
+                    and chain B (with n-k adopters) respectively. The payoff exhibits network effects:
+                </p>
+                <p style="text-align: center; font-family: 'Times New Roman', serif;">
+                    v<sub>A</sub>(k) = f(k) · m<sub>A</sub>
+                </p>
+                <p>
+                    where f(k) is an increasing function of adopters and m<sub>A</sub> is the
+                    intrinsic merit of chain A's properties.
+                </p>
+            </div>
+
+            <div class="theorem">
+                <p class="theorem-title">Theorem 26.4 (Network Effect Dominance)</p>
+                <p>
+                    In fork adoption games with strong network effects, equilibria tend toward:
+                </p>
+                <ol>
+                    <li><strong>Winner-take-all:</strong> One chain dominates completely</li>
+                    <li><strong>Tipping point:</strong> Small initial advantages amplify</li>
+                    <li><strong>Path dependence:</strong> Early coordination determines outcome</li>
+                </ol>
+            </div>
+
+            <div class="example">
+                <p class="example-title">Example 26.2 (Schelling Point Analysis)</p>
+                <p>
+                    Consider a hard fork creating chains A (status quo) and B (new features).
+                    Each has intrinsic value but network effects dominate:
+                </p>
+                <table class="data-table">
+                    <thead>
+                        <tr>
+                            <th></th>
+                            <th>Others choose A</th>
+                            <th>Others choose B</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td><strong>Choose A</strong></td>
+                            <td>High (majority network)</td>
+                            <td>Low (isolated)</td>
+                        </tr>
+                        <tr>
+                            <td><strong>Choose B</strong></td>
+                            <td>Low (isolated)</td>
+                            <td>High (majority network)</td>
+                        </tr>
+                    </tbody>
+                </table>
+                <p>
+                    Both "all choose A" and "all choose B" are Nash equilibria. The Schelling
+                    point—the natural focal point—typically favors the status quo (chain A)
+                    due to coordination costs.
+                </p>
+            </div>
+
+            <div class="remark">
+                <p class="remark-title">Remark 26.2 (Incumbent Advantage)</p>
+                <p>
+                    The status quo chain has inherent advantages:
+                </p>
+                <ul>
+                    <li>Existing liquidity and exchange infrastructure</li>
+                    <li>Brand recognition ("Bitcoin" vs "Bitcoin [Fork]")</li>
+                    <li>Coordination cost borne by challengers</li>
+                    <li>Conservative user preference for stability</li>
+                </ul>
+                <p>
+                    This creates asymmetric costs: forking away requires compelling justification.
+                </p>
+            </div>
+        </section>
+
+        <section>
+            <h2>26.5 Replay Protection</h2>
+
+            <p>
+                When chains diverge, transactions valid on one chain may be valid on both—a
+                dangerous property called <em>replay vulnerability</em>.
+            </p>
+
+            <div class="definition">
+                <p class="definition-title">Definition 26.7 (Replay Attack)</p>
+                <p>
+                    A <strong>replay attack</strong> occurs when a transaction broadcast on
+                    chain A is also valid on chain B, allowing an attacker to "replay" the
+                    transaction without the original sender's consent.
+                </p>
+            </div>
+
+            <div class="example">
+                <p class="example-title">Example 26.3 (Replay Scenario)</p>
+                <p>
+                    Alice holds 1 BTC before a hard fork creating BTC and BTX. She wants to
+                    sell BTX while keeping BTC. She sends BTX to an exchange:
+                </p>
+                <ol>
+                    <li>Alice signs a transaction spending her output on BTX chain</li>
+                    <li>The exchange broadcasts this transaction on BTX</li>
+                    <li>Without replay protection, the same transaction is valid on BTC</li>
+                    <li>An attacker broadcasts it on BTC, stealing Alice's BTC</li>
+                </ol>
+            </div>
+
+            <div class="definition">
+                <p class="definition-title">Definition 26.8 (Replay Protection Mechanisms)</p>
+                <p>
+                    Replay protection makes transactions chain-specific:
+                </p>
+                <ul>
+                    <li><strong>Strong replay protection:</strong> Transaction format changed (e.g., different sighash flag)</li>
+                    <li><strong>Opt-in replay protection:</strong> New script opcodes for chain identification</li>
+                    <li><strong>UTXO taint:</strong> Spend fork-specific coinbase outputs first</li>
+                </ul>
+            </div>
+
+            <figure>
+                <svg class="diagram" width="500" height="180" viewBox="0 0 500 180">
+                    <!-- Fork point -->
+                    <rect x="50" y="70" width="60" height="40" rx="4" fill="#e8f4e8" stroke="#5a8f5a" stroke-width="1.5"/>
+                    <text x="80" y="95" text-anchor="middle" font-family="Georgia" font-size="9">Pre-fork</text>
+
+                    <!-- Chain A -->
+                    <rect x="160" y="30" width="80" height="35" rx="4" fill="#e8f4e8" stroke="#5a8f5a" stroke-width="1.5"/>
+                    <text x="200" y="52" text-anchor="middle" font-family="Georgia" font-size="9">Chain A</text>
+
+                    <!-- Chain B -->
+                    <rect x="160" y="115" width="80" height="35" rx="4" fill="#ffe8e8" stroke="#c44" stroke-width="1.5"/>
+                    <text x="200" y="137" text-anchor="middle" font-family="Georgia" font-size="9">Chain B</text>
+
+                    <!-- Fork lines -->
+                    <path d="M 110 80 L 160 47" stroke="#5a8f5a" stroke-width="1.5" fill="none"/>
+                    <path d="M 110 100 L 160 132" stroke="#c44" stroke-width="1.5" fill="none"/>
+
+                    <!-- Transaction -->
+                    <rect x="280" y="30" width="60" height="35" rx="4" fill="#fff3cd" stroke="#f39c12" stroke-width="1.5"/>
+                    <text x="310" y="52" text-anchor="middle" font-family="Georgia" font-size="9">TX</text>
+
+                    <!-- Replay arrow -->
+                    <path d="M 310 65 L 310 115" stroke="#c44" stroke-width="1.5" stroke-dasharray="4,2" marker-end="url(#arrowRed26)"/>
+                    <text x="330" y="95" font-family="Georgia" font-size="8" fill="#c44">Replay!</text>
+
+                    <!-- Protection -->
+                    <rect x="400" y="70" width="80" height="40" rx="4" fill="#d4edda" stroke="#28a745" stroke-width="1.5"/>
+                    <text x="440" y="85" text-anchor="middle" font-family="Georgia" font-size="8">Replay</text>
+                    <text x="440" y="100" text-anchor="middle" font-family="Georgia" font-size="8">Protection</text>
+
+                    <line x1="340" y1="47" x2="400" y2="80" stroke="#28a745" stroke-width="1.5"/>
+
+                    <defs>
+                        <marker id="arrowRed26" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+                            <polygon points="0 0, 8 3, 0 6" fill="#c44"/>
+                        </marker>
+                    </defs>
+                </svg>
+                <figcaption>Figure 26.3: Without replay protection, transactions can be replayed across chains.</figcaption>
+            </figure>
+
+            <div class="remark">
+                <p class="remark-title">Remark 26.3 (Bitcoin Cash Replay Protection)</p>
+                <p>
+                    Bitcoin Cash (BCH) implemented strong replay protection via a new sighash
+                    flag (SIGHASH_FORKID). Transactions include a fork identifier, making them
+                    invalid on the original Bitcoin chain.
+                </p>
+            </div>
+        </section>
+
+        <section>
+            <h2>26.6 Fork Choice Rules</h2>
+
+            <p>
+                Different protocols use different rules to select between competing chains.
+            </p>
+
+            <div class="definition">
+                <p class="definition-title">Definition 26.9 (Fork Choice Rule)</p>
+                <p>
+                    A <strong>fork choice rule</strong> is a function that selects the "best"
+                    chain from a set of valid chains:
+                </p>
+                <p style="text-align: center; font-family: 'Times New Roman', serif;">
+                    FCR: 𝒫(Chains) → Chain
+                </p>
+            </div>
+
+            <div class="definition">
+                <p class="definition-title">Definition 26.10 (Nakamoto Fork Choice)</p>
+                <p>
+                    Bitcoin's fork choice rule selects the chain with most cumulative work:
+                </p>
+                <p style="text-align: center; font-family: 'Times New Roman', serif;">
+                    FCR<sub>Nakamoto</sub>(C) = argmax<sub>c∈C</sub> Σ<sub>b∈c</sub> work(b)
+                </p>
+                <p>
+                    where work(b) = 2<sup>256</sup> / target(b) for block b.
+                </p>
+            </div>
+
+            <div class="theorem">
+                <p class="theorem-title">Theorem 26.5 (Work vs. Length)</p>
+                <p>
+                    The "longest chain" description is imprecise. The correct rule is "most
+                    cumulative work." These differ when difficulty changes:
+                </p>
+                <ul>
+                    <li>Chain A: 10 blocks at difficulty 1 → work = 10</li>
+                    <li>Chain B: 5 blocks at difficulty 3 → work = 15</li>
+                </ul>
+                <p>
+                    Chain B wins despite being shorter.
+                </p>
+            </div>
+
+            <div class="remark">
+                <p class="remark-title">Remark 26.4 (Alternative Fork Choice Rules)</p>
+                <p>
+                    Other blockchain systems use different rules:
+                </p>
+                <ul>
+                    <li><strong>GHOST:</strong> Counts subtree weight, not just chain length</li>
+                    <li><strong>LMD-GHOST:</strong> Latest message driven, used in Ethereum PoS</li>
+                    <li><strong>Casper FFG:</strong> Finality gadget with economic guarantees</li>
+                </ul>
+                <p>
+                    Bitcoin's simplicity (pure cumulative work) provides strong security guarantees.
+                </p>
+            </div>
+        </section>
+
+        <section>
+            <h2>26.7 Finality and Reorg Depth</h2>
+
+            <p>
+                Unlike some consensus systems, Bitcoin has probabilistic rather than
+                absolute finality.
+            </p>
+
+            <div class="definition">
+                <p class="definition-title">Definition 26.11 (k-Confirmation Security)</p>
+                <p>
+                    A transaction is <strong>k-confirmed</strong> when it is included in a block
+                    with k-1 blocks built on top of it. The probability of reversal decreases
+                    exponentially with k.
+                </p>
+            </div>
+
+            <div class="theorem">
+                <p class="theorem-title">Theorem 26.6 (Double-Spend Probability)</p>
+                <p>
+                    Let q be the fraction of hash power controlled by an attacker, and k be
+                    the number of confirmations. The probability of successful double-spend is:
+                </p>
+                <p style="text-align: center; font-family: 'Times New Roman', serif;">
+                    P(double-spend) ≈ (q/p)<sup>k</sup> for q < p = 1-q
+                </p>
+                <p>
+                    For q = 0.1 (10% attacker) and k = 6: P ≈ 0.0001%
+                </p>
+            </div>
+
+            <table class="data-table">
+                <thead>
+                    <tr>
+                        <th>Attacker Hash Rate</th>
+                        <th>1 conf</th>
+                        <th>3 conf</th>
+                        <th>6 conf</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>10%</td>
+                        <td>20.5%</td>
+                        <td>1.3%</td>
+                        <td>0.02%</td>
+                    </tr>
+                    <tr>
+                        <td>25%</td>
+                        <td>43%</td>
+                        <td>13%</td>
+                        <td>2.4%</td>
+                    </tr>
+                    <tr>
+                        <td>33%</td>
+                        <td>54%</td>
+                        <td>23%</td>
+                        <td>8.5%</td>
+                    </tr>
+                    <tr>
+                        <td>45%</td>
+                        <td>72%</td>
+                        <td>50%</td>
+                        <td>35%</td>
+                    </tr>
+                </tbody>
+            </table>
+
+            <div class="remark">
+                <p class="remark-title">Remark 26.5 (Deep Reorgs)</p>
+                <p>
+                    The deepest reorg in Bitcoin mainnet history was 53 blocks (2010), caused
+                    by a bug. Since protocol stabilization, reorgs deeper than 1-2 blocks
+                    are exceptionally rare. A deep reorg today would indicate either:
+                </p>
+                <ul>
+                    <li>A catastrophic bug</li>
+                    <li>A 51% attack</li>
+                    <li>An intentional rollback by social consensus (unprecedented)</li>
+                </ul>
+            </div>
+        </section>
+
+        <section>
+            <h2>26.8 The Economics of Fork Creation</h2>
+
+            <p>
+                Creating a successful fork requires overcoming significant economic barriers.
+            </p>
+
+            <div class="definition">
+                <p class="definition-title">Definition 26.12 (Fork Viability Criteria)</p>
+                <p>
+                    A fork becomes economically viable when:
+                </p>
+                <ol>
+                    <li><strong>Hash power:</strong> Sufficient mining to maintain security</li>
+                    <li><strong>Liquidity:</strong> Exchange listings and trading pairs</li>
+                    <li><strong>Utility:</strong> Merchants, services, and use cases</li>
+                    <li><strong>Community:</strong> Developers, advocates, and users</li>
+                </ol>
+            </div>
+
+            <div class="theorem">
+                <p class="theorem-title">Theorem 26.7 (Difficulty Death Spiral)</p>
+                <p>
+                    A minority fork sharing Bitcoin's difficulty adjustment algorithm faces a
+                    potential "death spiral":
+                </p>
+                <ol>
+                    <li>Fork starts with minority hash power (e.g., 10%)</li>
+                    <li>Block times increase ~10x (100 minutes vs 10 minutes)</li>
+                    <li>2016 blocks take ~20 weeks instead of 2 weeks</li>
+                    <li>Slow blocks reduce usability, driving away users</li>
+                    <li>Reduced value makes mining unprofitable</li>
+                    <li>Miners leave, exacerbating the problem</li>
+                </ol>
+            </div>
+
+            <div class="example">
+                <p class="example-title">Example 26.4 (Bitcoin Cash EDA)</p>
+                <p>
+                    Bitcoin Cash (2017) anticipated this problem by implementing an Emergency
+                    Difficulty Adjustment (EDA). When blocks were slow, difficulty dropped
+                    rapidly. This prevented the death spiral but created oscillations:
+                </p>
+                <ul>
+                    <li>Difficulty drops → miners switch from BTC to BCH</li>
+                    <li>Fast blocks → difficulty rises</li>
+                    <li>Miners switch back to BTC</li>
+                    <li>Slow blocks → difficulty drops again</li>
+                </ul>
+                <p>
+                    BCH later replaced EDA with a smoother algorithm (DAA).
+                </p>
+            </div>
+        </section>
+
+        <section>
+            <h2>26.9 Contentious vs. Non-Contentious Forks</h2>
+
+            <p>
+                The social dynamics of forks depend critically on whether the change is
+                controversial.
+            </p>
+
+            <div class="definition">
+                <p class="definition-title">Definition 26.13 (Fork Contention Spectrum)</p>
+                <ul>
+                    <li><strong>Non-contentious:</strong> Near-universal agreement (e.g., Taproot)</li>
+                    <li><strong>Mildly contentious:</strong> Disagreement on timing/details (e.g., SegWit activation)</li>
+                    <li><strong>Highly contentious:</strong> Fundamental disagreement (e.g., block size debate)</li>
+                </ul>
+            </div>
+
+            <div class="remark">
+                <p class="remark-title">Remark 26.6 (Contentious Fork Outcomes)</p>
+                <p>
+                    Historical patterns for contentious forks:
+                </p>
+                <table class="data-table">
+                    <thead>
+                        <tr>
+                            <th>Fork</th>
+                            <th>Year</th>
+                            <th>Contention</th>
+                            <th>Outcome (2024)</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>Bitcoin XT</td>
+                            <td>2015</td>
+                            <td>High</td>
+                            <td>Abandoned</td>
+                        </tr>
+                        <tr>
+                            <td>Bitcoin Classic</td>
+                            <td>2016</td>
+                            <td>High</td>
+                            <td>Abandoned</td>
+                        </tr>
+                        <tr>
+                            <td>Bitcoin Unlimited</td>
+                            <td>2016</td>
+                            <td>High</td>
+                            <td>Marginal</td>
+                        </tr>
+                        <tr>
+                            <td>Bitcoin Cash</td>
+                            <td>2017</td>
+                            <td>High</td>
+                            <td>~0.5% BTC value</td>
+                        </tr>
+                        <tr>
+                            <td>Bitcoin SV</td>
+                            <td>2018</td>
+                            <td>High</td>
+                            <td>~0.1% BTC value</td>
+                        </tr>
+                        <tr>
+                            <td>SegWit (soft)</td>
+                            <td>2017</td>
+                            <td>Mild</td>
+                            <td>Universal adoption</td>
+                        </tr>
+                        <tr>
+                            <td>Taproot (soft)</td>
+                            <td>2021</td>
+                            <td>None</td>
+                            <td>Universal adoption</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+
+            <div class="theorem">
+                <p class="theorem-title">Theorem 26.8 (Schelling Point Preservation)</p>
+                <p>
+                    Non-contentious soft forks preserve the Schelling point (focal point for
+                    coordination) because:
+                </p>
+                <ol>
+                    <li>Old nodes accept new-rules blocks</li>
+                    <li>No chain split forces choice</li>
+                    <li>The "default" remains unchanged</li>
+                </ol>
+                <p>
+                    Contentious hard forks challenge the Schelling point, requiring massive
+                    coordination to shift focal point to the new chain.
+                </p>
+            </div>
+        </section>
+
+        <section class="exercises">
+            <h2>Exercises</h2>
+
+            <div class="exercise">
+                <p class="exercise-title">Exercise 26.1</p>
+                <p>
+                    Prove that if hash power is distributed such that no miner has more than
+                    1/n of the total, the expected time to natural fork resolution is bounded
+                    by 2·T<sub>block</sub> with high probability. What assumptions are needed?
+                </p>
+            </div>
+
+            <div class="exercise">
+                <p class="exercise-title">Exercise 26.2</p>
+                <p>
+                    A proposed change would require all transactions to be at least 100 bytes.
+                    Is this a soft fork or hard fork? What about requiring transactions to be
+                    at most 100 bytes?
+                </p>
+            </div>
+
+            <div class="exercise">
+                <p class="exercise-title">Exercise 26.3</p>
+                <p>
+                    Model the fork adoption game as a two-player game with payoff matrix.
+                    Find the Nash equilibria and determine conditions under which a challenger
+                    chain can succeed.
+                </p>
+            </div>
+
+            <div class="exercise">
+                <p class="exercise-title">Exercise 26.4</p>
+                <p>
+                    Design a replay protection mechanism using only existing Script opcodes
+                    (no protocol changes). What are its limitations?
+                </p>
+            </div>
+
+            <div class="exercise">
+                <p class="exercise-title">Exercise 26.5</p>
+                <p>
+                    Calculate the expected time for a 20% hash power minority fork to reach
+                    its first difficulty adjustment, assuming Bitcoin's 2016-block adjustment
+                    period. How does the EDA (Emergency Difficulty Adjustment) change this?
+                </p>
+            </div>
+        </section>
+
+        <nav class="chapter-navigation">
+            <a href="25-debunking-myths.html" class="prev-chapter">← Chapter 25: Debunking Myths</a>
+            <a href="27-historical-forks.html" class="next-chapter">Chapter 27: Historical Hard Forks →</a>
+        </nav>
+    </main>
+
+    <footer>
+        <p>Elementary Bitcoin · Volume IV: Forks and Futures (Draft)</p>
+    </footer>
+</body>
+</html>

--- a/chapters/27-historical-forks.html
+++ b/chapters/27-historical-forks.html
@@ -1,0 +1,879 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Chapter 27: Historical Hard Forks | Elementary Bitcoin</title>
+    <meta name="description" content="Chapter 27: Historical Hard Forks - Analysis of Bitcoin Cash, Bitcoin SV, Bitcoin Gold, and other chain splits">
+    <link rel="stylesheet" href="../style.css">
+</head>
+<body>
+    <nav class="chapter-nav">
+        <a href="../index.html">Contents</a>
+        <span class="nav-separator">·</span>
+        <span class="volume-indicator">Volume IV: Forks and Futures</span>
+    </nav>
+
+    <header class="chapter-header">
+        <p class="chapter-number">Chapter 27</p>
+        <h1>Historical Hard Forks</h1>
+        <p class="chapter-subtitle">A Post-Mortem Analysis</p>
+    </header>
+
+    <main class="chapter-content">
+        <section>
+            <p class="chapter-intro">
+                Bitcoin's history is marked by several contentious hard forks, each representing
+                a fundamental disagreement about the protocol's direction. This chapter provides
+                a rigorous analysis of major chain splits—their technical motivations, implementation
+                details, economic outcomes, and lessons learned. We examine these forks not to
+                judge their merits but to understand the dynamics of decentralized protocol evolution.
+            </p>
+        </section>
+
+        <section>
+            <h2>27.1 The Block Size Debate: Background</h2>
+
+            <p>
+                To understand Bitcoin's hard forks, we must first understand the conflict that
+                produced them: the block size debate.
+            </p>
+
+            <div class="definition">
+                <p class="definition-title">Definition 27.1 (Block Size Limit)</p>
+                <p>
+                    Bitcoin's consensus rules include a maximum block size, originally unlimited,
+                    then set to 1 MB in 2010 (commit 172f006):
+                </p>
+                <pre style="background: #f5f5f5; padding: 1rem; font-family: monospace; font-size: 0.9rem; overflow-x: auto;">
+if (block.GetSerializeSize() > MAX_BLOCK_SIZE)
+    return error("CheckBlock(): size limits failed");</pre>
+                <p>
+                    This limit was later redefined as 4 million weight units (SegWit, 2017),
+                    allowing blocks up to ~4 MB with witness data.
+                </p>
+            </div>
+
+            <div class="remark">
+                <p class="remark-title">Remark 27.1 (The Scaling Trilemma Applied)</p>
+                <p>
+                    The block size debate represents a manifestation of the scaling trilemma:
+                </p>
+                <ul>
+                    <li><strong>Throughput:</strong> Larger blocks → more transactions per second</li>
+                    <li><strong>Decentralization:</strong> Larger blocks → higher node costs → fewer nodes</li>
+                    <li><strong>Security:</strong> Fewer nodes → increased centralization risk</li>
+                </ul>
+                <p>
+                    The debate centered on where to position this tradeoff.
+                </p>
+            </div>
+
+            <figure>
+                <svg class="diagram" width="500" height="200" viewBox="0 0 500 200">
+                    <!-- Timeline -->
+                    <line x1="50" y1="100" x2="450" y2="100" stroke="#666" stroke-width="2"/>
+
+                    <!-- Events -->
+                    <circle cx="80" cy="100" r="5" fill="#5a8f5a"/>
+                    <text x="80" y="85" text-anchor="middle" font-family="Georgia" font-size="8">2010</text>
+                    <text x="80" y="130" text-anchor="middle" font-family="Georgia" font-size="7">1MB limit</text>
+                    <text x="80" y="142" text-anchor="middle" font-family="Georgia" font-size="7">added</text>
+
+                    <circle cx="150" cy="100" r="5" fill="#f39c12"/>
+                    <text x="150" y="85" text-anchor="middle" font-family="Georgia" font-size="8">2015</text>
+                    <text x="150" y="130" text-anchor="middle" font-family="Georgia" font-size="7">Bitcoin XT</text>
+
+                    <circle cx="200" cy="100" r="5" fill="#f39c12"/>
+                    <text x="200" y="85" text-anchor="middle" font-family="Georgia" font-size="8">2016</text>
+                    <text x="200" y="130" text-anchor="middle" font-family="Georgia" font-size="7">Classic/</text>
+                    <text x="200" y="142" text-anchor="middle" font-family="Georgia" font-size="7">Unlimited</text>
+
+                    <circle cx="270" cy="100" r="5" fill="#c44"/>
+                    <text x="270" y="85" text-anchor="middle" font-family="Georgia" font-size="8">Aug 2017</text>
+                    <text x="270" y="130" text-anchor="middle" font-family="Georgia" font-size="7">Bitcoin</text>
+                    <text x="270" y="142" text-anchor="middle" font-family="Georgia" font-size="7">Cash</text>
+
+                    <circle cx="330" cy="100" r="5" fill="#5a8f5a"/>
+                    <text x="330" y="85" text-anchor="middle" font-family="Georgia" font-size="8">Aug 2017</text>
+                    <text x="330" y="130" text-anchor="middle" font-family="Georgia" font-size="7">SegWit</text>
+                    <text x="330" y="142" text-anchor="middle" font-family="Georgia" font-size="7">activates</text>
+
+                    <circle cx="390" cy="100" r="5" fill="#c44"/>
+                    <text x="390" y="85" text-anchor="middle" font-family="Georgia" font-size="8">Nov 2018</text>
+                    <text x="390" y="130" text-anchor="middle" font-family="Georgia" font-size="7">BCH/BSV</text>
+                    <text x="390" y="142" text-anchor="middle" font-family="Georgia" font-size="7">split</text>
+
+                    <!-- Legend -->
+                    <circle cx="100" cy="175" r="4" fill="#5a8f5a"/>
+                    <text x="115" y="178" font-family="Georgia" font-size="8">Soft fork</text>
+                    <circle cx="180" cy="175" r="4" fill="#f39c12"/>
+                    <text x="195" y="178" font-family="Georgia" font-size="8">Proposal</text>
+                    <circle cx="260" cy="175" r="4" fill="#c44"/>
+                    <text x="275" y="178" font-family="Georgia" font-size="8">Hard fork</text>
+                </svg>
+                <figcaption>Figure 27.1: Timeline of the block size debate and resulting forks.</figcaption>
+            </figure>
+
+            <div class="definition">
+                <p class="definition-title">Definition 27.2 (The Two Scaling Philosophies)</p>
+                <p>
+                    <strong>On-chain scaling:</strong> Increase block size to accommodate more
+                    transactions directly on the base layer. Advocates argued this was Satoshi's
+                    original vision and necessary for mainstream adoption.
+                </p>
+                <p>
+                    <strong>Layer-2 scaling:</strong> Keep base layer small and secure; scale
+                    via payment channels (Lightning), sidechains, and other off-chain solutions.
+                    Advocates argued this preserves decentralization and enables novel use cases.
+                </p>
+            </div>
+        </section>
+
+        <section>
+            <h2>27.2 Failed Fork Attempts (2015-2017)</h2>
+
+            <p>
+                Before Bitcoin Cash, several attempts to increase the block size failed to
+                gain sufficient support.
+            </p>
+
+            <h3>27.2.1 Bitcoin XT (August 2015)</h3>
+
+            <div class="definition">
+                <p class="definition-title">Definition 27.3 (Bitcoin XT)</p>
+                <p>
+                    <strong>Bitcoin XT</strong> was a fork of Bitcoin Core by Mike Hearn and
+                    Gavin Andresen implementing BIP-101:
+                </p>
+                <ul>
+                    <li>Initial 8 MB block size</li>
+                    <li>Doubling every 2 years until 8 GB</li>
+                    <li>Activation at 75% miner support</li>
+                </ul>
+            </div>
+
+            <div class="remark">
+                <p class="remark-title">Remark 27.2 (XT Failure Analysis)</p>
+                <p>
+                    Bitcoin XT failed due to:
+                </p>
+                <ol>
+                    <li><strong>Insufficient miner signaling:</strong> Never approached 75% threshold</li>
+                    <li><strong>Community opposition:</strong> Perceived as hostile takeover</li>
+                    <li><strong>Technical concerns:</strong> Exponential growth criticized as reckless</li>
+                    <li><strong>DDoS attacks:</strong> XT nodes were targeted (controversial)</li>
+                </ol>
+                <p>
+                    Peak XT node share: ~12% (late 2015), then rapid decline.
+                </p>
+            </div>
+
+            <h3>27.2.2 Bitcoin Classic (February 2016)</h3>
+
+            <div class="definition">
+                <p class="definition-title">Definition 27.4 (Bitcoin Classic)</p>
+                <p>
+                    <strong>Bitcoin Classic</strong> proposed a more conservative increase:
+                </p>
+                <ul>
+                    <li>2 MB block size (one-time increase)</li>
+                    <li>Activation at 75% miner support over 28 days</li>
+                    <li>Positioned as compromise solution</li>
+                </ul>
+            </div>
+
+            <h3>27.2.3 Bitcoin Unlimited (December 2015)</h3>
+
+            <div class="definition">
+                <p class="definition-title">Definition 27.5 (Bitcoin Unlimited)</p>
+                <p>
+                    <strong>Bitcoin Unlimited</strong> took a radical approach: no hard-coded
+                    limit. Instead:
+                </p>
+                <ul>
+                    <li>Miners set their own limits ("Emergent Consensus")</li>
+                    <li>Market forces determine equilibrium block size</li>
+                    <li>Users configure acceptance depth for larger blocks</li>
+                </ul>
+            </div>
+
+            <div class="theorem">
+                <p class="theorem-title">Theorem 27.1 (Emergent Consensus Critique)</p>
+                <p>
+                    The "Emergent Consensus" model has a game-theoretic flaw: without a
+                    Schelling point (hard limit), miners have incentive to produce maximum-size
+                    blocks to:
+                </p>
+                <ol>
+                    <li>Collect more fees (more transactions)</li>
+                    <li>Disadvantage smaller competitors (propagation delay)</li>
+                </ol>
+                <p>
+                    This could lead to unbounded growth and centralization.
+                </p>
+            </div>
+        </section>
+
+        <section>
+            <h2>27.3 Bitcoin Cash (BCH)</h2>
+
+            <p>
+                Bitcoin Cash represents the most successful Bitcoin hard fork, creating a
+                persistent alternative chain.
+            </p>
+
+            <div class="definition">
+                <p class="definition-title">Definition 27.6 (Bitcoin Cash Fork)</p>
+                <p>
+                    <strong>Bitcoin Cash</strong> forked at block 478,558 (August 1, 2017):
+                </p>
+                <ul>
+                    <li><strong>Block size:</strong> 8 MB (later 32 MB)</li>
+                    <li><strong>Replay protection:</strong> SIGHASH_FORKID (new sighash type)</li>
+                    <li><strong>Difficulty:</strong> Emergency Difficulty Adjustment (EDA)</li>
+                    <li><strong>SegWit:</strong> Not included (philosophical rejection)</li>
+                </ul>
+            </div>
+
+            <figure>
+                <svg class="diagram" width="500" height="200" viewBox="0 0 500 200">
+                    <!-- Main Bitcoin chain -->
+                    <rect x="30" y="80" width="70" height="40" rx="4" fill="#f39c12" stroke="#c87f0a" stroke-width="1.5"/>
+                    <text x="65" y="105" text-anchor="middle" font-family="Georgia" font-size="9">Block</text>
+                    <text x="65" y="117" text-anchor="middle" font-family="Georgia" font-size="8">478,557</text>
+
+                    <!-- Fork point -->
+                    <circle cx="130" cy="100" r="10" fill="#c44" stroke="#a33" stroke-width="2"/>
+                    <text x="130" y="145" text-anchor="middle" font-family="Georgia" font-size="8" fill="#c44">Fork Point</text>
+                    <text x="130" y="157" text-anchor="middle" font-family="Georgia" font-size="7">Aug 1, 2017</text>
+
+                    <!-- BTC branch -->
+                    <path d="M 140 95 L 180 60" stroke="#f39c12" stroke-width="2" fill="none"/>
+                    <rect x="180" y="40" width="70" height="35" rx="4" fill="#f39c12" stroke="#c87f0a" stroke-width="1.5"/>
+                    <text x="215" y="60" text-anchor="middle" font-family="Georgia" font-size="9">BTC</text>
+                    <rect x="270" y="40" width="70" height="35" rx="4" fill="#f39c12" stroke="#c87f0a" stroke-width="1.5"/>
+                    <text x="305" y="55" text-anchor="middle" font-family="Georgia" font-size="8">1MB + SegWit</text>
+                    <text x="305" y="68" text-anchor="middle" font-family="Georgia" font-size="7">(~4MB weight)</text>
+
+                    <line x1="250" y1="57" x2="270" y2="57" stroke="#f39c12" stroke-width="1.5"/>
+                    <line x1="340" y1="57" x2="360" y2="57" stroke="#f39c12" stroke-width="1.5"/>
+                    <text x="380" y="62" font-family="Georgia" font-size="8" fill="#f39c12">→ continues</text>
+
+                    <!-- BCH branch -->
+                    <path d="M 140 105 L 180 140" stroke="#28a745" stroke-width="2" fill="none"/>
+                    <rect x="180" y="125" width="70" height="35" rx="4" fill="#28a745" stroke="#1e7b34" stroke-width="1.5"/>
+                    <text x="215" y="145" text-anchor="middle" font-family="Georgia" font-size="9" fill="white">BCH</text>
+                    <rect x="270" y="125" width="70" height="35" rx="4" fill="#28a745" stroke="#1e7b34" stroke-width="1.5"/>
+                    <text x="305" y="140" text-anchor="middle" font-family="Georgia" font-size="8" fill="white">8MB blocks</text>
+                    <text x="305" y="153" text-anchor="middle" font-family="Georgia" font-size="7" fill="white">(no SegWit)</text>
+
+                    <line x1="250" y1="142" x2="270" y2="142" stroke="#28a745" stroke-width="1.5"/>
+                    <line x1="340" y1="142" x2="360" y2="142" stroke="#28a745" stroke-width="1.5"/>
+                    <text x="380" y="147" font-family="Georgia" font-size="8" fill="#28a745">→ continues</text>
+                </svg>
+                <figcaption>Figure 27.2: Bitcoin Cash fork from block 478,558.</figcaption>
+            </figure>
+
+            <h3>27.3.1 Emergency Difficulty Adjustment</h3>
+
+            <div class="definition">
+                <p class="definition-title">Definition 27.7 (EDA Algorithm)</p>
+                <p>
+                    The <strong>Emergency Difficulty Adjustment</strong> reduced difficulty by
+                    20% if fewer than 6 blocks were mined in 12 hours:
+                </p>
+                <pre style="background: #f5f5f5; padding: 1rem; font-family: monospace; font-size: 0.85rem;">
+if (timeSince6Blocks > 12 hours):
+    difficulty = difficulty * 0.8</pre>
+            </div>
+
+            <div class="theorem">
+                <p class="theorem-title">Theorem 27.2 (EDA Instability)</p>
+                <p>
+                    The EDA created oscillating dynamics:
+                </p>
+                <ol>
+                    <li>Low BCH price → miners leave → slow blocks → EDA triggers</li>
+                    <li>Difficulty drops → BCH more profitable than BTC</li>
+                    <li>Miners switch to BCH → fast blocks → difficulty rises</li>
+                    <li>BCH less profitable → miners return to BTC → cycle repeats</li>
+                </ol>
+                <p>
+                    Result: 92,000 "extra" BCH mined in first months due to fast blocks.
+                </p>
+            </div>
+
+            <div class="example">
+                <p class="example-title">Example 27.1 (DAA Replacement)</p>
+                <p>
+                    Bitcoin Cash replaced EDA with the DAA (Difficulty Adjustment Algorithm)
+                    in November 2017:
+                </p>
+                <ul>
+                    <li>Adjusts difficulty every block</li>
+                    <li>Uses 144-block rolling window</li>
+                    <li>Targets 600 seconds per block</li>
+                    <li>Smooths oscillations</li>
+                </ul>
+            </div>
+
+            <h3>27.3.2 BCH Economic Performance</h3>
+
+            <table class="data-table">
+                <thead>
+                    <tr>
+                        <th>Metric</th>
+                        <th>At Fork (2017)</th>
+                        <th>Peak (2017)</th>
+                        <th>2024</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>Price (USD)</td>
+                        <td>~$300</td>
+                        <td>~$4,000</td>
+                        <td>~$250</td>
+                    </tr>
+                    <tr>
+                        <td>% of BTC price</td>
+                        <td>10%</td>
+                        <td>25%</td>
+                        <td>0.5%</td>
+                    </tr>
+                    <tr>
+                        <td>Hash rate (% of BTC)</td>
+                        <td>~5%</td>
+                        <td>~20%</td>
+                        <td>~1%</td>
+                    </tr>
+                    <tr>
+                        <td>Daily transactions</td>
+                        <td>~10,000</td>
+                        <td>~50,000</td>
+                        <td>~30,000</td>
+                    </tr>
+                </tbody>
+            </table>
+        </section>
+
+        <section>
+            <h2>27.4 Bitcoin SV (BSV)</h2>
+
+            <p>
+                Bitcoin SV emerged from a schism within the Bitcoin Cash community.
+            </p>
+
+            <div class="definition">
+                <p class="definition-title">Definition 27.8 (Bitcoin SV Fork)</p>
+                <p>
+                    <strong>Bitcoin SV</strong> ("Satoshi Vision") forked from BCH at block
+                    556,766 (November 15, 2018):
+                </p>
+                <ul>
+                    <li><strong>Block size:</strong> 128 MB (later removed entirely)</li>
+                    <li><strong>Philosophy:</strong> Return to "original" Bitcoin protocol</li>
+                    <li><strong>Restoration:</strong> Re-enabled some disabled opcodes</li>
+                    <li><strong>Leader:</strong> Craig Wright / Calvin Ayre</li>
+                </ul>
+            </div>
+
+            <div class="remark">
+                <p class="remark-title">Remark 27.3 (The Hash War)</p>
+                <p>
+                    The BCH/BSV split involved an unusual "hash war" where both sides
+                    threatened to attack each other's chain:
+                </p>
+                <ul>
+                    <li>Both chains mined at a loss to accumulate work</li>
+                    <li>BSV side threatened 51% attacks</li>
+                    <li>Exchanges suspended trading during uncertainty</li>
+                    <li>Eventually, both chains coexisted with replay protection</li>
+                </ul>
+            </div>
+
+            <figure>
+                <svg class="diagram" width="500" height="180" viewBox="0 0 500 180">
+                    <!-- BCH chain -->
+                    <rect x="30" y="70" width="70" height="40" rx="4" fill="#28a745" stroke="#1e7b34" stroke-width="1.5"/>
+                    <text x="65" y="95" text-anchor="middle" font-family="Georgia" font-size="9" fill="white">BCH</text>
+
+                    <!-- Fork point -->
+                    <circle cx="130" cy="90" r="8" fill="#c44"/>
+                    <text x="130" y="130" text-anchor="middle" font-family="Georgia" font-size="7" fill="#c44">Nov 15, 2018</text>
+
+                    <!-- BCH-ABC branch -->
+                    <path d="M 138 85 L 170 55" stroke="#28a745" stroke-width="2"/>
+                    <rect x="170" y="35" width="80" height="35" rx="4" fill="#28a745" stroke="#1e7b34" stroke-width="1.5"/>
+                    <text x="210" y="50" text-anchor="middle" font-family="Georgia" font-size="8" fill="white">BCH (ABC)</text>
+                    <text x="210" y="63" text-anchor="middle" font-family="Georgia" font-size="7" fill="white">32MB blocks</text>
+
+                    <!-- BSV branch -->
+                    <path d="M 138 95 L 170 125" stroke="#9b59b6" stroke-width="2"/>
+                    <rect x="170" y="110" width="80" height="35" rx="4" fill="#9b59b6" stroke="#7d3c98" stroke-width="1.5"/>
+                    <text x="210" y="125" text-anchor="middle" font-family="Georgia" font-size="8" fill="white">BSV</text>
+                    <text x="210" y="138" text-anchor="middle" font-family="Georgia" font-size="7" fill="white">128MB+ blocks</text>
+
+                    <!-- Continuation -->
+                    <line x1="250" y1="52" x2="280" y2="52" stroke="#28a745" stroke-width="1.5"/>
+                    <rect x="280" y="35" width="70" height="35" rx="4" fill="#28a745" stroke="#1e7b34" stroke-width="1.5"/>
+                    <text x="315" y="57" text-anchor="middle" font-family="Georgia" font-size="8" fill="white">→ BCH</text>
+
+                    <line x1="250" y1="127" x2="280" y2="127" stroke="#9b59b6" stroke-width="1.5"/>
+                    <rect x="280" y="110" width="70" height="35" rx="4" fill="#9b59b6" stroke="#7d3c98" stroke-width="1.5"/>
+                    <text x="315" y="132" text-anchor="middle" font-family="Georgia" font-size="8" fill="white">→ BSV</text>
+
+                    <!-- 2020 split -->
+                    <text x="420" y="52" font-family="Georgia" font-size="7" fill="#666">2020: eCash fork</text>
+                    <text x="420" y="127" font-family="Georgia" font-size="7" fill="#666">Delisted from</text>
+                    <text x="420" y="140" font-family="Georgia" font-size="7" fill="#666">major exchanges</text>
+                </svg>
+                <figcaption>Figure 27.3: BCH → BSV fork and subsequent developments.</figcaption>
+            </figure>
+
+            <h3>27.4.1 Technical Differences</h3>
+
+            <table class="data-table">
+                <thead>
+                    <tr>
+                        <th>Feature</th>
+                        <th>BCH</th>
+                        <th>BSV</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>Block size</td>
+                        <td>32 MB</td>
+                        <td>Unlimited (4GB tested)</td>
+                    </tr>
+                    <tr>
+                        <td>OP_RETURN limit</td>
+                        <td>220 bytes</td>
+                        <td>Unlimited</td>
+                    </tr>
+                    <tr>
+                        <td>Script opcodes</td>
+                        <td>Some re-enabled</td>
+                        <td>More re-enabled</td>
+                    </tr>
+                    <tr>
+                        <td>Development model</td>
+                        <td>Multiple implementations</td>
+                        <td>nChain-led</td>
+                    </tr>
+                    <tr>
+                        <td>Major exchanges (2024)</td>
+                        <td>Listed</td>
+                        <td>Largely delisted</td>
+                    </tr>
+                </tbody>
+            </table>
+
+            <div class="remark">
+                <p class="remark-title">Remark 27.4 (BSV Controversies)</p>
+                <p>
+                    BSV faced unique challenges:
+                </p>
+                <ul>
+                    <li>Association with Craig Wright's disputed Satoshi claims</li>
+                    <li>Legal threats against critics</li>
+                    <li>Delisting from Binance, Kraken, ShapeShift</li>
+                    <li>Multiple 51% attacks (2021)</li>
+                    <li>Centralization concerns (few large miners)</li>
+                </ul>
+            </div>
+        </section>
+
+        <section>
+            <h2>27.5 Bitcoin Gold (BTG)</h2>
+
+            <p>
+                Bitcoin Gold represents a different type of fork: changing the mining algorithm.
+            </p>
+
+            <div class="definition">
+                <p class="definition-title">Definition 27.9 (Bitcoin Gold Fork)</p>
+                <p>
+                    <strong>Bitcoin Gold</strong> forked at block 491,407 (October 24, 2017):
+                </p>
+                <ul>
+                    <li><strong>Algorithm:</strong> Equihash (ASIC-resistant) instead of SHA-256d</li>
+                    <li><strong>Goal:</strong> Democratize mining (GPU-friendly)</li>
+                    <li><strong>Block size:</strong> 1 MB (unchanged)</li>
+                    <li><strong>Premine:</strong> 100,000 BTG for development</li>
+                </ul>
+            </div>
+
+            <div class="theorem">
+                <p class="theorem-title">Theorem 27.3 (ASIC Resistance Futility)</p>
+                <p>
+                    Changing proof-of-work algorithm to be "ASIC-resistant" provides only
+                    temporary protection:
+                </p>
+                <ol>
+                    <li>Any fixed algorithm can eventually have ASICs designed for it</li>
+                    <li>GPU mining leads to botnet participation (stolen compute)</li>
+                    <li>Algorithm changes cause disruptive hard forks</li>
+                    <li>Smaller hash rate increases 51% attack vulnerability</li>
+                </ol>
+            </div>
+
+            <div class="example">
+                <p class="example-title">Example 27.2 (BTG 51% Attacks)</p>
+                <p>
+                    Bitcoin Gold suffered multiple 51% attacks:
+                </p>
+                <table class="data-table">
+                    <thead>
+                        <tr>
+                            <th>Date</th>
+                            <th>Double-Spend</th>
+                            <th>Reorg Depth</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>May 2018</td>
+                            <td>~$18 million</td>
+                            <td>22 blocks</td>
+                        </tr>
+                        <tr>
+                            <td>January 2020</td>
+                            <td>~$72,000</td>
+                            <td>14 blocks</td>
+                        </tr>
+                        <tr>
+                            <td>July 2020</td>
+                            <td>~$10,000</td>
+                            <td>10 blocks</td>
+                        </tr>
+                    </tbody>
+                </table>
+                <p>
+                    These attacks demonstrated the security cost of low hash rate.
+                </p>
+            </div>
+        </section>
+
+        <section>
+            <h2>27.6 Other Notable Forks</h2>
+
+            <h3>27.6.1 Bitcoin Diamond (BCD)</h3>
+
+            <div class="definition">
+                <p class="definition-title">Definition 27.10 (Bitcoin Diamond)</p>
+                <p>
+                    Forked November 2017 with:
+                </p>
+                <ul>
+                    <li>10× coin supply (210 million)</li>
+                    <li>8 MB blocks</li>
+                    <li>X13 proof-of-work algorithm</li>
+                    <li>Encrypted transaction amounts (claimed)</li>
+                </ul>
+                <p>
+                    Largely considered a "fork for profit" with minimal development.
+                </p>
+            </div>
+
+            <h3>27.6.2 Bitcoin Private (BTCP)</h3>
+
+            <div class="definition">
+                <p class="definition-title">Definition 27.11 (Bitcoin Private)</p>
+                <p>
+                    A fork-merge combining Bitcoin and Zclassic (February 2018):
+                </p>
+                <ul>
+                    <li>zk-SNARK privacy features from Zcash</li>
+                    <li>Combined UTXO sets of BTC and ZCL</li>
+                    <li>Equihash algorithm</li>
+                </ul>
+                <p>
+                    Investigation later revealed 2.04 million secretly premined coins.
+                </p>
+            </div>
+
+            <h3>27.6.3 eCash (XEC)</h3>
+
+            <div class="definition">
+                <p class="definition-title">Definition 27.12 (eCash)</p>
+                <p>
+                    Forked from Bitcoin Cash in November 2020:
+                </p>
+                <ul>
+                    <li>Avalanche consensus layer (post-consensus)</li>
+                    <li>Redenomination (1 BCH = 1,000,000 XEC)</li>
+                    <li>Development funded by block reward</li>
+                    <li>Led by Bitcoin ABC team</li>
+                </ul>
+            </div>
+
+            <div class="remark">
+                <p class="remark-title">Remark 27.5 (The Long Tail of Forks)</p>
+                <p>
+                    Dozens of Bitcoin forks have been created. Most share characteristics:
+                </p>
+                <ul>
+                    <li>Minimal development post-fork</li>
+                    <li>Value decay relative to BTC</li>
+                    <li>Low liquidity and exchange support</li>
+                    <li>Security vulnerabilities from small hash rate</li>
+                </ul>
+                <p>
+                    The "free coins" distribution model proved insufficient for building
+                    sustainable networks.
+                </p>
+            </div>
+        </section>
+
+        <section>
+            <h2>27.7 The 2017 SegWit2x Attempt</h2>
+
+            <p>
+                The most dramatic fork attempt that <em>didn't</em> happen: SegWit2x.
+            </p>
+
+            <div class="definition">
+                <p class="definition-title">Definition 27.13 (New York Agreement / SegWit2x)</p>
+                <p>
+                    The <strong>New York Agreement</strong> (May 2017) was a compromise signed
+                    by major companies and miners:
+                </p>
+                <ol>
+                    <li>Activate SegWit (soft fork) - achieved August 2017</li>
+                    <li>2 MB base block size hard fork within 6 months</li>
+                </ol>
+                <p>
+                    The second part (SegWit2x) was abandoned days before activation.
+                </p>
+            </div>
+
+            <div class="theorem">
+                <p class="theorem-title">Theorem 27.4 (SegWit2x Failure Factors)</p>
+                <p>
+                    SegWit2x failed despite ~90% miner signaling because:
+                </p>
+                <ol>
+                    <li><strong>No replay protection:</strong> Intentionally omitted, seen as aggressive</li>
+                    <li><strong>Core developer opposition:</strong> None of Bitcoin Core signed NYA</li>
+                    <li><strong>User opposition:</strong> Futures markets showed BTC premium over B2X</li>
+                    <li><strong>Business defections:</strong> Key signatories withdrew support</li>
+                </ol>
+            </div>
+
+            <div class="remark">
+                <p class="remark-title">Remark 27.6 (Lessons from SegWit2x)</p>
+                <p>
+                    SegWit2x demonstrated that:
+                </p>
+                <ul>
+                    <li>Miner signaling is necessary but not sufficient</li>
+                    <li>Users (economic nodes) have effective veto power</li>
+                    <li>Futures markets can reveal true preferences</li>
+                    <li>Hard forks require broader social consensus than soft forks</li>
+                </ul>
+                <p>
+                    The episode strengthened the "User Activated" model of consensus.
+                </p>
+            </div>
+        </section>
+
+        <section>
+            <h2>27.8 Comparative Analysis</h2>
+
+            <p>
+                A systematic comparison reveals patterns in fork outcomes.
+            </p>
+
+            <table class="data-table">
+                <thead>
+                    <tr>
+                        <th>Fork</th>
+                        <th>Type</th>
+                        <th>% BTC Value (Peak)</th>
+                        <th>% BTC Value (2024)</th>
+                        <th>Status</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>Bitcoin Cash</td>
+                        <td>Ideological</td>
+                        <td>~25%</td>
+                        <td>~0.5%</td>
+                        <td>Active</td>
+                    </tr>
+                    <tr>
+                        <td>Bitcoin SV</td>
+                        <td>Ideological</td>
+                        <td>~10%</td>
+                        <td>~0.1%</td>
+                        <td>Marginal</td>
+                    </tr>
+                    <tr>
+                        <td>Bitcoin Gold</td>
+                        <td>Technical</td>
+                        <td>~5%</td>
+                        <td>~0.02%</td>
+                        <td>Marginal</td>
+                    </tr>
+                    <tr>
+                        <td>Bitcoin Diamond</td>
+                        <td>Commercial</td>
+                        <td>~1%</td>
+                        <td>~0.001%</td>
+                        <td>Zombie</td>
+                    </tr>
+                    <tr>
+                        <td>Bitcoin Private</td>
+                        <td>Commercial</td>
+                        <td>~1%</td>
+                        <td>N/A</td>
+                        <td>Dead</td>
+                    </tr>
+                    <tr>
+                        <td>SegWit2x</td>
+                        <td>Political</td>
+                        <td>N/A</td>
+                        <td>N/A</td>
+                        <td>Never launched</td>
+                    </tr>
+                </tbody>
+            </table>
+
+            <div class="theorem">
+                <p class="theorem-title">Theorem 27.5 (Fork Value Decay)</p>
+                <p>
+                    Empirically, Bitcoin forks exhibit value decay relative to BTC following
+                    a pattern consistent with:
+                </p>
+                <p style="text-align: center; font-family: 'Times New Roman', serif;">
+                    V<sub>fork</sub>(t) / V<sub>BTC</sub>(t) ∝ e<sup>-λt</sup>
+                </p>
+                <p>
+                    where λ varies by fork (BCH: ~0.3/year, BTG: ~0.7/year).
+                </p>
+                <p>
+                    This suggests that network effects compound over time, increasingly
+                    favoring the dominant chain.
+                </p>
+            </div>
+        </section>
+
+        <section>
+            <h2>27.9 Lessons and Principles</h2>
+
+            <div class="theorem">
+                <p class="theorem-title">Theorem 27.6 (Fork Success Factors)</p>
+                <p>
+                    Analysis of historical forks suggests success factors:
+                </p>
+                <ol>
+                    <li><strong>Clear value proposition:</strong> Must offer something BTC cannot</li>
+                    <li><strong>Technical competence:</strong> Must maintain security and development</li>
+                    <li><strong>Community:</strong> Must build independent user base</li>
+                    <li><strong>Timing:</strong> Early forks captured more value</li>
+                    <li><strong>Replay protection:</strong> Essential for user safety</li>
+                </ol>
+            </div>
+
+            <div class="remark">
+                <p class="remark-title">Remark 27.7 (Why Hard Forks Rarely Succeed)</p>
+                <p>
+                    The historical record suggests hard forks face structural disadvantages:
+                </p>
+                <ul>
+                    <li>Network effects strongly favor incumbents</li>
+                    <li>Developer talent tends toward dominant chain</li>
+                    <li>Liquidity fragmentation harms both chains initially</li>
+                    <li>User confusion degrades trust</li>
+                    <li>Minority chain faces security challenges</li>
+                </ul>
+                <p>
+                    Soft forks, by maintaining compatibility, avoid these problems.
+                </p>
+            </div>
+
+            <div class="remark">
+                <p class="remark-title">Remark 27.8 (The Fork Right)</p>
+                <p>
+                    Despite their typically poor outcomes, the ability to fork remains
+                    important:
+                </p>
+                <ul>
+                    <li>Provides exit option, limiting majoritanian abuse</li>
+                    <li>Creates natural experiment for different approaches</li>
+                    <li>Demonstrates that Bitcoin is not controlled by any group</li>
+                    <li>Historical forks actually strengthened BTC's Schelling point</li>
+                </ul>
+                <p>
+                    The freedom to fork, even if rarely exercised successfully, is a
+                    feature, not a bug.
+                </p>
+            </div>
+        </section>
+
+        <section class="exercises">
+            <h2>Exercises</h2>
+
+            <div class="exercise">
+                <p class="exercise-title">Exercise 27.1</p>
+                <p>
+                    Calculate the cost (in USD) to perform a 51% attack on Bitcoin Gold for
+                    1 hour, given that BTG hash rate is approximately 2 MS/s and Equihash
+                    ASIC rental costs $0.10 per MS/s per hour. Compare to the cost of
+                    attacking Bitcoin.
+                </p>
+            </div>
+
+            <div class="exercise">
+                <p class="exercise-title">Exercise 27.2</p>
+                <p>
+                    Design a replay protection mechanism that works without changing the
+                    transaction format. What are the tradeoffs of your approach?
+                </p>
+            </div>
+
+            <div class="exercise">
+                <p class="exercise-title">Exercise 27.3</p>
+                <p>
+                    Model the "difficulty death spiral" mathematically. Given a minority
+                    chain starting with 10% hash rate, Bitcoin's 2016-block adjustment
+                    period, and miners who switch chains based on profitability, simulate
+                    the first month of the minority chain. Under what conditions does it
+                    survive?
+                </p>
+            </div>
+
+            <div class="exercise">
+                <p class="exercise-title">Exercise 27.4</p>
+                <p>
+                    Analyze the SegWit2x futures markets. Given that B2X futures traded at
+                    0.15 BTC before cancellation, what did this imply about market
+                    expectations? How do futures markets serve as coordination mechanisms?
+                </p>
+            </div>
+
+            <div class="exercise">
+                <p class="exercise-title">Exercise 27.5</p>
+                <p>
+                    Research the BCH "hash war" of November 2018. Both sides mined at a
+                    significant loss. Model this as a game theory problem: what were the
+                    payoffs, and why did both sides eventually accept coexistence?
+                </p>
+            </div>
+        </section>
+
+        <nav class="chapter-navigation">
+            <a href="26-fork-theory.html" class="prev-chapter">← Chapter 26: Fork Theory</a>
+            <a href="28-segwit-deep-dive.html" class="next-chapter">Chapter 28: SegWit Deep Dive →</a>
+        </nav>
+    </main>
+
+    <footer>
+        <p>Elementary Bitcoin · Volume IV: Forks and Futures (Draft)</p>
+    </footer>
+</body>
+</html>

--- a/chapters/30-covenants.html
+++ b/chapters/30-covenants.html
@@ -1,0 +1,720 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Chapter 30: Covenant Proposals | Elementary Bitcoin</title>
+    <meta name="description" content="Chapter 30: Covenant Proposals - CTV, OP_CAT, OP_VAULT, and programmable spending restrictions">
+    <link rel="stylesheet" href="../style.css">
+</head>
+<body>
+    <nav class="chapter-nav">
+        <a href="../index.html">Contents</a>
+        <span class="nav-separator">·</span>
+        <span class="volume-indicator">Volume IV: Forks and Futures</span>
+    </nav>
+
+    <header class="chapter-header">
+        <p class="chapter-number">Chapter 30</p>
+        <h1>Covenant Proposals</h1>
+        <p class="chapter-subtitle">Programmable Spending Restrictions</p>
+    </header>
+
+    <main class="chapter-content">
+        <section>
+            <p class="chapter-intro">
+                A <em>covenant</em> is a spending condition that restricts not just <em>who</em>
+                can spend, but <em>how</em> the funds can be spent—constraining future transactions.
+                This chapter examines the major covenant proposals under discussion: OP_CHECKTEMPLATEVERIFY
+                (CTV), OP_CAT, OP_VAULT, and others. We analyze their technical mechanisms,
+                use cases, and the tradeoffs that make covenant design contentious.
+            </p>
+        </section>
+
+        <section>
+            <h2>30.1 What Are Covenants?</h2>
+
+            <div class="definition">
+                <p class="definition-title">Definition 30.1 (Covenant)</p>
+                <p>
+                    A <strong>covenant</strong> is a script mechanism that constrains how an
+                    output can be spent beyond simple authorization. Specifically, it can
+                    restrict:
+                </p>
+                <ul>
+                    <li>What outputs the spending transaction must create</li>
+                    <li>What other inputs must be included</li>
+                    <li>Transaction-level properties (locktime, version, etc.)</li>
+                </ul>
+            </div>
+
+            <div class="definition">
+                <p class="definition-title">Definition 30.2 (Introspection)</p>
+                <p>
+                    <strong>Introspection</strong> is the ability of a script to examine
+                    properties of its containing transaction. Covenants require some form
+                    of introspection to constrain spending.
+                </p>
+            </div>
+
+            <figure>
+                <svg class="diagram" width="500" height="200" viewBox="0 0 500 200">
+                    <!-- Traditional Script -->
+                    <rect x="30" y="40" width="180" height="70" rx="4" fill="#e8f4e8" stroke="#5a8f5a" stroke-width="1.5"/>
+                    <text x="120" y="60" text-anchor="middle" font-family="Georgia" font-size="10" font-weight="bold">Traditional Script</text>
+                    <text x="120" y="80" text-anchor="middle" font-family="Georgia" font-size="9">Constrains: WHO can spend</text>
+                    <text x="120" y="95" text-anchor="middle" font-family="Georgia" font-size="8" fill="#666">(signature check)</text>
+
+                    <!-- Covenant Script -->
+                    <rect x="290" y="40" width="180" height="70" rx="4" fill="#fff3cd" stroke="#f39c12" stroke-width="1.5"/>
+                    <text x="380" y="60" text-anchor="middle" font-family="Georgia" font-size="10" font-weight="bold">Covenant Script</text>
+                    <text x="380" y="80" text-anchor="middle" font-family="Georgia" font-size="9">Constrains: WHO + HOW</text>
+                    <text x="380" y="95" text-anchor="middle" font-family="Georgia" font-size="8" fill="#666">(spending conditions)</text>
+
+                    <!-- Examples -->
+                    <text x="120" y="135" text-anchor="middle" font-family="Georgia" font-size="8">"Alice can spend"</text>
+                    <text x="380" y="130" text-anchor="middle" font-family="Georgia" font-size="8">"Alice can spend,</text>
+                    <text x="380" y="142" text-anchor="middle" font-family="Georgia" font-size="8">but only to Bob or Carol"</text>
+
+                    <!-- Arrow -->
+                    <path d="M 210 75 L 290 75" stroke="#666" stroke-width="2" marker-end="url(#arrow30)"/>
+                    <text x="250" y="65" text-anchor="middle" font-family="Georgia" font-size="8">+Covenant</text>
+
+                    <defs>
+                        <marker id="arrow30" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+                            <polygon points="0 0, 8 3, 0 6" fill="#666"/>
+                        </marker>
+                    </defs>
+                </svg>
+                <figcaption>Figure 30.1: Covenants add HOW constraints to the traditional WHO authorization.</figcaption>
+            </figure>
+
+            <div class="remark">
+                <p class="remark-title">Remark 30.1 (Why Bitcoin Lacks Covenants)</p>
+                <p>
+                    Bitcoin Script currently has no introspection opcodes. A script cannot
+                    examine:
+                </p>
+                <ul>
+                    <li>The outputs of the spending transaction</li>
+                    <li>Other inputs being spent</li>
+                    <li>Transaction metadata beyond the current input</li>
+                </ul>
+                <p>
+                    This was a deliberate design choice—simplicity and security over
+                    programmability.
+                </p>
+            </div>
+        </section>
+
+        <section>
+            <h2>30.2 OP_CHECKTEMPLATEVERIFY (CTV)</h2>
+
+            <p>
+                CTV (BIP-119) is the simplest and most conservative covenant proposal.
+            </p>
+
+            <div class="definition">
+                <p class="definition-title">Definition 30.3 (OP_CHECKTEMPLATEVERIFY)</p>
+                <p>
+                    <strong>OP_CTV</strong> takes a 32-byte hash from the stack and verifies
+                    that it matches a commitment to the spending transaction's:
+                </p>
+                <ul>
+                    <li>nVersion</li>
+                    <li>nLockTime</li>
+                    <li>scriptSig hash (if any non-SegWit inputs)</li>
+                    <li>Number of inputs</li>
+                    <li>Sequences hash</li>
+                    <li>Number of outputs</li>
+                    <li>Outputs hash</li>
+                    <li>Input index (which input is being spent)</li>
+                </ul>
+            </div>
+
+            <div class="definition">
+                <p class="definition-title">Definition 30.4 (CTV Template Hash)</p>
+                <p>
+                    The template hash is computed as:
+                </p>
+                <pre style="background: #f5f5f5; padding: 1rem; font-family: monospace; font-size: 0.85rem;">
+DefaultCheckTemplateVerifyHash(tx, input_index):
+    return SHA256(
+        nVersion ||
+        nLockTime ||
+        SHA256(scriptSigs) ||      // if any
+        input_count ||
+        SHA256(sequences) ||
+        output_count ||
+        SHA256(outputs) ||
+        input_index
+    )</pre>
+            </div>
+
+            <figure>
+                <svg class="diagram" width="500" height="220" viewBox="0 0 500 220">
+                    <!-- CTV Output -->
+                    <rect x="30" y="30" width="150" height="60" rx="4" fill="#e8f4e8" stroke="#5a8f5a" stroke-width="1.5"/>
+                    <text x="105" y="50" text-anchor="middle" font-family="Georgia" font-size="9" font-weight="bold">CTV Output</text>
+                    <text x="105" y="70" text-anchor="middle" font-family="monospace" font-size="7">&lt;hash&gt; OP_CTV</text>
+
+                    <!-- Arrow -->
+                    <path d="M 180 60 L 230 60" stroke="#666" stroke-width="1.5" marker-end="url(#arrow30b)"/>
+                    <text x="205" y="50" text-anchor="middle" font-family="Georgia" font-size="8">spend</text>
+
+                    <!-- Spending TX -->
+                    <rect x="230" y="20" width="240" height="150" rx="4" fill="#f5f5f5" stroke="#999"/>
+                    <text x="350" y="40" text-anchor="middle" font-family="Georgia" font-size="10" font-weight="bold">Spending Transaction</text>
+
+                    <!-- TX fields that are committed -->
+                    <rect x="245" y="55" width="100" height="20" fill="#d4edda" stroke="#28a745"/>
+                    <text x="295" y="69" text-anchor="middle" font-family="Georgia" font-size="7">nVersion ✓</text>
+
+                    <rect x="355" y="55" width="100" height="20" fill="#d4edda" stroke="#28a745"/>
+                    <text x="405" y="69" text-anchor="middle" font-family="Georgia" font-size="7">nLockTime ✓</text>
+
+                    <rect x="245" y="80" width="210" height="25" fill="#d4edda" stroke="#28a745"/>
+                    <text x="350" y="97" text-anchor="middle" font-family="Georgia" font-size="8">Outputs (hash committed) ✓</text>
+
+                    <rect x="245" y="110" width="100" height="20" fill="#d4edda" stroke="#28a745"/>
+                    <text x="295" y="124" text-anchor="middle" font-family="Georgia" font-size="7">Input count ✓</text>
+
+                    <rect x="355" y="110" width="100" height="20" fill="#d4edda" stroke="#28a745"/>
+                    <text x="405" y="124" text-anchor="middle" font-family="Georgia" font-size="7">Sequences ✓</text>
+
+                    <rect x="245" y="135" width="100" height="20" fill="#ffe8e8" stroke="#c44"/>
+                    <text x="295" y="149" text-anchor="middle" font-family="Georgia" font-size="7">Inputs (NOT)</text>
+
+                    <!-- Note -->
+                    <text x="250" y="195" font-family="Georgia" font-size="8" fill="#666">CTV constrains outputs but NOT which inputs fund the tx</text>
+                    <text x="250" y="210" font-family="Georgia" font-size="8" fill="#666">→ Enables fee bumping via additional inputs</text>
+
+                    <defs>
+                        <marker id="arrow30b" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+                            <polygon points="0 0, 8 3, 0 6" fill="#666"/>
+                        </marker>
+                    </defs>
+                </svg>
+                <figcaption>Figure 30.2: CTV commits to most transaction fields except which inputs fund it.</figcaption>
+            </figure>
+
+            <h3>30.2.1 CTV Use Cases</h3>
+
+            <div class="example">
+                <p class="example-title">Example 30.1 (Congestion Control / Payment Batching)</p>
+                <p>
+                    An exchange wants to batch withdrawals but fees spike. With CTV:
+                </p>
+                <ol>
+                    <li>Create single output: CTV(hash of batch expansion)</li>
+                    <li>Commit to a tree of future transactions</li>
+                    <li>Users can later expand their branch when fees drop</li>
+                    <li>Exchange's commitment is on-chain immediately</li>
+                </ol>
+            </div>
+
+            <figure>
+                <svg class="diagram" width="500" height="200" viewBox="0 0 500 200">
+                    <!-- Root CTV -->
+                    <rect x="200" y="20" width="100" height="40" rx="4" fill="#28a745" stroke="#1e7b34" stroke-width="2"/>
+                    <text x="250" y="45" text-anchor="middle" font-family="Georgia" font-size="9" fill="white">CTV Root</text>
+
+                    <!-- Level 1 -->
+                    <rect x="100" y="90" width="80" height="35" rx="4" fill="#5a8f5a" stroke="#3a6f3a"/>
+                    <text x="140" y="112" text-anchor="middle" font-family="Georgia" font-size="8" fill="white">CTV</text>
+
+                    <rect x="320" y="90" width="80" height="35" rx="4" fill="#5a8f5a" stroke="#3a6f3a"/>
+                    <text x="360" y="112" text-anchor="middle" font-family="Georgia" font-size="8" fill="white">CTV</text>
+
+                    <!-- Level 2 -->
+                    <rect x="30" y="150" width="60" height="30" rx="4" fill="#e8f4e8" stroke="#5a8f5a"/>
+                    <text x="60" y="169" text-anchor="middle" font-family="Georgia" font-size="7">Alice</text>
+
+                    <rect x="110" y="150" width="60" height="30" rx="4" fill="#e8f4e8" stroke="#5a8f5a"/>
+                    <text x="140" y="169" text-anchor="middle" font-family="Georgia" font-size="7">Bob</text>
+
+                    <rect x="250" y="150" width="60" height="30" rx="4" fill="#e8f4e8" stroke="#5a8f5a"/>
+                    <text x="280" y="169" text-anchor="middle" font-family="Georgia" font-size="7">Carol</text>
+
+                    <rect x="330" y="150" width="60" height="30" rx="4" fill="#e8f4e8" stroke="#5a8f5a"/>
+                    <text x="360" y="169" text-anchor="middle" font-family="Georgia" font-size="7">Dave</text>
+
+                    <rect x="410" y="150" width="60" height="30" rx="4" fill="#e8f4e8" stroke="#5a8f5a"/>
+                    <text x="440" y="169" text-anchor="middle" font-family="Georgia" font-size="7">Eve</text>
+
+                    <!-- Connections -->
+                    <line x1="230" y1="60" x2="150" y2="90" stroke="#3a6f3a" stroke-width="1.5"/>
+                    <line x1="270" y1="60" x2="350" y2="90" stroke="#3a6f3a" stroke-width="1.5"/>
+
+                    <line x1="125" y1="125" x2="70" y2="150" stroke="#5a8f5a"/>
+                    <line x1="155" y1="125" x2="150" y2="150" stroke="#5a8f5a"/>
+
+                    <line x1="340" y1="125" x2="290" y2="150" stroke="#5a8f5a"/>
+                    <line x1="360" y1="125" x2="360" y2="150" stroke="#5a8f5a"/>
+                    <line x1="380" y1="125" x2="430" y2="150" stroke="#5a8f5a"/>
+                </svg>
+                <figcaption>Figure 30.3: CTV enables tree-structured withdrawal batching.</figcaption>
+            </figure>
+
+            <div class="example">
+                <p class="example-title">Example 30.2 (Simple Vault)</p>
+                <p>
+                    A basic vault with CTV:
+                </p>
+                <pre style="background: #f5f5f5; padding: 1rem; font-family: monospace; font-size: 0.85rem;">
+Vault Script:
+  IF
+    <hot_key> CHECKSIG         // Immediate spend (compromised!)
+  ELSE
+    <ctv_hash> CTV             // Must go to staged withdrawal
+  ENDIF
+
+Staged Withdrawal (CTV-enforced):
+  - Output 1: Time-locked return to vault (clawback)
+  - Output 2: Time-locked to destination (actual withdrawal)</pre>
+            </div>
+
+            <h3>30.2.2 CTV Controversy</h3>
+
+            <div class="remark">
+                <p class="remark-title">Remark 30.2 (CTV Debate)</p>
+                <p>
+                    CTV has been controversial despite its simplicity:
+                </p>
+                <ul>
+                    <li><strong>Proponents:</strong> Minimal, well-analyzed, enables useful patterns</li>
+                    <li><strong>Opponents:</strong> Too limited, may need replacement soon</li>
+                    <li><strong>Concerns:</strong> Could enable new MEV-like extraction</li>
+                    <li><strong>Process:</strong> Activation attempts have stalled multiple times</li>
+                </ul>
+            </div>
+        </section>
+
+        <section>
+            <h2>30.3 OP_CAT</h2>
+
+            <p>
+                OP_CAT (concatenation) was disabled in 2010 but proposals to re-enable it
+                have gained traction.
+            </p>
+
+            <div class="definition">
+                <p class="definition-title">Definition 30.5 (OP_CAT)</p>
+                <p>
+                    <strong>OP_CAT</strong> concatenates two stack elements:
+                </p>
+                <pre style="background: #f5f5f5; padding: 1rem; font-family: monospace; font-size: 0.85rem;">
+Stack before: [x] [y]
+OP_CAT
+Stack after:  [x || y]</pre>
+                <p>
+                    BIP-347 proposes re-enabling CAT in Tapscript with a 520-byte limit.
+                </p>
+            </div>
+
+            <div class="theorem">
+                <p class="theorem-title">Theorem 30.1 (CAT Enables Covenants)</p>
+                <p>
+                    OP_CAT combined with Schnorr signatures enables introspection through
+                    signature reconstruction:
+                </p>
+                <ol>
+                    <li>Schnorr signature: (R, s) where s = k + H(R||P||m)·d</li>
+                    <li>Script reconstructs m (the sighash) using CAT</li>
+                    <li>Script verifies the signature against reconstructed message</li>
+                    <li>If valid, script has verified properties of m (the transaction)</li>
+                </ol>
+            </div>
+
+            <div class="example">
+                <p class="example-title">Example 30.3 (CAT-based Vault)</p>
+                <p>
+                    Using CAT to verify transaction outputs:
+                </p>
+                <pre style="background: #f5f5f5; padding: 1rem; font-family: monospace; font-size: 0.85rem;">
+// Conceptual (simplified)
+<expected_output_script>
+<actual_output_from_witness>
+OP_EQUAL                        // Verify output matches
+OP_VERIFY
+
+// Then verify the sighash includes this output
+<sig_components...>
+OP_CAT OP_CAT ...               // Reconstruct sighash
+<signature>
+<pubkey>
+OP_CHECKSIG</pre>
+            </div>
+
+            <div class="remark">
+                <p class="remark-title">Remark 30.3 (CAT Power and Concerns)</p>
+                <p>
+                    OP_CAT is surprisingly powerful:
+                </p>
+                <ul>
+                    <li><strong>Enables:</strong> Covenants, validity proofs, Lamport signatures</li>
+                    <li><strong>Recursive covenants:</strong> Potentially possible with CAT</li>
+                    <li><strong>Script complexity:</strong> CAT-based covenants are complex</li>
+                    <li><strong>Audit difficulty:</strong> Harder to reason about than CTV</li>
+                </ul>
+            </div>
+        </section>
+
+        <section>
+            <h2>30.4 OP_VAULT (BIP-345)</h2>
+
+            <p>
+                OP_VAULT is a purpose-built opcode specifically for secure custody.
+            </p>
+
+            <div class="definition">
+                <p class="definition-title">Definition 30.6 (OP_VAULT)</p>
+                <p>
+                    <strong>OP_VAULT</strong> (BIP-345) creates a two-stage withdrawal process:
+                </p>
+                <ul>
+                    <li><strong>Trigger:</strong> Initiates withdrawal, starts timelock</li>
+                    <li><strong>Recovery:</strong> Can cancel during timelock period</li>
+                    <li><strong>Complete:</strong> After timelock, funds go to destination</li>
+                </ul>
+            </div>
+
+            <figure>
+                <svg class="diagram" width="500" height="220" viewBox="0 0 500 220">
+                    <!-- Vault UTXO -->
+                    <rect x="30" y="80" width="80" height="50" rx="4" fill="#28a745" stroke="#1e7b34" stroke-width="2"/>
+                    <text x="70" y="100" text-anchor="middle" font-family="Georgia" font-size="9" fill="white">Vault</text>
+                    <text x="70" y="115" text-anchor="middle" font-family="Georgia" font-size="8" fill="white">UTXO</text>
+
+                    <!-- Trigger path -->
+                    <path d="M 110 95 L 160 60" stroke="#f39c12" stroke-width="2" marker-end="url(#arrowOrange30)"/>
+                    <text x="135" y="65" font-family="Georgia" font-size="7" fill="#f39c12">trigger</text>
+
+                    <!-- Triggered state -->
+                    <rect x="160" y="35" width="100" height="50" rx="4" fill="#fff3cd" stroke="#f39c12" stroke-width="1.5"/>
+                    <text x="210" y="55" text-anchor="middle" font-family="Georgia" font-size="8">Triggered</text>
+                    <text x="210" y="70" text-anchor="middle" font-family="Georgia" font-size="7" fill="#666">timelock: 24h</text>
+
+                    <!-- Recovery path -->
+                    <path d="M 185 85 L 160 120" stroke="#c44" stroke-width="2" marker-end="url(#arrowRed30)"/>
+                    <text x="145" y="110" font-family="Georgia" font-size="7" fill="#c44">recover</text>
+
+                    <!-- Back to vault -->
+                    <rect x="130" y="130" width="80" height="40" rx="4" fill="#28a745" stroke="#1e7b34"/>
+                    <text x="170" y="155" text-anchor="middle" font-family="Georgia" font-size="8" fill="white">Back to Vault</text>
+
+                    <!-- Complete path -->
+                    <path d="M 260 60 L 320 60" stroke="#5a8f5a" stroke-width="2" marker-end="url(#arrowGreen30)"/>
+                    <text x="290" y="50" font-family="Georgia" font-size="7" fill="#5a8f5a">complete</text>
+
+                    <!-- Final destination -->
+                    <rect x="320" y="35" width="100" height="50" rx="4" fill="#d4edda" stroke="#28a745"/>
+                    <text x="370" y="55" text-anchor="middle" font-family="Georgia" font-size="8">Destination</text>
+                    <text x="370" y="70" text-anchor="middle" font-family="Georgia" font-size="7" fill="#666">(withdrawal)</text>
+
+                    <!-- Direct recovery -->
+                    <path d="M 110 115 L 130 140" stroke="#c44" stroke-width="1.5" marker-end="url(#arrowRed30)"/>
+                    <text x="85" y="135" font-family="Georgia" font-size="7" fill="#c44">emergency</text>
+
+                    <!-- Timeline -->
+                    <line x1="160" y1="190" x2="420" y2="190" stroke="#666" stroke-width="1"/>
+                    <text x="160" y="205" font-family="Georgia" font-size="7">t=0</text>
+                    <text x="290" y="205" font-family="Georgia" font-size="7">timelock</text>
+                    <text x="420" y="205" font-family="Georgia" font-size="7">complete</text>
+
+                    <defs>
+                        <marker id="arrowOrange30" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+                            <polygon points="0 0, 8 3, 0 6" fill="#f39c12"/>
+                        </marker>
+                        <marker id="arrowRed30" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+                            <polygon points="0 0, 8 3, 0 6" fill="#c44"/>
+                        </marker>
+                        <marker id="arrowGreen30" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+                            <polygon points="0 0, 8 3, 0 6" fill="#5a8f5a"/>
+                        </marker>
+                    </defs>
+                </svg>
+                <figcaption>Figure 30.4: OP_VAULT lifecycle with trigger, recovery, and completion paths.</figcaption>
+            </figure>
+
+            <div class="definition">
+                <p class="definition-title">Definition 30.7 (OP_VAULT Opcodes)</p>
+                <p>
+                    BIP-345 introduces two new opcodes:
+                </p>
+                <ul>
+                    <li><strong>OP_VAULT:</strong> Creates vault with recovery and trigger paths</li>
+                    <li><strong>OP_VAULT_RECOVER:</strong> Specialized for recovery spending</li>
+                </ul>
+            </div>
+
+            <div class="theorem">
+                <p class="theorem-title">Theorem 30.2 (Vault Security Properties)</p>
+                <p>
+                    OP_VAULT provides security guarantees:
+                </p>
+                <ol>
+                    <li><strong>Theft prevention:</strong> Attacker with trigger key cannot steal immediately</li>
+                    <li><strong>Recovery window:</strong> Owner has timelock period to react</li>
+                    <li><strong>Emergency recovery:</strong> Recovery key bypasses normal flow</li>
+                    <li><strong>No key rotation:</strong> Recovery works even if trigger key compromised</li>
+                </ol>
+            </div>
+        </section>
+
+        <section>
+            <h2>30.5 Other Covenant Proposals</h2>
+
+            <h3>30.5.1 SIGHASH_ANYPREVOUT (BIP-118)</h3>
+
+            <div class="definition">
+                <p class="definition-title">Definition 30.8 (ANYPREVOUT)</p>
+                <p>
+                    <strong>SIGHASH_ANYPREVOUT</strong> creates signatures that don't commit
+                    to specific inputs:
+                </p>
+                <ul>
+                    <li>Signature valid for any UTXO with matching script</li>
+                    <li>Enables "floating" transactions</li>
+                    <li>Primary use: LN-Symmetry (Eltoo) protocol</li>
+                </ul>
+            </div>
+
+            <h3>30.5.2 OP_TXHASH / OP_CHECKTXHASHVERIFY</h3>
+
+            <div class="definition">
+                <p class="definition-title">Definition 30.9 (TXHASH)</p>
+                <p>
+                    <strong>OP_TXHASH</strong> provides flexible transaction introspection:
+                </p>
+                <ul>
+                    <li>Field selector specifies which parts to hash</li>
+                    <li>More flexible than CTV's fixed commitment</li>
+                    <li>Can commit to outputs only, inputs only, or various combinations</li>
+                </ul>
+            </div>
+
+            <h3>30.5.3 OP_CHECKSIGFROMSTACK</h3>
+
+            <div class="definition">
+                <p class="definition-title">Definition 30.10 (CSFS)</p>
+                <p>
+                    <strong>OP_CHECKSIGFROMSTACK</strong> verifies a signature against arbitrary
+                    data (not the transaction sighash):
+                </p>
+                <pre style="background: #f5f5f5; padding: 1rem; font-family: monospace; font-size: 0.85rem;">
+Stack: [signature] [message] [pubkey]
+OP_CHECKSIGFROMSTACK
+Stack: [1 if valid]</pre>
+                <p>
+                    Enables oracles, delegation, and complex covenant constructions.
+                </p>
+            </div>
+
+            <h3>30.5.4 Comparison Table</h3>
+
+            <table class="data-table">
+                <thead>
+                    <tr>
+                        <th>Proposal</th>
+                        <th>Complexity</th>
+                        <th>Power</th>
+                        <th>Status</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>CTV (BIP-119)</td>
+                        <td>Low</td>
+                        <td>Limited covenants</td>
+                        <td>Proposed, stalled</td>
+                    </tr>
+                    <tr>
+                        <td>CAT (BIP-347)</td>
+                        <td>Low opcode, high usage</td>
+                        <td>General covenants</td>
+                        <td>Proposed</td>
+                    </tr>
+                    <tr>
+                        <td>VAULT (BIP-345)</td>
+                        <td>Medium</td>
+                        <td>Custody-specific</td>
+                        <td>Proposed</td>
+                    </tr>
+                    <tr>
+                        <td>APO (BIP-118)</td>
+                        <td>Low</td>
+                        <td>LN-Symmetry</td>
+                        <td>Proposed</td>
+                    </tr>
+                    <tr>
+                        <td>TXHASH</td>
+                        <td>Medium</td>
+                        <td>Flexible covenants</td>
+                        <td>Draft</td>
+                    </tr>
+                    <tr>
+                        <td>CSFS</td>
+                        <td>Low</td>
+                        <td>Oracles, delegation</td>
+                        <td>Discussion</td>
+                    </tr>
+                </tbody>
+            </table>
+        </section>
+
+        <section>
+            <h2>30.6 Recursive Covenants and Concerns</h2>
+
+            <div class="definition">
+                <p class="definition-title">Definition 30.11 (Recursive Covenant)</p>
+                <p>
+                    A <strong>recursive covenant</strong> can enforce that outputs must
+                    themselves be encumbered by the same (or similar) covenant:
+                </p>
+                <p style="text-align: center; font-family: 'Times New Roman', serif;">
+                    spend(covenant) → outputs must have covenant
+                </p>
+                <p>
+                    This creates perpetual spending restrictions.
+                </p>
+            </div>
+
+            <div class="theorem">
+                <p class="theorem-title">Theorem 30.3 (Recursive Covenant Implications)</p>
+                <p>
+                    Recursive covenants enable:
+                </p>
+                <ul>
+                    <li><strong>Positive:</strong> Perpetual vaults, on-chain governance, colored coins</li>
+                    <li><strong>Concerning:</strong> "Tainted" coins, censorship infrastructure</li>
+                </ul>
+            </div>
+
+            <div class="remark">
+                <p class="remark-title">Remark 30.4 (The Fungibility Debate)</p>
+                <p>
+                    A key concern about recursive covenants:
+                </p>
+                <ul>
+                    <li>Could governments mandate covenants on regulated coins?</li>
+                    <li>Would "covenant-free" coins trade at premium?</li>
+                    <li>Does this threaten Bitcoin's fungibility?</li>
+                </ul>
+                <p>
+                    Counter-arguments:
+                </p>
+                <ul>
+                    <li>Coerced covenant adoption already possible via regulation</li>
+                    <li>Covenants are opt-in; users choose to use them</li>
+                    <li>Benefits (vaults, scaling) may outweigh risks</li>
+                </ul>
+            </div>
+        </section>
+
+        <section>
+            <h2>30.7 Covenant Applications</h2>
+
+            <div class="example">
+                <p class="example-title">Example 30.4 (Summary of Applications)</p>
+                <table class="data-table">
+                    <thead>
+                        <tr>
+                            <th>Application</th>
+                            <th>Minimum Requirement</th>
+                            <th>Benefit</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>Vaults</td>
+                            <td>CTV or VAULT</td>
+                            <td>Custody security</td>
+                        </tr>
+                        <tr>
+                            <td>Congestion control</td>
+                            <td>CTV</td>
+                            <td>Fee smoothing</td>
+                        </tr>
+                        <tr>
+                            <td>Channel factories</td>
+                            <td>CTV + APO</td>
+                            <td>LN scaling</td>
+                        </tr>
+                        <tr>
+                            <td>LN-Symmetry</td>
+                            <td>APO</td>
+                            <td>Simpler channels</td>
+                        </tr>
+                        <tr>
+                            <td>DLCs</td>
+                            <td>CTV or CSFS</td>
+                            <td>Efficient oracles</td>
+                        </tr>
+                        <tr>
+                            <td>Validity rollups</td>
+                            <td>CAT + more</td>
+                            <td>L2 scaling</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </section>
+
+        <section class="exercises">
+            <h2>Exercises</h2>
+
+            <div class="exercise">
+                <p class="exercise-title">Exercise 30.1</p>
+                <p>
+                    Design a CTV-based "dead man's switch" that automatically sends funds
+                    to heirs if not renewed annually. What are the limitations?
+                </p>
+            </div>
+
+            <div class="exercise">
+                <p class="exercise-title">Exercise 30.2</p>
+                <p>
+                    Explain how OP_CAT + CHECKSIG can verify that a spending transaction
+                    has specific outputs. What stack manipulations are required?
+                </p>
+            </div>
+
+            <div class="exercise">
+                <p class="exercise-title">Exercise 30.3</p>
+                <p>
+                    Compare the on-chain footprint of a 3-of-5 multisig vault using:
+                    (a) Current Taproot/MuSig, (b) OP_VAULT, (c) CTV-based vault.
+                </p>
+            </div>
+
+            <div class="exercise">
+                <p class="exercise-title">Exercise 30.4</p>
+                <p>
+                    Analyze the fungibility implications of recursive covenants. Could a
+                    government effectively "mark" Bitcoin with spending restrictions?
+                    What would users do in response?
+                </p>
+            </div>
+
+            <div class="exercise">
+                <p class="exercise-title">Exercise 30.5</p>
+                <p>
+                    SIGHASH_ANYPREVOUT enables "floating" transactions. Design an attack
+                    scenario where this could be dangerous, and explain how the proposed
+                    restrictions in BIP-118 mitigate it.
+                </p>
+            </div>
+        </section>
+
+        <nav class="chapter-navigation">
+            <a href="29-taproot-architecture.html" class="prev-chapter">← Chapter 29: Taproot Architecture</a>
+            <a href="31-sidechains.html" class="next-chapter">Chapter 31: Sidechains →</a>
+        </nav>
+    </main>
+
+    <footer>
+        <p>Elementary Bitcoin · Volume IV: Forks and Futures (Draft)</p>
+    </footer>
+</body>
+</html>

--- a/chapters/31-sidechains.html
+++ b/chapters/31-sidechains.html
@@ -1,0 +1,466 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Chapter 31: Sidechains | Elementary Bitcoin</title>
+    <meta name="description" content="Chapter 31: Sidechains - Federated pegs, Liquid Network, RSK, and two-way peg mechanisms">
+    <link rel="stylesheet" href="../style.css">
+</head>
+<body>
+    <nav class="chapter-nav">
+        <a href="../index.html">Contents</a>
+        <span class="nav-separator">·</span>
+        <span class="volume-indicator">Volume IV: Forks and Futures</span>
+    </nav>
+
+    <header class="chapter-header">
+        <p class="chapter-number">Chapter 31</p>
+        <h1>Sidechains</h1>
+        <p class="chapter-subtitle">Federated and Trust-Minimized Alternatives</p>
+    </header>
+
+    <main class="chapter-content">
+        <section>
+            <p class="chapter-intro">
+                A sidechain is a separate blockchain that allows Bitcoin to be "moved" between
+                chains via a two-way peg. This chapter examines the theoretical foundations of
+                sidechains, the trust models of different implementations (Liquid, RSK, Stacks),
+                and the fundamental tradeoffs between security, functionality, and decentralization.
+            </p>
+        </section>
+
+        <section>
+            <h2>31.1 Two-Way Peg Fundamentals</h2>
+
+            <div class="definition">
+                <p class="definition-title">Definition 31.1 (Sidechain)</p>
+                <p>
+                    A <strong>sidechain</strong> is a blockchain that:
+                </p>
+                <ul>
+                    <li>Has its own consensus mechanism</li>
+                    <li>Can receive and release Bitcoin via a two-way peg</li>
+                    <li>Operates independently of Bitcoin's main chain</li>
+                </ul>
+            </div>
+
+            <div class="definition">
+                <p class="definition-title">Definition 31.2 (Two-Way Peg)</p>
+                <p>
+                    A <strong>two-way peg</strong> mechanism allows:
+                </p>
+                <ul>
+                    <li><strong>Peg-in:</strong> Lock BTC on mainchain → mint equivalent on sidechain</li>
+                    <li><strong>Peg-out:</strong> Burn on sidechain → unlock BTC on mainchain</li>
+                </ul>
+                <p>
+                    The peg maintains a 1:1 relationship: total sidechain tokens ≤ locked BTC.
+                </p>
+            </div>
+
+            <figure>
+                <svg class="diagram" width="500" height="200" viewBox="0 0 500 200">
+                    <!-- Bitcoin mainchain -->
+                    <rect x="30" y="30" width="180" height="60" rx="4" fill="#f39c12" stroke="#c87f0a" stroke-width="2"/>
+                    <text x="120" y="55" text-anchor="middle" font-family="Georgia" font-size="11" fill="white" font-weight="bold">Bitcoin Mainchain</text>
+                    <text x="120" y="75" text-anchor="middle" font-family="Georgia" font-size="9" fill="white">BTC locked in peg address</text>
+
+                    <!-- Sidechain -->
+                    <rect x="290" y="30" width="180" height="60" rx="4" fill="#3498db" stroke="#2980b9" stroke-width="2"/>
+                    <text x="380" y="55" text-anchor="middle" font-family="Georgia" font-size="11" fill="white" font-weight="bold">Sidechain</text>
+                    <text x="380" y="75" text-anchor="middle" font-family="Georgia" font-size="9" fill="white">sBTC (pegged tokens)</text>
+
+                    <!-- Peg-in arrow -->
+                    <path d="M 210 45 L 290 45" stroke="#28a745" stroke-width="2" marker-end="url(#arrowGreen31)"/>
+                    <text x="250" y="35" text-anchor="middle" font-family="Georgia" font-size="8" fill="#28a745">Peg-in</text>
+
+                    <!-- Peg-out arrow -->
+                    <path d="M 290 75 L 210 75" stroke="#c44" stroke-width="2" marker-end="url(#arrowRed31)"/>
+                    <text x="250" y="90" text-anchor="middle" font-family="Georgia" font-size="8" fill="#c44">Peg-out</text>
+
+                    <!-- Trust model -->
+                    <rect x="150" y="120" width="200" height="60" rx="4" fill="#f5f5f5" stroke="#999"/>
+                    <text x="250" y="140" text-anchor="middle" font-family="Georgia" font-size="9" font-weight="bold">Trust Model</text>
+                    <text x="250" y="160" text-anchor="middle" font-family="Georgia" font-size="8">Who controls the locked BTC?</text>
+                    <text x="250" y="175" text-anchor="middle" font-family="Georgia" font-size="8" fill="#666">(Federation, SPV, Miners, ...)</text>
+
+                    <defs>
+                        <marker id="arrowGreen31" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+                            <polygon points="0 0, 8 3, 0 6" fill="#28a745"/>
+                        </marker>
+                        <marker id="arrowRed31" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+                            <polygon points="0 0, 8 3, 0 6" fill="#c44"/>
+                        </marker>
+                    </defs>
+                </svg>
+                <figcaption>Figure 31.1: Two-way peg between Bitcoin mainchain and sidechain.</figcaption>
+            </figure>
+
+            <div class="theorem">
+                <p class="theorem-title">Theorem 31.1 (Peg Security Tradeoff)</p>
+                <p>
+                    Without changes to Bitcoin's consensus rules, a trustless two-way peg is
+                    impossible. Bitcoin cannot verify sidechain state, so peg-outs require
+                    either:
+                </p>
+                <ul>
+                    <li>Trusted custodians (federation)</li>
+                    <li>Bitcoin consensus changes (SPV proofs, validity proofs)</li>
+                    <li>Economic incentives (collateral, fraud proofs)</li>
+                </ul>
+            </div>
+        </section>
+
+        <section>
+            <h2>31.2 Federated Sidechains</h2>
+
+            <p>
+                The most practical current approach: trust a federation to manage the peg.
+            </p>
+
+            <div class="definition">
+                <p class="definition-title">Definition 31.3 (Federated Peg)</p>
+                <p>
+                    A <strong>federated peg</strong> uses a multisig controlled by known
+                    entities (the federation):
+                </p>
+                <ul>
+                    <li>Peg-in: Send BTC to federation multisig</li>
+                    <li>Sidechain validates, mints pegged tokens</li>
+                    <li>Peg-out: Federation signs BTC release after sidechain burn</li>
+                </ul>
+            </div>
+
+            <div class="definition">
+                <p class="definition-title">Definition 31.4 (Federation Security Model)</p>
+                <p>
+                    For an m-of-n federation:
+                </p>
+                <ul>
+                    <li><strong>Liveness:</strong> Requires m members to process peg-outs</li>
+                    <li><strong>Safety:</strong> Requires n-m+1 honest members to prevent theft</li>
+                    <li><strong>Attack cost:</strong> Must corrupt m members to steal funds</li>
+                </ul>
+            </div>
+
+            <h3>31.2.1 Liquid Network</h3>
+
+            <div class="definition">
+                <p class="definition-title">Definition 31.5 (Liquid)</p>
+                <p>
+                    <strong>Liquid</strong> (by Blockstream) is a federated sidechain:
+                </p>
+                <ul>
+                    <li><strong>Federation:</strong> ~15 members (exchanges, financial institutions)</li>
+                    <li><strong>Peg:</strong> 11-of-15 multisig</li>
+                    <li><strong>Consensus:</strong> Federated (1-minute blocks)</li>
+                    <li><strong>Features:</strong> Confidential Transactions, Issued Assets</li>
+                </ul>
+            </div>
+
+            <div class="example">
+                <p class="example-title">Example 31.1 (Liquid Peg-in Process)</p>
+                <ol>
+                    <li>User sends BTC to federation multisig address</li>
+                    <li>Wait for 102 Bitcoin confirmations</li>
+                    <li>Federation validates and signs L-BTC mint</li>
+                    <li>User receives L-BTC on Liquid network</li>
+                </ol>
+                <p>
+                    Peg-out reverses this with ~2 Bitcoin block wait time.
+                </p>
+            </div>
+
+            <div class="remark">
+                <p class="remark-title">Remark 31.1 (Liquid Tradeoffs)</p>
+                <table class="data-table">
+                    <thead>
+                        <tr>
+                            <th>Advantage</th>
+                            <th>Disadvantage</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>1-minute finality</td>
+                            <td>Federated trust model</td>
+                        </tr>
+                        <tr>
+                            <td>Confidential Transactions</td>
+                            <td>Regulatory exposure of federation</td>
+                        </tr>
+                        <tr>
+                            <td>Asset issuance</td>
+                            <td>Limited decentralization</td>
+                        </tr>
+                        <tr>
+                            <td>Production-tested</td>
+                            <td>~$100M+ AUM risk concentration</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+
+            <h3>31.2.2 RSK (Rootstock)</h3>
+
+            <div class="definition">
+                <p class="definition-title">Definition 31.6 (RSK)</p>
+                <p>
+                    <strong>RSK</strong> is an EVM-compatible sidechain:
+                </p>
+                <ul>
+                    <li><strong>Consensus:</strong> Merge-mined with Bitcoin</li>
+                    <li><strong>Peg:</strong> Federated (PowPeg) with HSM enforcement</li>
+                    <li><strong>Features:</strong> Smart contracts (Solidity)</li>
+                    <li><strong>Token:</strong> RBTC (Smart Bitcoin)</li>
+                </ul>
+            </div>
+
+            <div class="definition">
+                <p class="definition-title">Definition 31.7 (Merge Mining)</p>
+                <p>
+                    <strong>Merge mining</strong> allows miners to mine both Bitcoin and a
+                    sidechain simultaneously by including the sidechain block hash in Bitcoin's
+                    coinbase. The sidechain accepts Bitcoin PoW as valid.
+                </p>
+            </div>
+        </section>
+
+        <section>
+            <h2>31.3 SPV Sidechains (Theoretical)</h2>
+
+            <p>
+                The original sidechain proposal (Blockstream, 2014) envisioned SPV proofs.
+            </p>
+
+            <div class="definition">
+                <p class="definition-title">Definition 31.8 (SPV Peg)</p>
+                <p>
+                    An <strong>SPV sidechain</strong> would verify peg-outs using SPV proofs:
+                </p>
+                <ol>
+                    <li>Sidechain transaction burns pegged tokens</li>
+                    <li>User creates SPV proof of burn (sidechain headers + Merkle path)</li>
+                    <li>Bitcoin script verifies SPV proof</li>
+                    <li>BTC released from peg address</li>
+                </ol>
+            </div>
+
+            <div class="theorem">
+                <p class="theorem-title">Theorem 31.2 (SPV Peg Limitations)</p>
+                <p>
+                    SPV pegs face fundamental challenges:
+                </p>
+                <ul>
+                    <li><strong>Script limitations:</strong> Bitcoin Script cannot verify SPV proofs</li>
+                    <li><strong>Soft fork required:</strong> New opcode needed (never activated)</li>
+                    <li><strong>Security weakness:</strong> Sidechain 51% attack could steal peg funds</li>
+                </ul>
+            </div>
+        </section>
+
+        <section>
+            <h2>31.4 Validity Rollups and ZK Sidechains</h2>
+
+            <p>
+                Emerging designs use validity proofs for trust-minimized pegs.
+            </p>
+
+            <div class="definition">
+                <p class="definition-title">Definition 31.9 (Validity Rollup)</p>
+                <p>
+                    A <strong>validity rollup</strong> posts compressed state updates to Bitcoin
+                    with a cryptographic proof (typically ZK-SNARK/STARK) that the state
+                    transition is valid.
+                </p>
+            </div>
+
+            <div class="definition">
+                <p class="definition-title">Definition 31.10 (ZK Bridge)</p>
+                <p>
+                    A <strong>ZK bridge</strong> uses validity proofs for peg verification:
+                </p>
+                <ol>
+                    <li>Sidechain generates ZK proof of valid peg-out</li>
+                    <li>Bitcoin verifies proof (requires new opcodes)</li>
+                    <li>No federation needed—proof is self-validating</li>
+                </ol>
+            </div>
+
+            <div class="remark">
+                <p class="remark-title">Remark 31.2 (Bitcoin ZK Requirements)</p>
+                <p>
+                    For Bitcoin to verify ZK proofs natively:
+                </p>
+                <ul>
+                    <li>Need OP_CAT (for proof construction)</li>
+                    <li>Potentially need OP_VERIFYSTARKPROOF or similar</li>
+                    <li>Active research area (BitVM, etc.)</li>
+                </ul>
+            </div>
+        </section>
+
+        <section>
+            <h2>31.5 Stacks and Proof of Transfer</h2>
+
+            <div class="definition">
+                <p class="definition-title">Definition 31.11 (Stacks / PoX)</p>
+                <p>
+                    <strong>Stacks</strong> uses Proof of Transfer (PoX):
+                </p>
+                <ul>
+                    <li>Miners commit BTC to participate in Stacks consensus</li>
+                    <li>BTC goes to STX stakers (recycled security)</li>
+                    <li>Stacks blocks anchor to Bitcoin blocks</li>
+                    <li>Not a traditional sidechain—no direct BTC peg until sBTC</li>
+                </ul>
+            </div>
+
+            <div class="definition">
+                <p class="definition-title">Definition 31.12 (sBTC)</p>
+                <p>
+                    <strong>sBTC</strong> (2024) adds a Bitcoin peg to Stacks:
+                </p>
+                <ul>
+                    <li>Threshold signature scheme for peg custody</li>
+                    <li>Decentralized signer set (STX stakers)</li>
+                    <li>Economic penalties for misbehavior</li>
+                </ul>
+            </div>
+        </section>
+
+        <section>
+            <h2>31.6 Comparison of Approaches</h2>
+
+            <table class="data-table">
+                <thead>
+                    <tr>
+                        <th>Sidechain</th>
+                        <th>Peg Type</th>
+                        <th>Trust Model</th>
+                        <th>Features</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>Liquid</td>
+                        <td>Federated 11/15</td>
+                        <td>Trust federation</td>
+                        <td>CT, Assets, Fast</td>
+                    </tr>
+                    <tr>
+                        <td>RSK</td>
+                        <td>Federated + MM</td>
+                        <td>Trust federation + miners</td>
+                        <td>EVM, Smart contracts</td>
+                    </tr>
+                    <tr>
+                        <td>Stacks</td>
+                        <td>PoX + sBTC</td>
+                        <td>Economic + threshold sig</td>
+                        <td>Smart contracts</td>
+                    </tr>
+                    <tr>
+                        <td>ZK Rollup</td>
+                        <td>Validity proof</td>
+                        <td>Cryptographic (future)</td>
+                        <td>Any (theoretical)</td>
+                    </tr>
+                </tbody>
+            </table>
+
+            <div class="theorem">
+                <p class="theorem-title">Theorem 31.3 (Sidechain Security Hierarchy)</p>
+                <p>
+                    Trust assumptions from strongest to weakest:
+                </p>
+                <ol>
+                    <li><strong>Bitcoin mainchain:</strong> Full consensus security</li>
+                    <li><strong>Validity rollup:</strong> Cryptographic proofs (if implemented)</li>
+                    <li><strong>Optimistic rollup:</strong> Fraud proofs + challenge period</li>
+                    <li><strong>Large federation:</strong> m-of-n trust (e.g., 11-of-15)</li>
+                    <li><strong>Small federation:</strong> Few trusted parties</li>
+                    <li><strong>Single custodian:</strong> Full trust in one entity</li>
+                </ol>
+            </div>
+        </section>
+
+        <section>
+            <h2>31.7 Sidechain Economics</h2>
+
+            <div class="theorem">
+                <p class="theorem-title">Theorem 31.4 (Sidechain Fee Market)</p>
+                <p>
+                    Sidechains create parallel fee markets:
+                </p>
+                <ul>
+                    <li>Low-value transactions move to cheaper sidechain</li>
+                    <li>High-value transactions stay on mainchain</li>
+                    <li>Peg operations incur mainchain fees</li>
+                    <li>Net effect on mainchain fees: debated</li>
+                </ul>
+            </div>
+
+            <div class="remark">
+                <p class="remark-title">Remark 31.3 (Sidechain Value Proposition)</p>
+                <p>
+                    Sidechains are useful when:
+                </p>
+                <ul>
+                    <li>Users need features Bitcoin doesn't have (privacy, smart contracts)</li>
+                    <li>Users accept the trust tradeoff for benefits</li>
+                    <li>Transaction volume justifies peg-in/out costs</li>
+                </ul>
+            </div>
+        </section>
+
+        <section class="exercises">
+            <h2>Exercises</h2>
+
+            <div class="exercise">
+                <p class="exercise-title">Exercise 31.1</p>
+                <p>
+                    Calculate the security threshold for an 11-of-15 federation. How many
+                    members must collude to steal funds? How many must be offline to halt
+                    peg-outs?
+                </p>
+            </div>
+
+            <div class="exercise">
+                <p class="exercise-title">Exercise 31.2</p>
+                <p>
+                    Design a game-theoretic peg mechanism using collateral. How much
+                    collateral should custodians post? What happens if BTC price changes?
+                </p>
+            </div>
+
+            <div class="exercise">
+                <p class="exercise-title">Exercise 31.3</p>
+                <p>
+                    Analyze the attack cost for a merge-mined sidechain. If the sidechain
+                    has 30% of Bitcoin's hashrate participating in merge mining, what's
+                    the cost of a 51% attack on the sidechain?
+                </p>
+            </div>
+
+            <div class="exercise">
+                <p class="exercise-title">Exercise 31.4</p>
+                <p>
+                    Research BitVM. How does it enable validity proofs on Bitcoin without
+                    new opcodes? What are its limitations?
+                </p>
+            </div>
+        </section>
+
+        <nav class="chapter-navigation">
+            <a href="30-covenants.html" class="prev-chapter">← Chapter 30: Covenant Proposals</a>
+            <a href="32-beyond-lightning.html" class="next-chapter">Chapter 32: Beyond Lightning →</a>
+        </nav>
+    </main>
+
+    <footer>
+        <p>Elementary Bitcoin · Volume IV: Forks and Futures (Draft)</p>
+    </footer>
+</body>
+</html>

--- a/chapters/32-beyond-lightning.html
+++ b/chapters/32-beyond-lightning.html
@@ -1,0 +1,504 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Chapter 32: Beyond Lightning | Elementary Bitcoin</title>
+    <meta name="description" content="Chapter 32: Beyond Lightning - Ark, Statechains, Channel Factories, and next-generation Layer 2">
+    <link rel="stylesheet" href="../style.css">
+</head>
+<body>
+    <nav class="chapter-nav">
+        <a href="../index.html">Contents</a>
+        <span class="nav-separator">·</span>
+        <span class="volume-indicator">Volume IV: Forks and Futures</span>
+    </nav>
+
+    <header class="chapter-header">
+        <p class="chapter-number">Chapter 32</p>
+        <h1>Beyond Lightning</h1>
+        <p class="chapter-subtitle">Next-Generation Layer 2 Protocols</p>
+    </header>
+
+    <main class="chapter-content">
+        <section>
+            <p class="chapter-intro">
+                Lightning Network solved the payment channel problem, but its complexity and
+                liquidity requirements have spurred research into alternative Layer 2 designs.
+                This chapter examines emerging protocols—Ark, Statechains, Channel Factories,
+                and others—that offer different tradeoffs in interactivity, liquidity, and
+                on-chain footprint.
+            </p>
+        </section>
+
+        <section>
+            <h2>32.1 Lightning's Limitations</h2>
+
+            <p>
+                Understanding new L2 proposals requires understanding Lightning's constraints.
+            </p>
+
+            <div class="definition">
+                <p class="definition-title">Definition 32.1 (Lightning Limitations)</p>
+                <p>
+                    Lightning Network faces several challenges:
+                </p>
+                <ul>
+                    <li><strong>Inbound liquidity:</strong> Receivers need channel capacity toward them</li>
+                    <li><strong>Online requirement:</strong> Must be online to receive payments</li>
+                    <li><strong>Channel management:</strong> Opening/closing requires on-chain txs</li>
+                    <li><strong>Routing complexity:</strong> Finding paths is non-trivial</li>
+                    <li><strong>Capital efficiency:</strong> Liquidity locked in channels</li>
+                </ul>
+            </div>
+
+            <figure>
+                <svg class="diagram" width="500" height="150" viewBox="0 0 500 150">
+                    <text x="250" y="20" text-anchor="middle" font-family="Georgia" font-size="11" font-weight="bold">L2 Design Space</text>
+
+                    <!-- Axes -->
+                    <line x1="50" y1="120" x2="450" y2="120" stroke="#666" stroke-width="1"/>
+                    <line x1="50" y1="120" x2="50" y2="40" stroke="#666" stroke-width="1"/>
+
+                    <text x="250" y="140" text-anchor="middle" font-family="Georgia" font-size="8">Trust / Interactivity →</text>
+                    <text x="25" y="80" text-anchor="middle" font-family="Georgia" font-size="8" transform="rotate(-90, 25, 80)">Capital Efficiency →</text>
+
+                    <!-- Protocols -->
+                    <circle cx="100" cy="100" r="15" fill="#f39c12" stroke="#c87f0a"/>
+                    <text x="100" y="105" text-anchor="middle" font-family="Georgia" font-size="7" fill="white">LN</text>
+
+                    <circle cx="200" cy="70" r="15" fill="#3498db" stroke="#2980b9"/>
+                    <text x="200" y="75" text-anchor="middle" font-family="Georgia" font-size="7" fill="white">Ark</text>
+
+                    <circle cx="300" cy="90" r="15" fill="#28a745" stroke="#1e7b34"/>
+                    <text x="300" y="95" text-anchor="middle" font-family="Georgia" font-size="7" fill="white">State</text>
+
+                    <circle cx="380" cy="60" r="15" fill="#9b59b6" stroke="#7d3c98"/>
+                    <text x="380" y="65" text-anchor="middle" font-family="Georgia" font-size="7" fill="white">Factory</text>
+                </svg>
+                <figcaption>Figure 32.1: Different L2 protocols make different tradeoffs.</figcaption>
+            </figure>
+        </section>
+
+        <section>
+            <h2>32.2 Ark Protocol</h2>
+
+            <p>
+                Ark is a new L2 design that trades interactivity for simplicity.
+            </p>
+
+            <div class="definition">
+                <p class="definition-title">Definition 32.2 (Ark)</p>
+                <p>
+                    <strong>Ark</strong> is an off-chain payment protocol where:
+                </p>
+                <ul>
+                    <li>An <strong>Ark Service Provider (ASP)</strong> facilitates payments</li>
+                    <li>Users hold <strong>virtual UTXOs (vTXOs)</strong> in shared outputs</li>
+                    <li>Payments happen by exchanging vTXOs</li>
+                    <li>No inbound liquidity needed</li>
+                    <li>Can receive while offline</li>
+                </ul>
+            </div>
+
+            <div class="definition">
+                <p class="definition-title">Definition 32.3 (Ark Round)</p>
+                <p>
+                    Every few seconds, the ASP creates a <strong>round</strong>:
+                </p>
+                <ol>
+                    <li>Collects payment intents from users</li>
+                    <li>Creates new shared UTXO containing all recipients' vTXOs</li>
+                    <li>Creates transaction tree allowing unilateral exit</li>
+                    <li>Publishes round transaction</li>
+                </ol>
+            </div>
+
+            <figure>
+                <svg class="diagram" width="500" height="220" viewBox="0 0 500 220">
+                    <!-- ASP -->
+                    <rect x="200" y="20" width="100" height="40" rx="4" fill="#3498db" stroke="#2980b9" stroke-width="2"/>
+                    <text x="250" y="45" text-anchor="middle" font-family="Georgia" font-size="10" fill="white" font-weight="bold">ASP</text>
+
+                    <!-- Round UTXO -->
+                    <rect x="150" y="90" width="200" height="50" rx="4" fill="#e8f4e8" stroke="#5a8f5a" stroke-width="1.5"/>
+                    <text x="250" y="110" text-anchor="middle" font-family="Georgia" font-size="9" font-weight="bold">Shared UTXO (Round)</text>
+                    <text x="250" y="128" text-anchor="middle" font-family="Georgia" font-size="8" fill="#666">Contains multiple vTXOs</text>
+
+                    <line x1="250" y1="60" x2="250" y2="90" stroke="#3498db" stroke-width="1.5"/>
+
+                    <!-- vTXOs -->
+                    <rect x="50" y="170" width="70" height="35" rx="4" fill="#fff3cd" stroke="#f39c12"/>
+                    <text x="85" y="192" text-anchor="middle" font-family="Georgia" font-size="8">Alice vTXO</text>
+
+                    <rect x="140" y="170" width="70" height="35" rx="4" fill="#fff3cd" stroke="#f39c12"/>
+                    <text x="175" y="192" text-anchor="middle" font-family="Georgia" font-size="8">Bob vTXO</text>
+
+                    <rect x="230" y="170" width="70" height="35" rx="4" fill="#fff3cd" stroke="#f39c12"/>
+                    <text x="265" y="192" text-anchor="middle" font-family="Georgia" font-size="8">Carol vTXO</text>
+
+                    <rect x="320" y="170" width="70" height="35" rx="4" fill="#fff3cd" stroke="#f39c12"/>
+                    <text x="355" y="192" text-anchor="middle" font-family="Georgia" font-size="8">Dave vTXO</text>
+
+                    <!-- Connections -->
+                    <line x1="175" y1="140" x2="95" y2="170" stroke="#5a8f5a" stroke-width="1"/>
+                    <line x1="210" y1="140" x2="175" y2="170" stroke="#5a8f5a" stroke-width="1"/>
+                    <line x1="290" y1="140" x2="265" y2="170" stroke="#5a8f5a" stroke-width="1"/>
+                    <line x1="325" y1="140" x2="345" y2="170" stroke="#5a8f5a" stroke-width="1"/>
+
+                    <!-- Exit note -->
+                    <text x="440" y="190" font-family="Georgia" font-size="7" fill="#666">Each can exit</text>
+                    <text x="440" y="202" font-family="Georgia" font-size="7" fill="#666">unilaterally</text>
+                </svg>
+                <figcaption>Figure 32.2: Ark round structure with virtual UTXOs.</figcaption>
+            </figure>
+
+            <div class="theorem">
+                <p class="theorem-title">Theorem 32.1 (Ark Properties)</p>
+                <p>
+                    Ark provides:
+                </p>
+                <ul>
+                    <li><strong>Non-interactive receiving:</strong> Recipient doesn't need to be online</li>
+                    <li><strong>No inbound liquidity:</strong> ASP provides liquidity for everyone</li>
+                    <li><strong>Unilateral exit:</strong> Users can always claim on-chain</li>
+                    <li><strong>Privacy:</strong> Payments within rounds are unlinkable</li>
+                </ul>
+                <p>
+                    Tradeoffs:
+                </p>
+                <ul>
+                    <li><strong>ASP trust:</strong> Must trust ASP for liveness (not safety)</li>
+                    <li><strong>Expiring vTXOs:</strong> Must refresh before timeout</li>
+                    <li><strong>ASP capital:</strong> ASP must lock significant BTC</li>
+                </ul>
+            </div>
+
+            <div class="remark">
+                <p class="remark-title">Remark 32.1 (Ark vs Lightning)</p>
+                <table class="data-table">
+                    <thead>
+                        <tr>
+                            <th>Property</th>
+                            <th>Lightning</th>
+                            <th>Ark</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>Receive offline</td>
+                            <td>No</td>
+                            <td>Yes</td>
+                        </tr>
+                        <tr>
+                            <td>Inbound liquidity</td>
+                            <td>Required</td>
+                            <td>Not needed</td>
+                        </tr>
+                        <tr>
+                            <td>Payment latency</td>
+                            <td>Instant</td>
+                            <td>Round time (~5s)</td>
+                        </tr>
+                        <tr>
+                            <td>Channel management</td>
+                            <td>Complex</td>
+                            <td>None</td>
+                        </tr>
+                        <tr>
+                            <td>Requires covenants</td>
+                            <td>No</td>
+                            <td>Optimal with CTV</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </section>
+
+        <section>
+            <h2>32.3 Statechains</h2>
+
+            <p>
+                Statechains enable off-chain UTXO transfer without channels.
+            </p>
+
+            <div class="definition">
+                <p class="definition-title">Definition 32.4 (Statechain)</p>
+                <p>
+                    A <strong>statechain</strong> transfers UTXO ownership off-chain:
+                </p>
+                <ul>
+                    <li>UTXO is locked to a 2-of-2: user key + statechain entity (SE) key</li>
+                    <li>Transfer: user sends their key share to recipient, SE updates co-signer</li>
+                    <li>SE cannot steal (doesn't know full key) but can censor</li>
+                    <li>Backup transaction allows unilateral on-chain claim</li>
+                </ul>
+            </div>
+
+            <figure>
+                <svg class="diagram" width="500" height="180" viewBox="0 0 500 180">
+                    <!-- UTXO -->
+                    <rect x="30" y="70" width="100" height="50" rx="4" fill="#f39c12" stroke="#c87f0a" stroke-width="2"/>
+                    <text x="80" y="90" text-anchor="middle" font-family="Georgia" font-size="9" fill="white" font-weight="bold">UTXO</text>
+                    <text x="80" y="108" text-anchor="middle" font-family="Georgia" font-size="7" fill="white">2-of-2: Alice + SE</text>
+
+                    <!-- Transfer 1 -->
+                    <path d="M 130 95 L 180 95" stroke="#28a745" stroke-width="2" marker-end="url(#arrowGreen32)"/>
+                    <text x="155" y="85" font-family="Georgia" font-size="7" fill="#28a745">transfer</text>
+
+                    <rect x="180" y="70" width="100" height="50" rx="4" fill="#3498db" stroke="#2980b9" stroke-width="2"/>
+                    <text x="230" y="90" text-anchor="middle" font-family="Georgia" font-size="9" fill="white" font-weight="bold">UTXO</text>
+                    <text x="230" y="108" text-anchor="middle" font-family="Georgia" font-size="7" fill="white">2-of-2: Bob + SE</text>
+
+                    <!-- Transfer 2 -->
+                    <path d="M 280 95 L 330 95" stroke="#28a745" stroke-width="2" marker-end="url(#arrowGreen32)"/>
+                    <text x="305" y="85" font-family="Georgia" font-size="7" fill="#28a745">transfer</text>
+
+                    <rect x="330" y="70" width="100" height="50" rx="4" fill="#9b59b6" stroke="#7d3c98" stroke-width="2"/>
+                    <text x="380" y="90" text-anchor="middle" font-family="Georgia" font-size="9" fill="white" font-weight="bold">UTXO</text>
+                    <text x="380" y="108" text-anchor="middle" font-family="Georgia" font-size="7" fill="white">2-of-2: Carol + SE</text>
+
+                    <!-- Note -->
+                    <text x="250" y="150" text-anchor="middle" font-family="Georgia" font-size="8">Same on-chain UTXO, ownership transferred off-chain</text>
+                    <text x="250" y="165" text-anchor="middle" font-family="Georgia" font-size="8" fill="#666">SE deletes old key shares after each transfer</text>
+
+                    <defs>
+                        <marker id="arrowGreen32" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+                            <polygon points="0 0, 8 3, 0 6" fill="#28a745"/>
+                        </marker>
+                    </defs>
+                </svg>
+                <figcaption>Figure 32.3: Statechain transfers UTXO ownership without on-chain transaction.</figcaption>
+            </figure>
+
+            <div class="definition">
+                <p class="definition-title">Definition 32.5 (Mercury Layer)</p>
+                <p>
+                    <strong>Mercury Layer</strong> is a statechain implementation using:
+                </p>
+                <ul>
+                    <li>Blind signing by the SE (doesn't learn transaction details)</li>
+                    <li>Atomic swaps between statechains</li>
+                    <li>Fixed denominations for privacy</li>
+                </ul>
+            </div>
+
+            <div class="theorem">
+                <p class="theorem-title">Theorem 32.2 (Statechain Trust Model)</p>
+                <p>
+                    Statechain security properties:
+                </p>
+                <ul>
+                    <li><strong>SE cannot steal:</strong> Only has partial key</li>
+                    <li><strong>SE can censor:</strong> Can refuse to co-sign</li>
+                    <li><strong>SE can collude:</strong> With previous owner to double-spend</li>
+                    <li><strong>Backup tx:</strong> Allows on-chain exit if SE disappears</li>
+                </ul>
+            </div>
+        </section>
+
+        <section>
+            <h2>32.4 Channel Factories</h2>
+
+            <p>
+                Channel factories amortize on-chain costs across multiple channels.
+            </p>
+
+            <div class="definition">
+                <p class="definition-title">Definition 32.6 (Channel Factory)</p>
+                <p>
+                    A <strong>channel factory</strong> is a multi-party channel that can create
+                    and modify internal channels without on-chain transactions:
+                </p>
+                <ol>
+                    <li>N parties create a single on-chain funding output</li>
+                    <li>Off-chain, they create internal Lightning channels</li>
+                    <li>Channels can be rebalanced without on-chain txs</li>
+                    <li>Only factory open/close needs on-chain presence</li>
+                </ol>
+            </div>
+
+            <figure>
+                <svg class="diagram" width="500" height="200" viewBox="0 0 500 200">
+                    <!-- Factory funding -->
+                    <rect x="180" y="20" width="140" height="40" rx="4" fill="#28a745" stroke="#1e7b34" stroke-width="2"/>
+                    <text x="250" y="45" text-anchor="middle" font-family="Georgia" font-size="9" fill="white" font-weight="bold">Factory UTXO (on-chain)</text>
+
+                    <!-- Internal channels -->
+                    <rect x="50" y="100" width="400" height="80" rx="4" fill="#f5f5f5" stroke="#999" stroke-dasharray="4,2"/>
+                    <text x="250" y="120" text-anchor="middle" font-family="Georgia" font-size="9">Off-chain Layer</text>
+
+                    <rect x="70" y="135" width="80" height="35" rx="4" fill="#3498db" stroke="#2980b9"/>
+                    <text x="110" y="157" text-anchor="middle" font-family="Georgia" font-size="7" fill="white">A ↔ B</text>
+
+                    <rect x="170" y="135" width="80" height="35" rx="4" fill="#3498db" stroke="#2980b9"/>
+                    <text x="210" y="157" text-anchor="middle" font-family="Georgia" font-size="7" fill="white">B ↔ C</text>
+
+                    <rect x="270" y="135" width="80" height="35" rx="4" fill="#3498db" stroke="#2980b9"/>
+                    <text x="310" y="157" text-anchor="middle" font-family="Georgia" font-size="7" fill="white">C ↔ D</text>
+
+                    <rect x="370" y="135" width="70" height="35" rx="4" fill="#3498db" stroke="#2980b9"/>
+                    <text x="405" y="157" text-anchor="middle" font-family="Georgia" font-size="7" fill="white">A ↔ D</text>
+
+                    <!-- Connection -->
+                    <line x1="250" y1="60" x2="250" y2="100" stroke="#28a745" stroke-width="1.5" stroke-dasharray="4,2"/>
+                </svg>
+                <figcaption>Figure 32.4: Channel factory with multiple internal channels.</figcaption>
+            </figure>
+
+            <div class="theorem">
+                <p class="theorem-title">Theorem 32.3 (Factory Scaling)</p>
+                <p>
+                    For a factory with n participants and m internal channels:
+                </p>
+                <ul>
+                    <li><strong>On-chain cost:</strong> 1 UTXO (amortized over n users)</li>
+                    <li><strong>Channel creation:</strong> O(n) signatures, no on-chain tx</li>
+                    <li><strong>Complexity:</strong> All n must sign for factory updates</li>
+                </ul>
+            </div>
+
+            <div class="remark">
+                <p class="remark-title">Remark 32.2 (Factory Challenges)</p>
+                <p>
+                    Channel factories face practical issues:
+                </p>
+                <ul>
+                    <li><strong>Coordination:</strong> All parties must be online to update factory</li>
+                    <li><strong>One bad actor:</strong> Can force expensive on-chain closure</li>
+                    <li><strong>Complexity:</strong> State management is complex</li>
+                    <li><strong>Covenants would help:</strong> CTV could simplify coordination</li>
+                </ul>
+            </div>
+        </section>
+
+        <section>
+            <h2>32.5 LN-Symmetry (Eltoo)</h2>
+
+            <p>
+                A cleaner channel design that requires SIGHASH_ANYPREVOUT.
+            </p>
+
+            <div class="definition">
+                <p class="definition-title">Definition 32.7 (LN-Symmetry)</p>
+                <p>
+                    <strong>LN-Symmetry</strong> (formerly Eltoo) simplifies Lightning channels:
+                </p>
+                <ul>
+                    <li>No asymmetric states—both parties have same commitment tx</li>
+                    <li>No penalty mechanism needed</li>
+                    <li>State updates can be "rebased" on any prior state</li>
+                    <li>Requires ANYPREVOUT (BIP-118)</li>
+                </ul>
+            </div>
+
+            <div class="theorem">
+                <p class="theorem-title">Theorem 32.4 (Eltoo Advantages)</p>
+                <p>
+                    LN-Symmetry improves on LN-Penalty:
+                </p>
+                <ul>
+                    <li><strong>No toxic waste:</strong> Old states don't risk fund loss</li>
+                    <li><strong>Simpler watchtowers:</strong> Only need latest state</li>
+                    <li><strong>Multi-party channels:</strong> Much easier to implement</li>
+                    <li><strong>Smaller closure:</strong> Fewer transactions needed</li>
+                </ul>
+            </div>
+        </section>
+
+        <section>
+            <h2>32.6 Comparison Summary</h2>
+
+            <table class="data-table">
+                <thead>
+                    <tr>
+                        <th>Protocol</th>
+                        <th>Requires</th>
+                        <th>Best For</th>
+                        <th>Tradeoff</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>Lightning</td>
+                        <td>Current Bitcoin</td>
+                        <td>Payments</td>
+                        <td>Liquidity, online</td>
+                    </tr>
+                    <tr>
+                        <td>Ark</td>
+                        <td>CTV (optimal)</td>
+                        <td>Easy onboarding</td>
+                        <td>ASP availability</td>
+                    </tr>
+                    <tr>
+                        <td>Statechains</td>
+                        <td>Current Bitcoin</td>
+                        <td>UTXO transfer</td>
+                        <td>Fixed amounts</td>
+                    </tr>
+                    <tr>
+                        <td>Factories</td>
+                        <td>CTV (optimal)</td>
+                        <td>LN scaling</td>
+                        <td>Coordination</td>
+                    </tr>
+                    <tr>
+                        <td>LN-Symmetry</td>
+                        <td>ANYPREVOUT</td>
+                        <td>Cleaner LN</td>
+                        <td>Soft fork needed</td>
+                    </tr>
+                </tbody>
+            </table>
+        </section>
+
+        <section class="exercises">
+            <h2>Exercises</h2>
+
+            <div class="exercise">
+                <p class="exercise-title">Exercise 32.1</p>
+                <p>
+                    Calculate the capital efficiency of an Ark Service Provider. If the ASP
+                    has 100 BTC locked and processes 1000 payments/day of average 0.01 BTC,
+                    what's the capital turnover rate?
+                </p>
+            </div>
+
+            <div class="exercise">
+                <p class="exercise-title">Exercise 32.2</p>
+                <p>
+                    Design a hybrid protocol combining Lightning and Ark. How would you
+                    handle payments between users on different systems?
+                </p>
+            </div>
+
+            <div class="exercise">
+                <p class="exercise-title">Exercise 32.3</p>
+                <p>
+                    Analyze the statechain double-spend attack. What makes it possible,
+                    and what mechanisms could reduce the risk?
+                </p>
+            </div>
+
+            <div class="exercise">
+                <p class="exercise-title">Exercise 32.4</p>
+                <p>
+                    Model a channel factory with 10 participants. What's the probability
+                    that at least one goes offline during a factory update, assuming 95%
+                    individual uptime?
+                </p>
+            </div>
+        </section>
+
+        <nav class="chapter-navigation">
+            <a href="31-sidechains.html" class="prev-chapter">← Chapter 31: Sidechains</a>
+            <a href="33-governance.html" class="next-chapter">Chapter 33: Bitcoin Governance →</a>
+        </nav>
+    </main>
+
+    <footer>
+        <p>Elementary Bitcoin · Volume IV: Forks and Futures (Draft)</p>
+    </footer>
+</body>
+</html>

--- a/chapters/33-governance.html
+++ b/chapters/33-governance.html
@@ -1,0 +1,565 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Chapter 33: Bitcoin Governance | Elementary Bitcoin</title>
+    <meta name="description" content="Chapter 33: Bitcoin Governance - BIP process, consensus formation, and decentralized decision-making">
+    <link rel="stylesheet" href="../style.css">
+</head>
+<body>
+    <nav class="chapter-nav">
+        <a href="../index.html">Contents</a>
+        <span class="nav-separator">·</span>
+        <span class="volume-indicator">Volume IV: Forks and Futures</span>
+    </nav>
+
+    <header class="chapter-header">
+        <p class="chapter-number">Chapter 33</p>
+        <h1>Bitcoin Governance</h1>
+        <p class="chapter-subtitle">Decentralized Decision-Making</p>
+    </header>
+
+    <main class="chapter-content">
+        <section>
+            <p class="chapter-intro">
+                How does a protocol with no central authority evolve? Bitcoin's governance
+                is often called "rough consensus and running code"—a process where changes
+                require broad agreement across developers, miners, users, and businesses.
+                This chapter examines Bitcoin's unique governance model: the BIP process,
+                the dynamics of soft fork activation, and the philosophical tensions that
+                shape protocol development.
+            </p>
+        </section>
+
+        <section>
+            <h2>33.1 The Stakeholders</h2>
+
+            <div class="definition">
+                <p class="definition-title">Definition 33.1 (Bitcoin Stakeholder Groups)</p>
+                <p>
+                    Bitcoin governance involves multiple constituencies:
+                </p>
+                <ul>
+                    <li><strong>Developers:</strong> Write code, propose changes, review</li>
+                    <li><strong>Node operators:</strong> Run full nodes, enforce rules</li>
+                    <li><strong>Miners:</strong> Produce blocks, signal for upgrades</li>
+                    <li><strong>Users:</strong> Hold and transact in BTC</li>
+                    <li><strong>Businesses:</strong> Exchanges, wallets, payment processors</li>
+                </ul>
+            </div>
+
+            <figure>
+                <svg class="diagram" width="500" height="200" viewBox="0 0 500 200">
+                    <!-- Center: Bitcoin Protocol -->
+                    <circle cx="250" cy="100" r="50" fill="#f39c12" stroke="#c87f0a" stroke-width="2"/>
+                    <text x="250" y="95" text-anchor="middle" font-family="Georgia" font-size="10" fill="white">Bitcoin</text>
+                    <text x="250" y="110" text-anchor="middle" font-family="Georgia" font-size="10" fill="white">Protocol</text>
+
+                    <!-- Stakeholders -->
+                    <ellipse cx="100" cy="60" rx="60" ry="30" fill="#3498db" stroke="#2980b9"/>
+                    <text x="100" y="65" text-anchor="middle" font-family="Georgia" font-size="9" fill="white">Developers</text>
+
+                    <ellipse cx="400" cy="60" rx="60" ry="30" fill="#28a745" stroke="#1e7b34"/>
+                    <text x="400" y="65" text-anchor="middle" font-family="Georgia" font-size="9" fill="white">Miners</text>
+
+                    <ellipse cx="100" cy="150" rx="60" ry="30" fill="#9b59b6" stroke="#7d3c98"/>
+                    <text x="100" y="155" text-anchor="middle" font-family="Georgia" font-size="9" fill="white">Users</text>
+
+                    <ellipse cx="400" cy="150" rx="60" ry="30" fill="#e74c3c" stroke="#c0392b"/>
+                    <text x="400" y="155" text-anchor="middle" font-family="Georgia" font-size="9" fill="white">Businesses</text>
+
+                    <ellipse cx="250" cy="180" rx="50" ry="20" fill="#1abc9c" stroke="#16a085"/>
+                    <text x="250" y="185" text-anchor="middle" font-family="Georgia" font-size="8" fill="white">Node Operators</text>
+
+                    <!-- Connections -->
+                    <line x1="150" y1="75" x2="205" y2="90" stroke="#666" stroke-width="1"/>
+                    <line x1="350" y1="75" x2="295" y2="90" stroke="#666" stroke-width="1"/>
+                    <line x1="150" y1="135" x2="205" y2="115" stroke="#666" stroke-width="1"/>
+                    <line x1="350" y1="135" x2="295" y2="115" stroke="#666" stroke-width="1"/>
+                    <line x1="250" y1="160" x2="250" y2="150" stroke="#666" stroke-width="1"/>
+                </svg>
+                <figcaption>Figure 33.1: Bitcoin's multiple stakeholder groups.</figcaption>
+            </figure>
+
+            <div class="theorem">
+                <p class="theorem-title">Theorem 33.1 (Power Distribution)</p>
+                <p>
+                    No single stakeholder group can unilaterally change Bitcoin:
+                </p>
+                <ul>
+                    <li><strong>Developers:</strong> Write code but can't force adoption</li>
+                    <li><strong>Miners:</strong> Produce blocks but users can reject them</li>
+                    <li><strong>Users:</strong> Choose software but need developer support</li>
+                    <li><strong>Businesses:</strong> Influence but don't control consensus</li>
+                </ul>
+                <p>
+                    Changes require implicit or explicit agreement across groups.
+                </p>
+            </div>
+        </section>
+
+        <section>
+            <h2>33.2 The BIP Process</h2>
+
+            <div class="definition">
+                <p class="definition-title">Definition 33.2 (Bitcoin Improvement Proposal)</p>
+                <p>
+                    A <strong>BIP</strong> is a design document describing:
+                </p>
+                <ul>
+                    <li>A new feature or process for Bitcoin</li>
+                    <li>Technical specification</li>
+                    <li>Rationale and motivation</li>
+                </ul>
+                <p>
+                    BIPs are numbered and tracked in the bitcoin/bips repository.
+                </p>
+            </div>
+
+            <div class="definition">
+                <p class="definition-title">Definition 33.3 (BIP Types)</p>
+                <p>
+                    <strong>Standards Track:</strong> Changes affecting implementations
+                </p>
+                <ul>
+                    <li>Consensus (soft/hard fork)</li>
+                    <li>Peer Services (network protocol)</li>
+                    <li>API/RPC</li>
+                    <li>Applications</li>
+                </ul>
+                <p>
+                    <strong>Informational:</strong> General guidelines or information
+                </p>
+                <p>
+                    <strong>Process:</strong> Changes to BIP process itself
+                </p>
+            </div>
+
+            <figure>
+                <svg class="diagram" width="500" height="160" viewBox="0 0 500 160">
+                    <!-- BIP lifecycle -->
+                    <rect x="30" y="60" width="70" height="40" rx="4" fill="#e8f4e8" stroke="#5a8f5a"/>
+                    <text x="65" y="85" text-anchor="middle" font-family="Georgia" font-size="8">Draft</text>
+
+                    <rect x="130" y="60" width="70" height="40" rx="4" fill="#fff3cd" stroke="#f39c12"/>
+                    <text x="165" y="85" text-anchor="middle" font-family="Georgia" font-size="8">Proposed</text>
+
+                    <rect x="230" y="60" width="70" height="40" rx="4" fill="#d4edda" stroke="#28a745"/>
+                    <text x="265" y="85" text-anchor="middle" font-family="Georgia" font-size="8">Final</text>
+
+                    <rect x="330" y="60" width="70" height="40" rx="4" fill="#d1ecf1" stroke="#17a2b8"/>
+                    <text x="365" y="85" text-anchor="middle" font-family="Georgia" font-size="8">Active</text>
+
+                    <!-- Alternative outcomes -->
+                    <rect x="130" y="120" width="70" height="30" rx="4" fill="#ffe8e8" stroke="#c44"/>
+                    <text x="165" y="140" text-anchor="middle" font-family="Georgia" font-size="7">Rejected</text>
+
+                    <rect x="230" y="120" width="70" height="30" rx="4" fill="#f5f5f5" stroke="#999"/>
+                    <text x="265" y="140" text-anchor="middle" font-family="Georgia" font-size="7">Withdrawn</text>
+
+                    <!-- Arrows -->
+                    <path d="M 100 80 L 130 80" stroke="#5a8f5a" stroke-width="1.5" marker-end="url(#arrowGreen33)"/>
+                    <path d="M 200 80 L 230 80" stroke="#f39c12" stroke-width="1.5" marker-end="url(#arrowOrange33)"/>
+                    <path d="M 300 80 L 330 80" stroke="#28a745" stroke-width="1.5" marker-end="url(#arrowGreen33)"/>
+
+                    <path d="M 165 100 L 165 120" stroke="#c44" stroke-width="1" marker-end="url(#arrowRed33)"/>
+                    <path d="M 265 100 L 265 120" stroke="#999" stroke-width="1" marker-end="url(#arrowGray33)"/>
+
+                    <!-- Labels -->
+                    <text x="250" y="30" text-anchor="middle" font-family="Georgia" font-size="10" font-weight="bold">BIP Lifecycle</text>
+
+                    <defs>
+                        <marker id="arrowGreen33" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+                            <polygon points="0 0, 8 3, 0 6" fill="#28a745"/>
+                        </marker>
+                        <marker id="arrowOrange33" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+                            <polygon points="0 0, 8 3, 0 6" fill="#f39c12"/>
+                        </marker>
+                        <marker id="arrowRed33" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+                            <polygon points="0 0, 8 3, 0 6" fill="#c44"/>
+                        </marker>
+                        <marker id="arrowGray33" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+                            <polygon points="0 0, 8 3, 0 6" fill="#999"/>
+                        </marker>
+                    </defs>
+                </svg>
+                <figcaption>Figure 33.2: BIP lifecycle from draft to final/active.</figcaption>
+            </figure>
+
+            <div class="example">
+                <p class="example-title">Example 33.1 (Notable BIPs)</p>
+                <table class="data-table">
+                    <thead>
+                        <tr>
+                            <th>BIP</th>
+                            <th>Title</th>
+                            <th>Status</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>32</td>
+                            <td>HD Wallets</td>
+                            <td>Final</td>
+                        </tr>
+                        <tr>
+                            <td>39</td>
+                            <td>Mnemonic Seed Phrases</td>
+                            <td>Proposed</td>
+                        </tr>
+                        <tr>
+                            <td>141</td>
+                            <td>Segregated Witness</td>
+                            <td>Final</td>
+                        </tr>
+                        <tr>
+                            <td>341</td>
+                            <td>Taproot</td>
+                            <td>Final</td>
+                        </tr>
+                        <tr>
+                            <td>119</td>
+                            <td>OP_CHECKTEMPLATEVERIFY</td>
+                            <td>Draft</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </section>
+
+        <section>
+            <h2>33.3 Consensus Formation</h2>
+
+            <p>
+                Beyond technical specification, controversial changes require social consensus.
+            </p>
+
+            <div class="definition">
+                <p class="definition-title">Definition 33.4 (Rough Consensus)</p>
+                <p>
+                    <strong>Rough consensus</strong> (from IETF) means:
+                </p>
+                <ul>
+                    <li>General agreement exists, though not unanimous</li>
+                    <li>Objections have been considered and addressed</li>
+                    <li>Remaining disagreement is not fundamental</li>
+                </ul>
+                <p>
+                    In Bitcoin: most participants accept a change, even if some disagree.
+                </p>
+            </div>
+
+            <div class="theorem">
+                <p class="theorem-title">Theorem 33.2 (Consensus Signals)</p>
+                <p>
+                    Social consensus is observed through:
+                </p>
+                <ul>
+                    <li><strong>Mailing list discussion:</strong> bitcoin-dev list debates</li>
+                    <li><strong>Implementation:</strong> Multiple independent implementations</li>
+                    <li><strong>Testing:</strong> Deployment on testnet/signet</li>
+                    <li><strong>Support statements:</strong> Companies and developers</li>
+                    <li><strong>Futures markets:</strong> Price discovery for contentious forks</li>
+                </ul>
+            </div>
+
+            <div class="remark">
+                <p class="remark-title">Remark 33.1 (The "Ossification" Debate)</p>
+                <p>
+                    A growing tension in Bitcoin governance:
+                </p>
+                <ul>
+                    <li><strong>Pro-change:</strong> Bitcoin needs features (covenants, etc.) to remain competitive</li>
+                    <li><strong>Pro-stability:</strong> Changes risk breaking what works; ossification protects value</li>
+                    <li><strong>Middle ground:</strong> Only changes with overwhelming consensus</li>
+                </ul>
+                <p>
+                    The bar for consensus has risen significantly since 2017.
+                </p>
+            </div>
+        </section>
+
+        <section>
+            <h2>33.4 Soft Fork Activation</h2>
+
+            <p>
+                Technical consensus (a working BIP) requires an activation mechanism.
+            </p>
+
+            <div class="definition">
+                <p class="definition-title">Definition 33.5 (Activation Methods)</p>
+                <ul>
+                    <li><strong>Flag Day:</strong> Fixed block height or date</li>
+                    <li><strong>BIP-9:</strong> Miner signaling with timeout</li>
+                    <li><strong>BIP-8:</strong> Signaling with optional mandatory activation</li>
+                    <li><strong>Speedy Trial:</strong> Fast signaling, delayed activation</li>
+                </ul>
+            </div>
+
+            <div class="theorem">
+                <p class="theorem-title">Theorem 33.3 (MASF vs UASF)</p>
+                <p>
+                    Two philosophical approaches to activation:
+                </p>
+                <p>
+                    <strong>Miner Activated Soft Fork (MASF):</strong>
+                </p>
+                <ul>
+                    <li>Miners signal readiness</li>
+                    <li>Activation at threshold (e.g., 95%)</li>
+                    <li>Risk: miners can block upgrades</li>
+                </ul>
+                <p>
+                    <strong>User Activated Soft Fork (UASF):</strong>
+                </p>
+                <ul>
+                    <li>Users set flag day activation</li>
+                    <li>Miners must comply or risk invalid blocks</li>
+                    <li>Risk: chain split if miners resist</li>
+                </ul>
+            </div>
+
+            <div class="example">
+                <p class="example-title">Example 33.2 (SegWit Activation)</p>
+                <p>
+                    SegWit activation combined both approaches:
+                </p>
+                <ol>
+                    <li>BIP-9 signaling deployed (2016)</li>
+                    <li>Signaling stalled at ~30% for months</li>
+                    <li>BIP-148 (UASF) announced August 1, 2017 deadline</li>
+                    <li>Miners rapidly signaled to avoid split</li>
+                    <li>95% reached; SegWit activated August 2017</li>
+                </ol>
+            </div>
+        </section>
+
+        <section>
+            <h2>33.5 Bitcoin Core's Role</h2>
+
+            <div class="definition">
+                <p class="definition-title">Definition 33.6 (Bitcoin Core)</p>
+                <p>
+                    <strong>Bitcoin Core</strong> is the reference implementation:
+                </p>
+                <ul>
+                    <li>Descended from Satoshi's original code</li>
+                    <li>Most widely run full node software</li>
+                    <li>Open source, permissively licensed</li>
+                    <li>Maintained by ~30 active contributors</li>
+                </ul>
+            </div>
+
+            <div class="theorem">
+                <p class="theorem-title">Theorem 33.4 (Core is Not Bitcoin)</p>
+                <p>
+                    Bitcoin Core has significant influence but not control:
+                </p>
+                <ul>
+                    <li>Users can run alternative implementations</li>
+                    <li>Users can fork Bitcoin Core and modify it</li>
+                    <li>Core contributors cannot unilaterally change consensus</li>
+                    <li>If Core goes "wrong," users can reject their releases</li>
+                </ul>
+            </div>
+
+            <div class="remark">
+                <p class="remark-title">Remark 33.2 (Core Development Process)</p>
+                <p>
+                    Bitcoin Core changes require:
+                </p>
+                <ul>
+                    <li>Pull request with clear rationale</li>
+                    <li>Review by multiple contributors</li>
+                    <li>Testing and QA</li>
+                    <li>Concept ACK → Approach ACK → Code review ACK</li>
+                    <li>Merge by maintainer after sufficient review</li>
+                </ul>
+                <p>
+                    Consensus changes require much more scrutiny than other PRs.
+                </p>
+            </div>
+        </section>
+
+        <section>
+            <h2>33.6 Philosophical Foundations</h2>
+
+            <div class="definition">
+                <p class="definition-title">Definition 33.7 (Bitcoin Maximalism)</p>
+                <p>
+                    The philosophical position that:
+                </p>
+                <ul>
+                    <li>Bitcoin's core properties should be preserved above all</li>
+                    <li>Decentralization and censorship resistance are paramount</li>
+                    <li>Changes should be minimal and conservative</li>
+                    <li>Alternative cryptocurrencies are inferior or unnecessary</li>
+                </ul>
+            </div>
+
+            <div class="definition">
+                <p class="definition-title">Definition 33.8 (Core Properties)</p>
+                <p>
+                    Properties that Bitcoin governance tends to protect:
+                </p>
+                <ul>
+                    <li><strong>21 million cap:</strong> Fixed supply, no inflation</li>
+                    <li><strong>Censorship resistance:</strong> Anyone can transact</li>
+                    <li><strong>Permissionless:</strong> No gatekeepers</li>
+                    <li><strong>Decentralized:</strong> No single point of control</li>
+                    <li><strong>Sound money:</strong> Predictable monetary policy</li>
+                </ul>
+            </div>
+
+            <div class="theorem">
+                <p class="theorem-title">Theorem 33.5 (Schelling Point Preservation)</p>
+                <p>
+                    Bitcoin's value partially derives from being a Schelling point:
+                </p>
+                <ul>
+                    <li>The default choice for "cryptocurrency"</li>
+                    <li>The coordination point for sound money</li>
+                    <li>Changes risk disrupting this coordination</li>
+                </ul>
+                <p>
+                    This creates strong pressure toward conservatism.
+                </p>
+            </div>
+        </section>
+
+        <section>
+            <h2>33.7 Case Studies in Governance</h2>
+
+            <h3>33.7.1 The Block Size War (2015-2017)</h3>
+
+            <div class="example">
+                <p class="example-title">Example 33.3 (Block Size Debate)</p>
+                <p>
+                    The defining governance crisis:
+                </p>
+                <ul>
+                    <li><strong>Issue:</strong> How to scale Bitcoin (blocks vs layers)</li>
+                    <li><strong>Camps:</strong> Big blockers vs small blockers</li>
+                    <li><strong>Resolution:</strong> SegWit activated; BCH forked away</li>
+                    <li><strong>Lesson:</strong> Users, not just miners, determine consensus</li>
+                </ul>
+            </div>
+
+            <h3>33.7.2 Taproot Activation (2020-2021)</h3>
+
+            <div class="example">
+                <p class="example-title">Example 33.4 (Taproot)</p>
+                <p>
+                    A smoother activation process:
+                </p>
+                <ul>
+                    <li><strong>Technical consensus:</strong> Strong agreement on benefits</li>
+                    <li><strong>Debate:</strong> Activation method (LOT=true vs LOT=false)</li>
+                    <li><strong>Resolution:</strong> Speedy Trial compromise</li>
+                    <li><strong>Result:</strong> 90% signaling, activated November 2021</li>
+                </ul>
+            </div>
+
+            <h3>33.7.3 Ordinals/Inscriptions (2023)</h3>
+
+            <div class="example">
+                <p class="example-title">Example 33.5 (Ordinals Controversy)</p>
+                <p>
+                    Emergent use case causing debate:
+                </p>
+                <ul>
+                    <li><strong>Innovation:</strong> NFT-like assets on Bitcoin</li>
+                    <li><strong>Criticism:</strong> "Spam," increased fees, not intended use</li>
+                    <li><strong>Defense:</strong> Permissionless use, valid transactions</li>
+                    <li><strong>Outcome:</strong> No consensus to filter; market decides</li>
+                </ul>
+            </div>
+        </section>
+
+        <section>
+            <h2>33.8 Future Governance Challenges</h2>
+
+            <div class="remark">
+                <p class="remark-title">Remark 33.3 (Open Questions)</p>
+                <p>
+                    Bitcoin governance faces unresolved challenges:
+                </p>
+                <ul>
+                    <li><strong>Covenant activation:</strong> CTV/CAT debate ongoing</li>
+                    <li><strong>Developer funding:</strong> How to sustain contributors</li>
+                    <li><strong>Quantum resistance:</strong> Future necessity, timing unclear</li>
+                    <li><strong>Fee market:</strong> Long-term security budget</li>
+                    <li><strong>Ossification:</strong> When/if to "freeze" the protocol</li>
+                </ul>
+            </div>
+
+            <div class="theorem">
+                <p class="theorem-title">Theorem 33.6 (Governance Evolution)</p>
+                <p>
+                    Bitcoin's governance has evolved:
+                </p>
+                <ul>
+                    <li><strong>2009-2014:</strong> Satoshi-led, then core developers</li>
+                    <li><strong>2015-2017:</strong> Contested, stakeholder conflict</li>
+                    <li><strong>2017-present:</strong> Higher bar for changes, user power demonstrated</li>
+                    <li><strong>Future:</strong> Likely continued ossification trend</li>
+                </ul>
+            </div>
+        </section>
+
+        <section class="exercises">
+            <h2>Exercises</h2>
+
+            <div class="exercise">
+                <p class="exercise-title">Exercise 33.1</p>
+                <p>
+                    Research the "LOT=true" vs "LOT=false" debate for Taproot activation.
+                    What were the arguments on each side? How was consensus reached?
+                </p>
+            </div>
+
+            <div class="exercise">
+                <p class="exercise-title">Exercise 33.2</p>
+                <p>
+                    Model Bitcoin governance as a game theory problem. What are the payoffs
+                    for different stakeholder groups in supporting vs opposing a change?
+                </p>
+            </div>
+
+            <div class="exercise">
+                <p class="exercise-title">Exercise 33.3</p>
+                <p>
+                    Analyze the claim "Bitcoin Core developers control Bitcoin." What
+                    evidence supports or refutes this? Consider the block size war.
+                </p>
+            </div>
+
+            <div class="exercise">
+                <p class="exercise-title">Exercise 33.4</p>
+                <p>
+                    Design a mechanism for measuring social consensus on protocol changes.
+                    What metrics would you use? What are the limitations?
+                </p>
+            </div>
+
+            <div class="exercise">
+                <p class="exercise-title">Exercise 33.5</p>
+                <p>
+                    Compare Bitcoin's governance to other open-source projects (Linux,
+                    Ethereum, etc.). What makes Bitcoin's governance unique?
+                </p>
+            </div>
+        </section>
+
+        <nav class="chapter-navigation">
+            <a href="32-beyond-lightning.html" class="prev-chapter">← Chapter 32: Beyond Lightning</a>
+            <a href="../index.html" class="next-chapter">Back to Contents →</a>
+        </nav>
+    </main>
+
+    <footer>
+        <p>Elementary Bitcoin · Volume IV: Forks and Futures (Draft)</p>
+    </footer>
+</body>
+</html>

--- a/chapters/34-drivechains.html
+++ b/chapters/34-drivechains.html
@@ -1,0 +1,484 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Chapter 34: Drivechains | Elementary Bitcoin</title>
+    <meta name="description" content="Chapter 34: Drivechains - BIP-300/301, hashrate escrow, blind merged mining, and the sidechain debate">
+    <link rel="stylesheet" href="../style.css">
+</head>
+<body>
+    <nav class="chapter-nav">
+        <a href="../index.html">Contents</a>
+        <span class="nav-separator">·</span>
+        <span class="volume-indicator">Volume IV: Forks and Futures</span>
+    </nav>
+
+    <header class="chapter-header">
+        <p class="chapter-number">Chapter 34</p>
+        <h1>Drivechains</h1>
+        <p class="chapter-subtitle">BIP-300/301 and Miner-Enforced Sidechains</p>
+    </header>
+
+    <main class="chapter-content">
+        <section>
+            <p class="chapter-intro">
+                Drivechains propose a radical alternative to federated sidechains: let Bitcoin
+                miners themselves custody the two-way peg. Through "hashrate escrow," miners
+                collectively control sidechain withdrawals, theoretically providing trustless
+                interoperability without Bitcoin consensus changes beyond two new opcodes.
+                This chapter examines BIP-300/301's mechanism, security model, and the
+                intense controversy surrounding the proposal.
+            </p>
+        </section>
+
+        <section>
+            <h2>34.1 The Drivechain Vision</h2>
+
+            <div class="definition">
+                <p class="definition-title">Definition 34.1 (Drivechain)</p>
+                <p>
+                    A <strong>drivechain</strong> is a sidechain where:
+                </p>
+                <ul>
+                    <li>Bitcoin miners validate sidechain withdrawals</li>
+                    <li>No trusted federation required</li>
+                    <li>Sidechains can have arbitrary rules (smart contracts, privacy, etc.)</li>
+                    <li>BTC moves between chains via "hashrate escrow"</li>
+                </ul>
+            </div>
+
+            <div class="definition">
+                <p class="definition-title">Definition 34.2 (Hashrate Escrow)</p>
+                <p>
+                    <strong>Hashrate escrow</strong> (BIP-300) is a withdrawal mechanism where:
+                </p>
+                <ol>
+                    <li>Withdrawal requests are published on the sidechain</li>
+                    <li>Miners vote on withdrawals via coinbase outputs</li>
+                    <li>Withdrawals require ~3-6 months of miner ACKs</li>
+                    <li>Funds release only after threshold reached</li>
+                </ol>
+            </div>
+
+            <figure>
+                <svg class="diagram" width="500" height="220" viewBox="0 0 500 220">
+                    <!-- Bitcoin mainchain -->
+                    <rect x="30" y="30" width="180" height="50" rx="4" fill="#f39c12" stroke="#c87f0a" stroke-width="2"/>
+                    <text x="120" y="55" text-anchor="middle" font-family="Georgia" font-size="10" fill="white" font-weight="bold">Bitcoin Mainchain</text>
+                    <text x="120" y="70" text-anchor="middle" font-family="Georgia" font-size="8" fill="white">+ BIP-300/301 opcodes</text>
+
+                    <!-- Drivechain -->
+                    <rect x="290" y="30" width="180" height="50" rx="4" fill="#9b59b6" stroke="#7d3c98" stroke-width="2"/>
+                    <text x="380" y="55" text-anchor="middle" font-family="Georgia" font-size="10" fill="white" font-weight="bold">Drivechain</text>
+                    <text x="380" y="70" text-anchor="middle" font-family="Georgia" font-size="8" fill="white">(any rules)</text>
+
+                    <!-- Peg-in -->
+                    <path d="M 210 40 L 290 40" stroke="#28a745" stroke-width="2" marker-end="url(#arrowGreen34)"/>
+                    <text x="250" y="32" text-anchor="middle" font-family="Georgia" font-size="8" fill="#28a745">Peg-in (fast)</text>
+
+                    <!-- Peg-out -->
+                    <path d="M 290 70 L 210 70" stroke="#c44" stroke-width="2" marker-end="url(#arrowRed34)"/>
+                    <text x="250" y="88" text-anchor="middle" font-family="Georgia" font-size="8" fill="#c44">Peg-out (~3-6 months)</text>
+
+                    <!-- Miners -->
+                    <rect x="150" y="120" width="200" height="70" rx="4" fill="#e8f4e8" stroke="#5a8f5a" stroke-width="1.5"/>
+                    <text x="250" y="145" text-anchor="middle" font-family="Georgia" font-size="10" font-weight="bold">Bitcoin Miners</text>
+                    <text x="250" y="165" text-anchor="middle" font-family="Georgia" font-size="8">Vote on withdrawals in coinbase</text>
+                    <text x="250" y="180" text-anchor="middle" font-family="Georgia" font-size="8" fill="#666">(hashrate escrow)</text>
+
+                    <!-- Connections -->
+                    <line x1="120" y1="80" x2="200" y2="120" stroke="#5a8f5a" stroke-width="1.5" stroke-dasharray="4,2"/>
+                    <line x1="380" y1="80" x2="300" y2="120" stroke="#5a8f5a" stroke-width="1.5" stroke-dasharray="4,2"/>
+
+                    <defs>
+                        <marker id="arrowGreen34" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+                            <polygon points="0 0, 8 3, 0 6" fill="#28a745"/>
+                        </marker>
+                        <marker id="arrowRed34" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+                            <polygon points="0 0, 8 3, 0 6" fill="#c44"/>
+                        </marker>
+                    </defs>
+                </svg>
+                <figcaption>Figure 34.1: Drivechain architecture with miner-enforced two-way peg.</figcaption>
+            </figure>
+        </section>
+
+        <section>
+            <h2>34.2 BIP-300: Hashrate Escrow</h2>
+
+            <div class="definition">
+                <p class="definition-title">Definition 34.3 (BIP-300 Mechanism)</p>
+                <p>
+                    BIP-300 introduces <code>OP_DRIVECHAIN</code> for withdrawal voting:
+                </p>
+                <pre style="background: #f5f5f5; padding: 1rem; font-family: monospace; font-size: 0.85rem;">
+Sidechain deposit address:
+  OP_DRIVECHAIN <sidechain_id>
+
+Withdrawal process:
+  1. User requests withdrawal on sidechain
+  2. Sidechain bundles requests into withdrawal bundle
+  3. Bundle hash published to mainchain
+  4. Miners ACK/NACK in coinbase for ~13,150 blocks (~3 months)
+  5. If ACKs > threshold, withdrawal executes</pre>
+            </div>
+
+            <div class="definition">
+                <p class="definition-title">Definition 34.4 (Withdrawal Bundle)</p>
+                <p>
+                    A <strong>withdrawal bundle</strong> (WT^) aggregates multiple withdrawals:
+                </p>
+                <ul>
+                    <li>Created by sidechain nodes</li>
+                    <li>Contains destinations and amounts</li>
+                    <li>Single mainchain transaction when approved</li>
+                    <li>Batching reduces on-chain footprint</li>
+                </ul>
+            </div>
+
+            <div class="theorem">
+                <p class="theorem-title">Theorem 34.1 (Withdrawal Security)</p>
+                <p>
+                    For a withdrawal to be stolen, miners must:
+                </p>
+                <ol>
+                    <li>Create a fraudulent withdrawal bundle</li>
+                    <li>Accumulate ~13,150 ACKs over ~3 months</li>
+                    <li>Maintain >50% hashrate commitment throughout</li>
+                </ol>
+                <p>
+                    The extended timeframe allows users to detect and respond to theft attempts.
+                </p>
+            </div>
+
+            <figure>
+                <svg class="diagram" width="500" height="160" viewBox="0 0 500 160">
+                    <!-- Timeline -->
+                    <line x1="50" y1="80" x2="450" y2="80" stroke="#666" stroke-width="2"/>
+
+                    <!-- Withdrawal proposed -->
+                    <circle cx="80" cy="80" r="8" fill="#f39c12"/>
+                    <text x="80" y="60" text-anchor="middle" font-family="Georgia" font-size="8">Proposed</text>
+                    <text x="80" y="110" text-anchor="middle" font-family="Georgia" font-size="7">Block 0</text>
+
+                    <!-- Voting period -->
+                    <rect x="100" y="72" width="250" height="16" fill="#e8f4e8" stroke="#5a8f5a"/>
+                    <text x="225" y="84" text-anchor="middle" font-family="Georgia" font-size="8">Miner voting (~13,150 blocks)</text>
+
+                    <!-- Threshold reached -->
+                    <circle cx="370" cy="80" r="8" fill="#28a745"/>
+                    <text x="370" y="60" text-anchor="middle" font-family="Georgia" font-size="8">Threshold</text>
+                    <text x="370" y="110" text-anchor="middle" font-family="Georgia" font-size="7">~3 months</text>
+
+                    <!-- Execution -->
+                    <circle cx="420" cy="80" r="8" fill="#3498db"/>
+                    <text x="420" y="60" text-anchor="middle" font-family="Georgia" font-size="8">Execute</text>
+
+                    <!-- ACK counter -->
+                    <text x="225" y="140" text-anchor="middle" font-family="Georgia" font-size="9">ACK score: 0 → 13,150 (threshold)</text>
+                </svg>
+                <figcaption>Figure 34.2: Withdrawal voting timeline (~3 months).</figcaption>
+            </figure>
+        </section>
+
+        <section>
+            <h2>34.3 BIP-301: Blind Merged Mining</h2>
+
+            <div class="definition">
+                <p class="definition-title">Definition 34.5 (Blind Merged Mining)</p>
+                <p>
+                    <strong>Blind Merged Mining</strong> (BMM) allows sidechain blocks to be
+                    mined without miners running sidechain software:
+                </p>
+                <ol>
+                    <li>Sidechain node creates block, computes header hash</li>
+                    <li>Node pays Bitcoin miner (via mainchain) to include hash</li>
+                    <li>Miner includes hash in coinbase without validating sidechain</li>
+                    <li>Sidechain accepts block if hash is in valid Bitcoin block</li>
+                </ol>
+            </div>
+
+            <div class="theorem">
+                <p class="theorem-title">Theorem 34.2 (BMM Properties)</p>
+                <p>
+                    Blind merged mining provides:
+                </p>
+                <ul>
+                    <li><strong>No miner overhead:</strong> Miners don't run sidechain nodes</li>
+                    <li><strong>Permissionless:</strong> Anyone can pay for block inclusion</li>
+                    <li><strong>Fee market:</strong> Sidechain block space has its own market</li>
+                    <li><strong>Inherited security:</strong> Sidechain blocks anchored to Bitcoin PoW</li>
+                </ul>
+            </div>
+
+            <div class="example">
+                <p class="example-title">Example 34.1 (BMM Transaction)</p>
+                <pre style="background: #f5f5f5; padding: 1rem; font-family: monospace; font-size: 0.85rem;">
+// Sidechain operator creates BMM request
+BMM Request:
+  - Sidechain ID: 1
+  - Block hash: 0xabc123...
+  - Fee to miner: 0.001 BTC
+
+// Miner includes in coinbase
+OP_RETURN <BMM_TAG> <sidechain_id> <block_hash>
+
+// Sidechain accepts if:
+// 1. Hash matches sidechain block
+// 2. Bitcoin block is valid and in best chain</pre>
+            </div>
+        </section>
+
+        <section>
+            <h2>34.4 Security Analysis</h2>
+
+            <div class="theorem">
+                <p class="theorem-title">Theorem 34.3 (Drivechain Trust Model)</p>
+                <p>
+                    Drivechains are secured by:
+                </p>
+                <ul>
+                    <li><strong>Miner honesty:</strong> Majority of hashrate must be honest</li>
+                    <li><strong>Time delay:</strong> ~3-6 months to complete theft</li>
+                    <li><strong>Public visibility:</strong> Theft attempts are observable</li>
+                    <li><strong>Economic incentives:</strong> Theft risks Bitcoin's value</li>
+                </ul>
+            </div>
+
+            <div class="definition">
+                <p class="definition-title">Definition 34.6 (Miner Theft Attack)</p>
+                <p>
+                    A <strong>miner theft attack</strong> on drivechains:
+                </p>
+                <ol>
+                    <li>Malicious miners create false withdrawal to themselves</li>
+                    <li>Vote for it over ~3 months</li>
+                    <li>If successful, steal all sidechain deposits</li>
+                </ol>
+                <p>
+                    Cost: Must maintain >50% hashrate for 3 months while attack is visible.
+                </p>
+            </div>
+
+            <div class="remark">
+                <p class="remark-title">Remark 34.1 (Attack Economics)</p>
+                <p>
+                    The economic argument for drivechain security:
+                </p>
+                <ul>
+                    <li>Stealing sidechain funds would damage Bitcoin's reputation</li>
+                    <li>Miners have large investments in Bitcoin-denominated equipment</li>
+                    <li>Rational miners won't destroy their own revenue source</li>
+                    <li>3-month visibility allows market/social response</li>
+                </ul>
+                <p>
+                    Counter-argument: miners could steal and exit if theft value > future mining revenue.
+                </p>
+            </div>
+
+            <table class="data-table">
+                <thead>
+                    <tr>
+                        <th>Security Model</th>
+                        <th>Federation</th>
+                        <th>Drivechain</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>Trust</td>
+                        <td>m-of-n federation</td>
+                        <td>>50% hashrate</td>
+                    </tr>
+                    <tr>
+                        <td>Theft speed</td>
+                        <td>Instant (if colluding)</td>
+                        <td>~3-6 months</td>
+                    </tr>
+                    <tr>
+                        <td>Visibility</td>
+                        <td>Private collusion possible</td>
+                        <td>Public on-chain</td>
+                    </tr>
+                    <tr>
+                        <td>Entities</td>
+                        <td>~15 known parties</td>
+                        <td>Anonymous miners</td>
+                    </tr>
+                </tbody>
+            </table>
+        </section>
+
+        <section>
+            <h2>34.5 The Drivechain Controversy</h2>
+
+            <p>
+                Drivechains are among the most contentious Bitcoin proposals.
+            </p>
+
+            <h3>34.5.1 Arguments For</h3>
+
+            <div class="remark">
+                <p class="remark-title">Remark 34.2 (Pro-Drivechain Arguments)</p>
+                <ul>
+                    <li><strong>Permissionless innovation:</strong> Experiment without risking mainchain</li>
+                    <li><strong>Absorb altcoin demand:</strong> Features as sidechains, not competitors</li>
+                    <li><strong>No federation:</strong> More decentralized than Liquid</li>
+                    <li><strong>Opt-in:</strong> Only users who want sidechains are exposed</li>
+                    <li><strong>Miner revenue:</strong> Additional fee income from BMM</li>
+                </ul>
+            </div>
+
+            <h3>34.5.2 Arguments Against</h3>
+
+            <div class="remark">
+                <p class="remark-title">Remark 34.3 (Anti-Drivechain Arguments)</p>
+                <ul>
+                    <li><strong>Miner incentives:</strong> Gives miners new power over user funds</li>
+                    <li><strong>MEV concerns:</strong> Miners could extract value via sidechain ordering</li>
+                    <li><strong>51% attack surface:</strong> Reduces cost of certain attacks</li>
+                    <li><strong>Complexity:</strong> Adds significant consensus complexity</li>
+                    <li><strong>Ossification:</strong> Major change to Bitcoin's security model</li>
+                </ul>
+            </div>
+
+            <div class="theorem">
+                <p class="theorem-title">Theorem 34.4 (The MEV Concern)</p>
+                <p>
+                    With drivechains, miners gain new extractable value:
+                </p>
+                <ul>
+                    <li>Sidechain transaction ordering (via BMM)</li>
+                    <li>Withdrawal censorship or delay</li>
+                    <li>Front-running sidechain DeFi (if applicable)</li>
+                </ul>
+                <p>
+                    Critics argue this creates perverse incentives absent in Bitcoin today.
+                </p>
+            </div>
+
+            <h3>34.5.3 Technical Criticisms</h3>
+
+            <div class="remark">
+                <p class="remark-title">Remark 34.4 (Specific Concerns)</p>
+                <ul>
+                    <li><strong>Withdrawal time:</strong> 3-6 months is impractical for most users</li>
+                    <li><strong>Capital lockup:</strong> Funds stuck during withdrawal</li>
+                    <li><strong>Sidechain failure:</strong> If sidechain dies, withdrawals may be impossible</li>
+                    <li><strong>Coordination:</strong> Miners must coordinate voting (potential centralization)</li>
+                </ul>
+            </div>
+        </section>
+
+        <section>
+            <h2>34.6 Proposed Sidechains</h2>
+
+            <div class="example">
+                <p class="example-title">Example 34.2 (Potential Drivechains)</p>
+                <p>
+                    Proposed sidechains if BIP-300/301 activates:
+                </p>
+                <table class="data-table">
+                    <thead>
+                        <tr>
+                            <th>Sidechain</th>
+                            <th>Purpose</th>
+                            <th>Features</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>Zside</td>
+                            <td>Privacy</td>
+                            <td>Zcash-style shielded transactions</td>
+                        </tr>
+                        <tr>
+                            <td>EVM chain</td>
+                            <td>Smart contracts</td>
+                            <td>Ethereum compatibility</td>
+                        </tr>
+                        <tr>
+                            <td>Large blocks</td>
+                            <td>Scaling</td>
+                            <td>High throughput, low security</td>
+                        </tr>
+                        <tr>
+                            <td>Prediction markets</td>
+                            <td>Forecasting</td>
+                            <td>Specialized for betting/prediction</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </section>
+
+        <section>
+            <h2>34.7 Current Status</h2>
+
+            <div class="remark">
+                <p class="remark-title">Remark 34.5 (Activation Status)</p>
+                <p>
+                    As of 2024:
+                </p>
+                <ul>
+                    <li>BIP-300/301 written and specified</li>
+                    <li>Implementation exists (Bitcoin Core fork)</li>
+                    <li>No activation attempt yet</li>
+                    <li>Significant developer opposition</li>
+                    <li>Active debate in community</li>
+                </ul>
+                <p>
+                    Drivechains remain one of the most debated potential upgrades.
+                </p>
+            </div>
+        </section>
+
+        <section class="exercises">
+            <h2>Exercises</h2>
+
+            <div class="exercise">
+                <p class="exercise-title">Exercise 34.1</p>
+                <p>
+                    Calculate the expected cost of a drivechain theft attack. Assume: 500 EH/s
+                    network hashrate, $0.05/kWh electricity, 30 J/TH efficiency, 3-month attack.
+                    Compare to potential theft of $1B in sidechain deposits.
+                </p>
+            </div>
+
+            <div class="exercise">
+                <p class="exercise-title">Exercise 34.2</p>
+                <p>
+                    Analyze the game theory of miner coordination on drivechain withdrawals.
+                    Under what conditions would miners collude to steal vs remain honest?
+                </p>
+            </div>
+
+            <div class="exercise">
+                <p class="exercise-title">Exercise 34.3</p>
+                <p>
+                    Compare drivechain security to a 15-of-25 federated sidechain. Which
+                    has stronger security guarantees? Under what threat models?
+                </p>
+            </div>
+
+            <div class="exercise">
+                <p class="exercise-title">Exercise 34.4</p>
+                <p>
+                    Design a mechanism to speed up drivechain withdrawals while maintaining
+                    security. What tradeoffs would your design introduce?
+                </p>
+            </div>
+        </section>
+
+        <nav class="chapter-navigation">
+            <a href="33-governance.html" class="prev-chapter">← Chapter 33: Bitcoin Governance</a>
+            <a href="35-consensus-cleanup.html" class="next-chapter">Chapter 35: Great Consensus Cleanup →</a>
+        </nav>
+    </main>
+
+    <footer>
+        <p>Elementary Bitcoin · Volume IV: Forks and Futures (Draft)</p>
+    </footer>
+</body>
+</html>

--- a/chapters/37-defense-mechanisms.html
+++ b/chapters/37-defense-mechanisms.html
@@ -1,0 +1,503 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Chapter 37: Defense Mechanisms | Elementary Bitcoin</title>
+    <meta name="description" content="Chapter 37: Defense Mechanisms - Checkpoints, confirmations, finality, and protection against attacks">
+    <link rel="stylesheet" href="../style.css">
+</head>
+<body>
+    <nav class="chapter-nav">
+        <a href="../index.html">Contents</a>
+        <span class="nav-separator">·</span>
+        <span class="volume-indicator">Volume V: The Path to Sustainability</span>
+    </nav>
+
+    <header class="chapter-header">
+        <p class="chapter-number">Chapter 37</p>
+        <h1>Defense Mechanisms</h1>
+        <p class="chapter-subtitle">Checkpoints, Confirmations, and Protection</p>
+    </header>
+
+    <main class="chapter-content">
+        <section>
+            <p class="chapter-intro">
+                Bitcoin has evolved multiple layers of defense against the threats described
+                in the previous chapter. Some are built into the protocol, others are social
+                or economic. This chapter examines confirmation requirements, checkpoints,
+                node hardening, and the broader security model that protects Bitcoin users.
+            </p>
+        </section>
+
+        <section>
+            <h2>37.1 Confirmation-Based Security</h2>
+
+            <div class="definition">
+                <p class="definition-title">Definition 37.1 (Confirmation)</p>
+                <p>
+                    A transaction has <strong>k confirmations</strong> when it is included
+                    in a block with k-1 blocks built on top of it. The first block containing
+                    the transaction is confirmation 1.
+                </p>
+            </div>
+
+            <div class="theorem">
+                <p class="theorem-title">Theorem 37.1 (Confirmation Security Model)</p>
+                <p>
+                    Confirmations provide probabilistic security:
+                </p>
+                <ul>
+                    <li>More confirmations = exponentially lower reversal probability</li>
+                    <li>Against attacker with hashrate q < 50%, k confirmations gives security ≈ (q/(1-q))<sup>k</sup></li>
+                    <li>6 confirmations (~1 hour): Standard for large transactions</li>
+                    <li>1 confirmation (~10 min): Often sufficient for small amounts</li>
+                </ul>
+            </div>
+
+            <div class="example">
+                <p class="example-title">Example 37.1 (Industry Standards)</p>
+                <table class="data-table">
+                    <thead>
+                        <tr>
+                            <th>Amount/Risk</th>
+                            <th>Confirmations</th>
+                            <th>Rationale</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>Small (<$1000)</td>
+                            <td>1-2</td>
+                            <td>Attack cost > value</td>
+                        </tr>
+                        <tr>
+                            <td>Medium ($1K-$100K)</td>
+                            <td>3-6</td>
+                            <td>Standard security</td>
+                        </tr>
+                        <tr>
+                            <td>Large (>$100K)</td>
+                            <td>6-12</td>
+                            <td>High-value protection</td>
+                        </tr>
+                        <tr>
+                            <td>Exchange deposits</td>
+                            <td>2-6</td>
+                            <td>Balance speed/security</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+
+            <figure>
+                <svg class="diagram" width="500" height="160" viewBox="0 0 500 160">
+                    <!-- Security vs confirmations -->
+                    <text x="250" y="20" text-anchor="middle" font-family="Georgia" font-size="10" font-weight="bold">Reversal Probability vs Confirmations</text>
+
+                    <!-- Axis -->
+                    <line x1="80" y1="130" x2="420" y2="130" stroke="#666"/>
+                    <line x1="80" y1="130" x2="80" y2="40" stroke="#666"/>
+
+                    <text x="250" y="150" text-anchor="middle" font-family="Georgia" font-size="8">Confirmations</text>
+                    <text x="60" y="85" text-anchor="middle" font-family="Georgia" font-size="8" transform="rotate(-90, 60, 85)">P(reversal)</text>
+
+                    <!-- Curve for q=25% -->
+                    <path d="M 80 60 Q 120 80 160 100 T 280 120 T 400 128" stroke="#c44" stroke-width="2" fill="none"/>
+                    <text x="420" y="125" font-family="Georgia" font-size="7" fill="#c44">q=25%</text>
+
+                    <!-- Curve for q=10% -->
+                    <path d="M 80 50 Q 100 90 130 115 T 200 128" stroke="#f39c12" stroke-width="2" fill="none"/>
+                    <text x="220" y="125" font-family="Georgia" font-size="7" fill="#f39c12">q=10%</text>
+
+                    <!-- Markers -->
+                    <text x="80" y="143" font-family="Georgia" font-size="7">0</text>
+                    <text x="136" y="143" font-family="Georgia" font-size="7">1</text>
+                    <text x="192" y="143" font-family="Georgia" font-size="7">2</text>
+                    <text x="248" y="143" font-family="Georgia" font-size="7">3</text>
+                    <text x="304" y="143" font-family="Georgia" font-size="7">4</text>
+                    <text x="360" y="143" font-family="Georgia" font-size="7">5</text>
+                    <text x="400" y="143" font-family="Georgia" font-size="7">6</text>
+                </svg>
+                <figcaption>Figure 37.1: Reversal probability drops exponentially with confirmations.</figcaption>
+            </figure>
+        </section>
+
+        <section>
+            <h2>37.2 Checkpoints</h2>
+
+            <div class="definition">
+                <p class="definition-title">Definition 37.2 (Checkpoint)</p>
+                <p>
+                    A <strong>checkpoint</strong> is a hardcoded (block height, block hash)
+                    pair in node software. The node rejects any chain that doesn't include
+                    the checkpoint block.
+                </p>
+            </div>
+
+            <div class="definition">
+                <p class="definition-title">Definition 37.3 (Historical Checkpoints)</p>
+                <p>
+                    Bitcoin Core historically included checkpoints:
+                </p>
+                <pre style="background: #f5f5f5; padding: 1rem; font-family: monospace; font-size: 0.85rem;">
+// From chainparams.cpp (historical)
+checkpointData = {
+    {11111,  "0x0000000069e244f73d78e8fd29ba2fd2..."},
+    {33333,  "0x000000002dd5588a74784eaa7ab0507a..."},
+    {74000,  "0x0000000000573993a3c9e41ce34471c0..."},
+    {105000, "0x00000000000291ce28027faea320c8d2..."},
+    // ... more checkpoints
+};</pre>
+            </div>
+
+            <div class="theorem">
+                <p class="theorem-title">Theorem 37.2 (Checkpoint Security)</p>
+                <p>
+                    Checkpoints provide:
+                </p>
+                <ul>
+                    <li><strong>DoS protection:</strong> Reject low-work fake chains quickly</li>
+                    <li><strong>Deep reorg prevention:</strong> Cannot reorg past checkpoint</li>
+                    <li><strong>Sync speedup:</strong> Skip some validation before checkpoint</li>
+                </ul>
+                <p>
+                    Tradeoff: Requires trusting checkpoint authors.
+                </p>
+            </div>
+
+            <div class="remark">
+                <p class="remark-title">Remark 37.1 (Checkpoint Controversy)</p>
+                <p>
+                    Checkpoints are controversial because they:
+                </p>
+                <ul>
+                    <li>Add trust in developers who set them</li>
+                    <li>Could theoretically be used maliciously</li>
+                    <li>Contradict "don't trust, verify" ethos</li>
+                </ul>
+                <p>
+                    Modern Bitcoin Core has de-emphasized checkpoints in favor of:
+                </p>
+                <ul>
+                    <li><strong>AssumeValid:</strong> Skip signature verification before known block</li>
+                    <li><strong>Headers-first sync:</strong> Verify PoW chain before downloading</li>
+                    <li><strong>Minimum chain work:</strong> Reject chains below threshold</li>
+                </ul>
+            </div>
+        </section>
+
+        <section>
+            <h2>37.3 Minimum Chain Work</h2>
+
+            <div class="definition">
+                <p class="definition-title">Definition 37.4 (Minimum Chain Work)</p>
+                <p>
+                    <strong>nMinimumChainWork</strong> is a hardcoded minimum cumulative
+                    proof-of-work a chain must have to be considered valid:
+                </p>
+                <pre style="background: #f5f5f5; padding: 1rem; font-family: monospace; font-size: 0.85rem;">
+// Approximate minimum chain work (increases with each release)
+nMinimumChainWork = 0x0000000000000000000000000000000000000000
+                    7f0000000000000000000000;</pre>
+                <p>
+                    Chains below this threshold are rejected without full validation.
+                </p>
+            </div>
+
+            <div class="theorem">
+                <p class="theorem-title">Theorem 37.3 (Minimum Work Protection)</p>
+                <p>
+                    Minimum chain work provides:
+                </p>
+                <ul>
+                    <li>Protection against low-work attack chains</li>
+                    <li>Faster sync (reject obviously fake chains early)</li>
+                    <li>No checkpoint-style trust (only requires past work exists)</li>
+                </ul>
+                <p>
+                    An attacker must match the minimum work to even be considered.
+                </p>
+            </div>
+        </section>
+
+        <section>
+            <h2>37.4 AssumeValid and AssumeUTXO</h2>
+
+            <div class="definition">
+                <p class="definition-title">Definition 37.5 (AssumeValid)</p>
+                <p>
+                    <strong>AssumeValid</strong> skips signature verification for blocks
+                    before a known "valid" block:
+                </p>
+                <ul>
+                    <li>Still validates all other consensus rules</li>
+                    <li>Still builds UTXO set</li>
+                    <li>Just skips ECDSA checks (most CPU-intensive part)</li>
+                    <li>Can be disabled with -assumevalid=0</li>
+                </ul>
+            </div>
+
+            <div class="definition">
+                <p class="definition-title">Definition 37.6 (AssumeUTXO)</p>
+                <p>
+                    <strong>AssumeUTXO</strong> allows instant sync by assuming a UTXO
+                    set snapshot is valid:
+                </p>
+                <ol>
+                    <li>Download UTXO snapshot (serialized state)</li>
+                    <li>Verify hash matches hardcoded value</li>
+                    <li>Begin syncing from snapshot height immediately</li>
+                    <li>Background-validate full history eventually</li>
+                </ol>
+            </div>
+
+            <figure>
+                <svg class="diagram" width="500" height="180" viewBox="0 0 500 180">
+                    <!-- Timeline -->
+                    <line x1="50" y1="90" x2="450" y2="90" stroke="#666" stroke-width="2"/>
+
+                    <!-- Genesis -->
+                    <circle cx="70" cy="90" r="8" fill="#5a8f5a"/>
+                    <text x="70" y="115" text-anchor="middle" font-family="Georgia" font-size="7">Genesis</text>
+
+                    <!-- AssumeValid point -->
+                    <circle cx="250" cy="90" r="8" fill="#f39c12"/>
+                    <text x="250" y="75" text-anchor="middle" font-family="Georgia" font-size="7" fill="#f39c12">AssumeValid</text>
+                    <text x="250" y="115" text-anchor="middle" font-family="Georgia" font-size="7">Skip sigs</text>
+
+                    <!-- AssumeUTXO point -->
+                    <circle cx="350" cy="90" r="8" fill="#3498db"/>
+                    <text x="350" y="75" text-anchor="middle" font-family="Georgia" font-size="7" fill="#3498db">AssumeUTXO</text>
+                    <text x="350" y="115" text-anchor="middle" font-family="Georgia" font-size="7">Snapshot</text>
+
+                    <!-- Current tip -->
+                    <circle cx="430" cy="90" r="8" fill="#28a745"/>
+                    <text x="430" y="115" text-anchor="middle" font-family="Georgia" font-size="7">Tip</text>
+
+                    <!-- Regions -->
+                    <rect x="70" y="130" width="180" height="20" fill="#ffe8e8" stroke="#c44"/>
+                    <text x="160" y="145" text-anchor="middle" font-family="Georgia" font-size="7">Skip ECDSA verification</text>
+
+                    <rect x="350" y="130" width="80" height="20" fill="#d4edda" stroke="#28a745"/>
+                    <text x="390" y="145" text-anchor="middle" font-family="Georgia" font-size="7">Full validation</text>
+
+                    <rect x="70" y="155" width="280" height="15" fill="#e8f4e8" stroke="#5a8f5a"/>
+                    <text x="210" y="167" text-anchor="middle" font-family="Georgia" font-size="6">Background validation (AssumeUTXO)</text>
+                </svg>
+                <figcaption>Figure 37.2: AssumeValid and AssumeUTXO sync optimization.</figcaption>
+            </figure>
+        </section>
+
+        <section>
+            <h2>37.5 Node Hardening</h2>
+
+            <div class="definition">
+                <p class="definition-title">Definition 37.7 (Eclipse Attack Mitigations)</p>
+                <p>
+                    Bitcoin Core includes multiple eclipse attack defenses:
+                </p>
+                <ul>
+                    <li><strong>Bucketed peer storage:</strong> Peers stored in buckets by IP range</li>
+                    <li><strong>Outbound diversity:</strong> Connect to different /16 networks</li>
+                    <li><strong>Anchor connections:</strong> Remember peers across restarts</li>
+                    <li><strong>Feeler connections:</strong> Periodically test new peers</li>
+                    <li><strong>Peer eviction logic:</strong> Protect diverse, long-standing connections</li>
+                </ul>
+            </div>
+
+            <div class="definition">
+                <p class="definition-title">Definition 37.8 (Tor and Privacy)</p>
+                <p>
+                    Running over Tor provides additional protection:
+                </p>
+                <ul>
+                    <li>IP address hidden from peers</li>
+                    <li>Harder to target specific node</li>
+                    <li>Onion-only mode possible (-onlynet=onion)</li>
+                </ul>
+                <p>
+                    Tradeoff: Latency increase, potential Tor-level attacks.
+                </p>
+            </div>
+        </section>
+
+        <section>
+            <h2>37.6 Economic Security</h2>
+
+            <div class="theorem">
+                <p class="theorem-title">Theorem 37.4 (Security Budget)</p>
+                <p>
+                    Bitcoin's security is funded by:
+                </p>
+                <p style="text-align: center; font-family: 'Times New Roman', serif;">
+                    Security Budget = Block Subsidy + Transaction Fees
+                </p>
+                <p>
+                    This budget pays miners to provide honest hashrate, making attacks expensive.
+                </p>
+            </div>
+
+            <div class="definition">
+                <p class="definition-title">Definition 37.9 (Attack Cost Asymmetry)</p>
+                <p>
+                    A key security property: attacking costs more than defending because:
+                </p>
+                <ul>
+                    <li>Attacker must match honest hashrate + some margin</li>
+                    <li>Attacker pays for hardware, electricity, opportunity cost</li>
+                    <li>Honest miners are paid (block rewards)</li>
+                    <li>Attacker revenue limited to double-spend value</li>
+                </ul>
+            </div>
+
+            <div class="example">
+                <p class="example-title">Example 37.2 (Cost Comparison)</p>
+                <table class="data-table">
+                    <thead>
+                        <tr>
+                            <th></th>
+                            <th>Honest Miner</th>
+                            <th>Attacker</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>Revenue</td>
+                            <td>Block rewards + fees</td>
+                            <td>Double-spend value</td>
+                        </tr>
+                        <tr>
+                            <td>Cost</td>
+                            <td>Hardware + electricity</td>
+                            <td>Hardware + electricity</td>
+                        </tr>
+                        <tr>
+                            <td>Duration</td>
+                            <td>Ongoing</td>
+                            <td>One-time</td>
+                        </tr>
+                        <tr>
+                            <td>Risk</td>
+                            <td>Market fluctuation</td>
+                            <td>Detection, prosecution, price crash</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </section>
+
+        <section>
+            <h2>37.7 Social Layer Defenses</h2>
+
+            <div class="definition">
+                <p class="definition-title">Definition 37.10 (Social Consensus)</p>
+                <p>
+                    Beyond technical rules, Bitcoin has social defenses:
+                </p>
+                <ul>
+                    <li><strong>User Activated Soft Fork:</strong> Users can reject miner misbehavior</li>
+                    <li><strong>Exchange monitoring:</strong> Detect and respond to attacks</li>
+                    <li><strong>Community coordination:</strong> Share attack intelligence</li>
+                    <li><strong>Emergency response:</strong> Coordinate defensive forks if needed</li>
+                </ul>
+            </div>
+
+            <div class="remark">
+                <p class="remark-title">Remark 37.2 (The 2013 Fork Response)</p>
+                <p>
+                    When a bug caused a 24-block reorg in 2013:
+                </p>
+                <ul>
+                    <li>Developers, miners, and businesses coordinated on IRC</li>
+                    <li>Miners voluntarily downgraded to maintain consensus</li>
+                    <li>Crisis resolved within hours</li>
+                    <li>Demonstrated social layer's importance</li>
+                </ul>
+            </div>
+        </section>
+
+        <section>
+            <h2>37.8 Finality Considerations</h2>
+
+            <div class="definition">
+                <p class="definition-title">Definition 37.11 (Probabilistic vs Deterministic Finality)</p>
+                <p>
+                    <strong>Probabilistic finality</strong> (Bitcoin):
+                </p>
+                <ul>
+                    <li>Reversal probability decreases exponentially with confirmations</li>
+                    <li>Never reaches zero (theoretically)</li>
+                    <li>Practical finality after sufficient confirmations</li>
+                </ul>
+                <p>
+                    <strong>Deterministic finality</strong> (some other systems):
+                </p>
+                <ul>
+                    <li>Block is final after specific condition met</li>
+                    <li>Cannot be reversed without breaking protocol</li>
+                    <li>Often requires different consensus mechanism</li>
+                </ul>
+            </div>
+
+            <div class="theorem">
+                <p class="theorem-title">Theorem 37.5 (Practical Finality)</p>
+                <p>
+                    For practical purposes, Bitcoin transactions are "final" when:
+                </p>
+                <ul>
+                    <li>Cost of reversal exceeds transaction value</li>
+                    <li>Typically 6 confirmations for large amounts</li>
+                    <li>Even fewer for amounts below attack cost threshold</li>
+                </ul>
+            </div>
+        </section>
+
+        <section class="exercises">
+            <h2>Exercises</h2>
+
+            <div class="exercise">
+                <p class="exercise-title">Exercise 37.1</p>
+                <p>
+                    A merchant accepts payment of $10,000 with 3 confirmations. Estimate
+                    the minimum hashrate an attacker needs to have >50% chance of successful
+                    double-spend. Is this attack economically rational?
+                </p>
+            </div>
+
+            <div class="exercise">
+                <p class="exercise-title">Exercise 37.2</p>
+                <p>
+                    Explain the security tradeoff between AssumeValid and full verification.
+                    Under what threat model does AssumeValid fail to protect users?
+                </p>
+            </div>
+
+            <div class="exercise">
+                <p class="exercise-title">Exercise 37.3</p>
+                <p>
+                    Design an eclipse attack detection system. What metrics would you
+                    monitor? How would you respond to detected attacks?
+                </p>
+            </div>
+
+            <div class="exercise">
+                <p class="exercise-title">Exercise 37.4</p>
+                <p>
+                    Compare Bitcoin's probabilistic finality to Ethereum's Casper finality
+                    gadget. What are the tradeoffs of each approach?
+                </p>
+            </div>
+        </section>
+
+        <nav class="chapter-navigation">
+            <a href="36-security-threats.html" class="prev-chapter">← Chapter 36: Security Threats</a>
+            <a href="38-security-budget.html" class="next-chapter">Chapter 38: Security Budget →</a>
+        </nav>
+    </main>
+
+    <footer>
+        <p>Elementary Bitcoin · Volume V: The Path to Sustainability (Draft)</p>
+    </footer>
+</body>
+</html>

--- a/chapters/38-security-budget.html
+++ b/chapters/38-security-budget.html
@@ -1,0 +1,778 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Chapter 38: The Security Budget Problem - Elementary Bitcoin</title>
+    <link rel="stylesheet" href="../css/style.css">
+    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>&#8383;</text></svg>">
+</head>
+<body>
+    <nav class="chapter-nav">
+        <a href="37-defense-mechanisms.html" class="prev">&#8592; Chapter 37: Defense Mechanisms</a>
+        <a href="../index.html" class="home">&#8962; Home</a>
+        <a href="39-quantum-resistance.html" class="next">Chapter 39: Quantum Resistance &#8594;</a>
+    </nav>
+
+    <article class="chapter">
+        <header class="chapter-header">
+            <p class="volume-title">Volume V: The Path to a Sustainable Future</p>
+            <p class="part-title">Part XV: Long-Term Security</p>
+            <h1>Chapter 38: The Security Budget Problem</h1>
+            <p class="subtitle">Will Bitcoin Remain Secure as the Subsidy Diminishes?</p>
+        </header>
+
+        <blockquote class="chapter-quote">
+            "The security of Bitcoin depends on the total hashpower, which depends on miner revenue. As the block subsidy decreases, transaction fees must increase to maintain security—but will they?"
+            <cite>— The central question of Bitcoin's long-term sustainability</cite>
+        </blockquote>
+
+        <section id="introduction">
+            <h2>The Looming Question</h2>
+
+            <p>Bitcoin's security model faces a fundamental challenge: the block subsidy that currently funds most mining operations is designed to eventually reach zero. This creates what critics call the "security budget problem"—will transaction fees alone provide sufficient incentive for miners to secure the network?</p>
+
+            <div class="key-concept">
+                <h3>The Core Tension</h3>
+                <p>Bitcoin's fixed supply (21 million coins) is fundamental to its monetary properties, but this same property means miner revenue from new coins will eventually end. The network must transition from subsidy-funded security to fee-funded security.</p>
+            </div>
+
+            <p>This chapter examines the mathematics, economics, and game theory of Bitcoin's long-term security budget, analyzing whether the network can sustainably protect trillions of dollars of value with fees alone.</p>
+        </section>
+
+        <section id="subsidy-schedule">
+            <h2>The Subsidy Decline</h2>
+
+            <h3>Bitcoin's Emission Schedule</h3>
+
+            <p>Bitcoin's block subsidy halves approximately every four years (210,000 blocks):</p>
+
+            <table class="data-table">
+                <thead>
+                    <tr>
+                        <th>Halving</th>
+                        <th>Year</th>
+                        <th>Block Reward</th>
+                        <th>Daily Issuance</th>
+                        <th>Annual Inflation</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>Genesis</td>
+                        <td>2009</td>
+                        <td>50 BTC</td>
+                        <td>7,200 BTC</td>
+                        <td>N/A</td>
+                    </tr>
+                    <tr>
+                        <td>1st</td>
+                        <td>2012</td>
+                        <td>25 BTC</td>
+                        <td>3,600 BTC</td>
+                        <td>~8.4%</td>
+                    </tr>
+                    <tr>
+                        <td>2nd</td>
+                        <td>2016</td>
+                        <td>12.5 BTC</td>
+                        <td>1,800 BTC</td>
+                        <td>~4.0%</td>
+                    </tr>
+                    <tr>
+                        <td>3rd</td>
+                        <td>2020</td>
+                        <td>6.25 BTC</td>
+                        <td>900 BTC</td>
+                        <td>~1.8%</td>
+                    </tr>
+                    <tr>
+                        <td>4th</td>
+                        <td>2024</td>
+                        <td>3.125 BTC</td>
+                        <td>450 BTC</td>
+                        <td>~0.85%</td>
+                    </tr>
+                    <tr>
+                        <td>5th</td>
+                        <td>~2028</td>
+                        <td>1.5625 BTC</td>
+                        <td>225 BTC</td>
+                        <td>~0.4%</td>
+                    </tr>
+                    <tr>
+                        <td>10th</td>
+                        <td>~2048</td>
+                        <td>~0.049 BTC</td>
+                        <td>~7 BTC</td>
+                        <td>~0.01%</td>
+                    </tr>
+                    <tr>
+                        <td>Final</td>
+                        <td>~2140</td>
+                        <td>0 BTC</td>
+                        <td>0 BTC</td>
+                        <td>0%</td>
+                    </tr>
+                </tbody>
+            </table>
+
+            <h3>The Mathematical Reality</h3>
+
+            <div class="formula-block">
+                <p><strong>Subsidy at height h:</strong></p>
+                <code>subsidy(h) = 50 × 10⁸ satoshis >> floor(h / 210,000)</code>
+                <p><strong>Where:</strong></p>
+                <ul>
+                    <li>>> = right bit shift (halving)</li>
+                    <li>210,000 blocks ≈ 4 years</li>
+                </ul>
+            </div>
+
+            <p>By 2032, the block subsidy will be just 0.78125 BTC—less than a typical fee might be for a high-priority transaction today. By 2048, it will be negligible. The transition to a fee-based security model isn't a distant concern; it's already underway.</p>
+        </section>
+
+        <section id="security-budget-defined">
+            <h2>Defining the Security Budget</h2>
+
+            <h3>What Is the Security Budget?</h3>
+
+            <p>The security budget is the total revenue available to miners, which determines how much they can profitably spend on mining equipment and electricity:</p>
+
+            <div class="formula-block">
+                <p><strong>Security Budget:</strong></p>
+                <code>Security Budget = (Block Subsidy + Transaction Fees) × Blocks per Year</code>
+                <p><strong>Annual calculation:</strong></p>
+                <code>~52,560 blocks × (subsidy + avg_fees) = Annual Miner Revenue</code>
+            </div>
+
+            <h3>Why It Matters</h3>
+
+            <p>The security budget determines:</p>
+
+            <ol>
+                <li><strong>Attack Cost:</strong> How expensive it is to mount a 51% attack</li>
+                <li><strong>Hashrate Level:</strong> Total computational power securing the network</li>
+                <li><strong>Miner Decentralization:</strong> Whether mining remains profitable for diverse participants</li>
+                <li><strong>Finality Confidence:</strong> How many confirmations users need for security</li>
+            </ol>
+
+            <div class="key-concept">
+                <h3>The Cost of Attack Formula</h3>
+                <code>Attack Cost ≈ Security Budget × Attack Duration / 365</code>
+                <p>A network with a $10 billion annual security budget costs approximately $27 million per day to attack at the 51% threshold. If the security budget drops to $1 billion, attacks become 10x cheaper.</p>
+            </div>
+        </section>
+
+        <section id="historical-fees">
+            <h2>Historical Fee Analysis</h2>
+
+            <h3>Fee Revenue Over Time</h3>
+
+            <p>Transaction fees have historically been a small fraction of miner revenue:</p>
+
+            <table class="data-table">
+                <thead>
+                    <tr>
+                        <th>Year</th>
+                        <th>Avg Fee (BTC)</th>
+                        <th>Total Fees (BTC)</th>
+                        <th>Fee % of Revenue</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>2015</td>
+                        <td>0.00007</td>
+                        <td>~4,000</td>
+                        <td>0.3%</td>
+                    </tr>
+                    <tr>
+                        <td>2017</td>
+                        <td>0.0015</td>
+                        <td>~18,000</td>
+                        <td>2.7%</td>
+                    </tr>
+                    <tr>
+                        <td>2021</td>
+                        <td>0.0003</td>
+                        <td>~15,000</td>
+                        <td>4.5%</td>
+                    </tr>
+                    <tr>
+                        <td>2023</td>
+                        <td>0.0002</td>
+                        <td>~8,000</td>
+                        <td>2.5%</td>
+                    </tr>
+                    <tr>
+                        <td>2024 (Ordinals)</td>
+                        <td>0.0008</td>
+                        <td>~20,000</td>
+                        <td>12%</td>
+                    </tr>
+                </tbody>
+            </table>
+
+            <h3>Fee Spikes and Their Causes</h3>
+
+            <p>Fees have spiked dramatically during periods of high demand:</p>
+
+            <ul>
+                <li><strong>December 2017:</strong> $55 average fee during bull market peak</li>
+                <li><strong>April 2021:</strong> $62 average fee during institutional adoption wave</li>
+                <li><strong>May 2023:</strong> $31 average fee during BRC-20 inscription mania</li>
+                <li><strong>April 2024:</strong> $127 peak fee during Runes launch</li>
+            </ul>
+
+            <div class="warning-box">
+                <h4>The Volatility Problem</h4>
+                <p>Fee revenue is highly volatile, spiking 100x during demand surges and collapsing during quiet periods. This makes it difficult for miners to plan long-term investments in hardware and infrastructure.</p>
+            </div>
+        </section>
+
+        <section id="fee-market-dynamics">
+            <h2>Fee Market Dynamics</h2>
+
+            <h3>How Fees Are Determined</h3>
+
+            <p>Bitcoin's fee market is a first-price auction where users bid for limited block space:</p>
+
+            <div class="code-block">
+<pre>
+Block Space Supply (per block):
+├── Weight limit: 4,000,000 weight units
+├── Typical capacity: ~2,500-4,000 transactions
+└── Daily capacity: ~360,000-576,000 transactions
+
+Fee Determination:
+├── Users set fee rate (sat/vB)
+├── Miners sort by fee rate
+├── Highest bidders included first
+└── Market clears at marginal transaction
+</pre>
+            </div>
+
+            <h3>The Blockspace Demand Curve</h3>
+
+            <p>Demand for blockspace comes from multiple sources:</p>
+
+            <ol>
+                <li><strong>High-value transfers:</strong> Exchanges, institutions, large holders—price insensitive</li>
+                <li><strong>Time-sensitive payments:</strong> Commerce, payroll—moderately price sensitive</li>
+                <li><strong>Consolidation:</strong> UTXO management—price sensitive, can wait</li>
+                <li><strong>Data inscription:</strong> Ordinals, BRC-20—highly variable demand</li>
+                <li><strong>Layer 2 settlements:</strong> Lightning channel opens/closes—batched, price sensitive</li>
+            </ol>
+
+            <h3>Will Demand Be Sufficient?</h3>
+
+            <p>The critical question: as Bitcoin's value increases, will demand for on-chain transactions scale proportionally?</p>
+
+            <div class="key-concept">
+                <h3>The Scaling Paradox</h3>
+                <p>If Bitcoin succeeds as a global reserve asset, most transactions will occur on Layer 2 solutions. This increases Bitcoin's value but potentially reduces on-chain fee revenue. Success could undermine the security budget.</p>
+            </div>
+        </section>
+
+        <section id="economic-models">
+            <h2>Economic Models and Projections</h2>
+
+            <h3>Model 1: Linear Fee Growth</h3>
+
+            <p>Optimistic assumption: fees grow proportionally with Bitcoin's market cap.</p>
+
+            <div class="formula-block">
+                <p><strong>If Bitcoin reaches $10 trillion market cap:</strong></p>
+                <code>Required security budget: ~1% = $100 billion/year</code>
+                <code>Required fee revenue: ~$274 million/day</code>
+                <code>Required fee per block: ~$1.9 million</code>
+                <code>At 2,500 tx/block: ~$760 per transaction</code>
+            </div>
+
+            <p>This model requires average fees of hundreds of dollars—sustainable only if Bitcoin is used exclusively for high-value settlement.</p>
+
+            <h3>Model 2: Constant Dollar Security</h3>
+
+            <p>Conservative assumption: security budget stays constant in dollar terms.</p>
+
+            <div class="formula-block">
+                <p><strong>If security budget stays at ~$15 billion/year:</strong></p>
+                <code>Post-subsidy fee requirement: $41 million/day</code>
+                <code>Required fee per block: ~$285,000</code>
+                <code>At 2,500 tx/block: ~$114 per transaction</code>
+            </div>
+
+            <h3>Model 3: Security Percentage Decline</h3>
+
+            <p>Historical observation: security spending as a percentage of market cap has declined:</p>
+
+            <table class="data-table">
+                <thead>
+                    <tr>
+                        <th>Year</th>
+                        <th>Market Cap</th>
+                        <th>Security Budget</th>
+                        <th>Security %</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>2015</td>
+                        <td>$4B</td>
+                        <td>$350M</td>
+                        <td>8.75%</td>
+                    </tr>
+                    <tr>
+                        <td>2018</td>
+                        <td>$70B</td>
+                        <td>$5.5B</td>
+                        <td>7.9%</td>
+                    </tr>
+                    <tr>
+                        <td>2021</td>
+                        <td>$1T</td>
+                        <td>$17B</td>
+                        <td>1.7%</td>
+                    </tr>
+                    <tr>
+                        <td>2024</td>
+                        <td>$1.3T</td>
+                        <td>$15B</td>
+                        <td>1.15%</td>
+                    </tr>
+                </tbody>
+            </table>
+
+            <p>If this trend continues, security as a percentage of value secured could fall below 0.5%—potentially inadequate for a global reserve asset.</p>
+        </section>
+
+        <section id="game-theory">
+            <h2>Game Theoretic Considerations</h2>
+
+            <h3>The Miner's Dilemma</h3>
+
+            <p>In a low-subsidy environment, miners face new incentive challenges:</p>
+
+            <div class="code-block">
+<pre>
+Fee-Only Mining Game Theory:
+├── Fee Sniping
+│   ├── Profitable to re-mine recent blocks
+│   ├── If fees >> subsidy, orphaning becomes attractive
+│   └── Can cause chain instability
+│
+├── Selfish Mining Amplified
+│   ├── Fee variance increases block value variance
+│   ├── Lucky blocks (high fees) worth attacking
+│   └── Threshold for profitability may decrease
+│
+├── Transaction Withholding
+│   ├── Miners may hold high-fee transactions
+│   ├── Wait for own block to maximize revenue
+│   └── Increases confirmation time variance
+│
+└── Empty Block Mining
+    ├── In fee-only regime, empty blocks forfeit all revenue
+    ├── Actually improves fee market health
+    └── But indicates something wrong if common
+</pre>
+            </div>
+
+            <h3>Fee Sniping Attack</h3>
+
+            <p>When fees dominate block rewards, re-mining the previous block becomes attractive:</p>
+
+            <div class="formula-block">
+                <p><strong>Fee Sniping Condition:</strong></p>
+                <code>Attack profitable when: Fees_block_n > Subsidy + Expected_Fees_block_n+1</code>
+                <p>In a mature fee market with minimal subsidy, blocks with unusually high fees become attack targets.</p>
+            </div>
+
+            <h3>Mitigation: OP_CSV and Locktime</h3>
+
+            <p>Bitcoin Core includes fee sniping mitigation by default:</p>
+
+            <div class="code-block">
+<pre>
+// Default locktime set to current block height
+// Prevents transaction from being mined in re-org of recent blocks
+nLockTime = chainActive.Height();
+
+// Random offset to avoid fingerprinting
+if (GetRandInt(10) == 0)
+    nLockTime = std::max(0, (int)nLockTime - GetRandInt(100));
+</pre>
+            </div>
+
+            <p>This makes transactions invalid in any re-org attempting to steal fees from recent blocks.</p>
+        </section>
+
+        <section id="proposed-solutions">
+            <h2>Proposed Solutions</h2>
+
+            <h3>Solution 1: Do Nothing (Market Will Provide)</h3>
+
+            <p>The dominant view among Bitcoin maximalists:</p>
+
+            <ul>
+                <li>Bitcoin's value will increase enough that fees in dollar terms remain sufficient</li>
+                <li>Blockspace is genuinely scarce; market will price it appropriately</li>
+                <li>New use cases (Ordinals, etc.) demonstrate organic demand</li>
+                <li>Layer 2 anchor transactions will provide steady base demand</li>
+            </ul>
+
+            <div class="info-box">
+                <h4>The "It Will Work Out" Argument</h4>
+                <p>Bitcoin has survived every challenge so far. The fee market, while imperfect, has functioned for 15 years. As Bitcoin becomes more valuable, rational users will pay appropriate fees for the security they require.</p>
+            </div>
+
+            <h3>Solution 2: Increase Block Size</h3>
+
+            <p>Increase transaction throughput to compensate for lower per-transaction fees:</p>
+
+            <div class="formula-block">
+                <code>Total Fees = Fee_per_tx × Transactions_per_block</code>
+                <p>If fee per transaction drops 90%, increase capacity 10x to maintain revenue.</p>
+            </div>
+
+            <p><strong>Problems:</strong></p>
+            <ul>
+                <li>Reduces node decentralization</li>
+                <li>Contentious (see SegWit2x failure)</li>
+                <li>May not solve problem—fees might drop proportionally</li>
+            </ul>
+
+            <h3>Solution 3: Tail Emission (Perpetual Inflation)</h3>
+
+            <p>The most controversial proposal: modify Bitcoin to have permanent low-level issuance.</p>
+
+            <div class="warning-box">
+                <h4>The Tail Emission Debate</h4>
+                <p>Monero implements tail emission (0.6 XMR per block forever). Some researchers argue Bitcoin needs similar. This would fundamentally change Bitcoin's monetary properties and is considered a non-starter by most of the community.</p>
+            </div>
+
+            <p>Arguments for tail emission:</p>
+            <ul>
+                <li>Provides predictable miner revenue forever</li>
+                <li>Low inflation (0.1-0.5%) has minimal monetary impact</li>
+                <li>Lost coins make true inflation even lower</li>
+                <li>Security is more important than perfect scarcity</li>
+            </ul>
+
+            <p>Arguments against:</p>
+            <ul>
+                <li>Breaks social contract of 21 million cap</li>
+                <li>Sets precedent for further monetary changes</li>
+                <li>Fee market should handle this—if it can't, that's valuable information</li>
+                <li>Would require extremely contentious hard fork</li>
+            </ul>
+
+            <h3>Solution 4: Merged Mining</h3>
+
+            <p>Miners earn revenue from multiple chains simultaneously:</p>
+
+            <div class="code-block">
+<pre>
+Merged Mining Revenue Model:
+├── Bitcoin block reward: 3.125 BTC
+├── Namecoin (merged): 0.01 NMC
+├── RSK (merged): fees from sidechain
+├── Potential future chains: additional revenue
+└── Total revenue > Bitcoin alone
+</pre>
+            </div>
+
+            <p>This supplements miner revenue without changing Bitcoin's protocol.</p>
+
+            <h3>Solution 5: Fee Smoothing Mechanisms</h3>
+
+            <p>Protocol changes to reduce fee variance:</p>
+
+            <ul>
+                <li><strong>Fee averaging:</strong> Distribute fees across multiple blocks</li>
+                <li><strong>Fee burning:</strong> Remove portion of fees from circulation (deflationary pressure)</li>
+                <li><strong>Fee futures:</strong> Allow pre-payment for future block inclusion</li>
+            </ul>
+
+            <p>These reduce miner incentive problems but require consensus changes.</p>
+
+            <h3>Solution 6: Layer 2 Dependency</h3>
+
+            <p>Embrace that most transactions occur off-chain:</p>
+
+            <div class="code-block">
+<pre>
+Layer 2 Fee Model:
+├── Lightning Network
+│   ├── Channel opens/closes: high fees acceptable
+│   ├── Millions of transactions per channel lifetime
+│   └── Amortized fee per payment: near-zero
+│
+├── Ark/Statechains
+│   ├── Periodic on-chain settlements
+│   └── Batch many users into single transactions
+│
+└── Sidechains
+    ├── Peg-in/peg-out transactions
+    └── Independent fee markets on sidechains
+</pre>
+            </div>
+
+            <p>If each Lightning channel represents 10,000 off-chain payments, users can justify $100+ fees for channel management.</p>
+        </section>
+
+        <section id="security-requirements">
+            <h2>How Much Security Is Enough?</h2>
+
+            <h3>Defining "Sufficient" Security</h3>
+
+            <p>Security requirements depend on the threat model:</p>
+
+            <table class="data-table">
+                <thead>
+                    <tr>
+                        <th>Attacker</th>
+                        <th>Budget</th>
+                        <th>Required Defense</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>Individual criminal</td>
+                        <td>$1-10M</td>
+                        <td>~$50M/year security budget</td>
+                    </tr>
+                    <tr>
+                        <td>Criminal organization</td>
+                        <td>$10-100M</td>
+                        <td>~$500M/year security budget</td>
+                    </tr>
+                    <tr>
+                        <td>Corporation</td>
+                        <td>$100M-1B</td>
+                        <td>~$5B/year security budget</td>
+                    </tr>
+                    <tr>
+                        <td>Nation state</td>
+                        <td>$1-100B</td>
+                        <td>~$50B+/year security budget</td>
+                    </tr>
+                </tbody>
+            </table>
+
+            <h3>The Nation State Question</h3>
+
+            <p>If Bitcoin becomes a global reserve asset holding $10+ trillion in value, it must resist nation-state attacks. This requires:</p>
+
+            <div class="formula-block">
+                <p><strong>Nation-State Resistance:</strong></p>
+                <code>Attack cost > (Nation GDP × Political will coefficient)</code>
+                <p>For major powers with $20T+ GDP, Bitcoin likely needs $50B+ annual security budget to provide meaningful deterrence.</p>
+            </div>
+
+            <h3>Opportunity Cost Defense</h3>
+
+            <p>The cost of attack includes more than just hardware:</p>
+
+            <ul>
+                <li><strong>Hardware acquisition:</strong> Buying/building 51% of hashrate</li>
+                <li><strong>Opportunity cost:</strong> Revenue foregone by attacking instead of mining honestly</li>
+                <li><strong>Retaliation cost:</strong> Network response (PoW change, social coordination)</li>
+                <li><strong>Value destruction:</strong> Attacker's own holdings lose value</li>
+            </ul>
+
+            <p>These multipliers mean effective security may be higher than raw budget suggests.</p>
+        </section>
+
+        <section id="ordinals-impact">
+            <h2>Ordinals and the Fee Market</h2>
+
+            <h3>An Unexpected Demand Driver</h3>
+
+            <p>The emergence of Ordinals, BRC-20 tokens, and Runes has dramatically impacted the fee market:</p>
+
+            <table class="data-table">
+                <thead>
+                    <tr>
+                        <th>Period</th>
+                        <th>Protocol</th>
+                        <th>Fee Impact</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>Q1 2023</td>
+                        <td>Ordinals inscriptions</td>
+                        <td>Fees spike 5-10x</td>
+                    </tr>
+                    <tr>
+                        <td>Q2 2023</td>
+                        <td>BRC-20 mania</td>
+                        <td>$30+ average fees</td>
+                    </tr>
+                    <tr>
+                        <td>Q2 2024</td>
+                        <td>Runes launch</td>
+                        <td>$100+ fees, miners earn 4x normal</td>
+                    </tr>
+                </tbody>
+            </table>
+
+            <h3>Lessons for the Fee Market</h3>
+
+            <div class="key-concept">
+                <h3>Demand Is Unpredictable</h3>
+                <p>No one predicted Ordinals. New use cases can emerge that dramatically increase blockspace demand. The fee market may be more robust than models assuming only monetary transactions.</p>
+            </div>
+
+            <p>Counter-arguments:</p>
+            <ul>
+                <li>Inscription demand is speculative, not sustainable</li>
+                <li>May represent temporary fad, not permanent demand</li>
+                <li>Competes with monetary use cases, potentially pricing them out</li>
+            </ul>
+        </section>
+
+        <section id="timeline">
+            <h2>The Transition Timeline</h2>
+
+            <h3>When Does This Become Critical?</h3>
+
+            <div class="code-block">
+<pre>
+Security Budget Timeline:
+│
+├── 2024-2028: Subsidy = 3.125 BTC
+│   ├── Fees typically 5-15% of revenue
+│   ├── Plenty of runway
+│   └── Problem visible but not urgent
+│
+├── 2028-2032: Subsidy = 1.5625 BTC
+│   ├── Fees need to be 20-30% of revenue
+│   ├── Fee market becomes more important
+│   └── First real test of fee sustainability
+│
+├── 2032-2040: Subsidy < 1 BTC
+│   ├── Fees must dominate revenue
+│   ├── $100K+ BTC price helps
+│   └── Fee sniping becomes real concern
+│
+└── 2040+: Subsidy negligible
+    ├── Fees are ~100% of revenue
+    ├── All theoretical concerns become practical
+    └── Network has either adapted or hasn't
+</pre>
+            </div>
+
+            <h3>The Graduation Test</h3>
+
+            <p>Each halving is a test: can the network maintain security with reduced subsidy? So far, Bitcoin has passed every test:</p>
+
+            <ul>
+                <li><strong>2012:</strong> First halving, hashrate continued growing</li>
+                <li><strong>2016:</strong> Second halving, hashrate 10x higher than pre-halving</li>
+                <li><strong>2020:</strong> Third halving, hashrate reached new ATH within months</li>
+                <li><strong>2024:</strong> Fourth halving, network remains secure</li>
+            </ul>
+
+            <p>This track record provides evidence—but not proof—that future halvings will be manageable.</p>
+        </section>
+
+        <section id="scenarios">
+            <h2>Future Scenarios</h2>
+
+            <h3>Scenario 1: Fee Market Success</h3>
+
+            <p>The optimistic path:</p>
+            <ul>
+                <li>Bitcoin reaches $500K+ per coin</li>
+                <li>Layer 2 grows to millions of users, anchor transactions valuable</li>
+                <li>Average fee of $50-100 is acceptable for settlement layer</li>
+                <li>Ordinals/smart contract demand provides additional revenue</li>
+                <li>Security budget maintains nation-state resistance</li>
+            </ul>
+
+            <h3>Scenario 2: Gradual Decline</h3>
+
+            <p>The concerning path:</p>
+            <ul>
+                <li>Bitcoin becomes store of value with minimal transactions</li>
+                <li>Layer 2 captures 99% of activity, few anchor transactions</li>
+                <li>Fee revenue insufficient, hashrate declines</li>
+                <li>Network remains functional but vulnerable to well-funded attacks</li>
+                <li>Users accept longer confirmation times, higher confirmation requirements</li>
+            </ul>
+
+            <h3>Scenario 3: Crisis and Adaptation</h3>
+
+            <p>The transformative path:</p>
+            <ul>
+                <li>Security budget drops to dangerous levels</li>
+                <li>Attack occurs, demonstrating real risk</li>
+                <li>Community faces difficult choices</li>
+                <li>Either: tail emission debate revived, or new demand sources emerge</li>
+                <li>Crisis forces innovation or fundamental change</li>
+            </ul>
+        </section>
+
+        <section id="research-directions">
+            <h2>Active Research</h2>
+
+            <h3>Fee Market Design</h3>
+
+            <p>Researchers are studying improved fee mechanisms:</p>
+
+            <ul>
+                <li><strong>EIP-1559 style:</strong> Base fee + tip, smoother pricing</li>
+                <li><strong>Fee futures:</strong> Pre-commit to future block inclusion</li>
+                <li><strong>Batch auctions:</strong> More efficient price discovery</li>
+            </ul>
+
+            <h3>Alternative Security Models</h3>
+
+            <ul>
+                <li><strong>Proof of Stake:</strong> Different security economics (not for Bitcoin)</li>
+                <li><strong>Hybrid models:</strong> PoW + PoS combinations</li>
+                <li><strong>Checkpointing:</strong> Social consensus as security layer</li>
+            </ul>
+
+            <h3>Layer 2 Economic Integration</h3>
+
+            <ul>
+                <li>How do Layer 2 fees contribute to Layer 1 security?</li>
+                <li>Optimal channel lifetime vs. on-chain settlement frequency</li>
+                <li>Coordinated defense against Layer 1 attacks</li>
+            </ul>
+        </section>
+
+        <section id="summary">
+            <h2>Summary: An Open Question</h2>
+
+            <div class="key-takeaways">
+                <h3>Key Points</h3>
+                <ul>
+                    <li>Bitcoin's block subsidy will effectively end within 20-30 years</li>
+                    <li>Transaction fees must eventually fund 100% of mining revenue</li>
+                    <li>Historical fee revenue has been volatile and often insufficient</li>
+                    <li>New demand sources (Ordinals) suggest market may be more robust than expected</li>
+                    <li>Game theoretic challenges (fee sniping) emerge in low-subsidy environment</li>
+                    <li>No consensus on whether intervention is needed or what it should be</li>
+                    <li>Each halving provides real-world data on fee market resilience</li>
+                </ul>
+            </div>
+
+            <p>The security budget problem is perhaps Bitcoin's most significant long-term uncertainty. It cannot be solved with clever cryptography—it requires sustainable economics. The next two decades will determine whether Bitcoin's fee market can support a global settlement layer, or whether more fundamental changes become necessary.</p>
+        </section>
+
+        <nav class="chapter-navigation">
+            <a href="37-defense-mechanisms.html" class="prev-chapter">&#8592; Previous: Defense Mechanisms</a>
+            <a href="39-quantum-resistance.html" class="next-chapter">Next: Quantum Resistance &#8594;</a>
+        </nav>
+    </article>
+
+    <footer>
+        <p>Elementary Bitcoin - Volume V: The Path to a Sustainable Future</p>
+    </footer>
+</body>
+</html>

--- a/chapters/40-monetary-future.html
+++ b/chapters/40-monetary-future.html
@@ -1,0 +1,838 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Chapter 40: Bitcoin's Monetary Future - Elementary Bitcoin</title>
+    <link rel="stylesheet" href="../css/style.css">
+    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>&#8383;</text></svg>">
+</head>
+<body>
+    <nav class="chapter-nav">
+        <a href="39-quantum-resistance.html" class="prev">&#8592; Chapter 39: Quantum Resistance</a>
+        <a href="../index.html" class="home">&#8962; Home</a>
+        <a href="../index.html" class="next">Return to Index &#8594;</a>
+    </nav>
+
+    <article class="chapter">
+        <header class="chapter-header">
+            <p class="volume-title">Volume V: The Path to a Sustainable Future</p>
+            <p class="part-title">Part XVI: The Road Ahead</p>
+            <h1>Chapter 40: Bitcoin's Monetary Future</h1>
+            <p class="subtitle">From Digital Curiosity to Global Reserve Asset</p>
+        </header>
+
+        <blockquote class="chapter-quote">
+            "It might make sense just to get some in case it catches on. If enough people think the same way, that becomes a self-fulfilling prophecy."
+            <cite>— Satoshi Nakamoto, January 17, 2009</cite>
+        </blockquote>
+
+        <section id="introduction">
+            <h2>The Unfinished Revolution</h2>
+
+            <p>Fifteen years after its creation, Bitcoin has exceeded nearly every early expectation—yet its ultimate role in the global monetary system remains undefined. Is Bitcoin digital gold? A global settlement layer? An alternative reserve currency? The base money of a new financial system?</p>
+
+            <p>This final chapter explores Bitcoin's potential futures: the scenarios, the obstacles, the game theory of adoption, and the profound implications for human civilization if Bitcoin achieves its maximum potential.</p>
+
+            <div class="key-concept">
+                <h3>The Stakes</h3>
+                <p>Bitcoin isn't just a new payment technology—it's a potential transformation of money itself. The outcomes range from irrelevance to the most significant monetary change since the end of the gold standard. Understanding these possibilities is essential for navigating the decades ahead.</p>
+            </div>
+        </section>
+
+        <section id="monetary-evolution">
+            <h2>The Evolution of Money</h2>
+
+            <h3>Historical Progression</h3>
+
+            <p>Money has evolved through distinct phases:</p>
+
+            <div class="code-block">
+<pre>
+Monetary Evolution:
+
+1. Commodity Money (ancient - 1971)
+   ├── Shells, cattle, salt, metals
+   ├── Gold standard peak (1870-1914)
+   ├── Bretton Woods (1944-1971)
+   └── Properties: Scarce, durable, divisible, portable
+
+2. Fiat Currency (1971 - present)
+   ├── Nixon shock ends gold convertibility
+   ├── Central bank management
+   ├── Floating exchange rates
+   └── Properties: Elastic supply, political control
+
+3. Digital Fiat (1990s - present)
+   ├── Electronic banking
+   ├── Credit cards, ACH, SWIFT
+   ├── Central bank digital currencies (CBDCs)
+   └── Properties: Convenient, surveilled, controllable
+
+4. Bitcoin (2009 - future?)
+   ├── Programmable scarcity
+   ├── Decentralized issuance
+   ├── Permissionless access
+   └── Properties: Fixed supply, censorship-resistant, borderless
+</pre>
+            </div>
+
+            <h3>What Problem Does Bitcoin Solve?</h3>
+
+            <p>Bitcoin addresses fundamental issues with existing monetary systems:</p>
+
+            <table class="data-table">
+                <thead>
+                    <tr>
+                        <th>Problem</th>
+                        <th>Fiat Status Quo</th>
+                        <th>Bitcoin Solution</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>Inflation</td>
+                        <td>2-10%+ annual debasement</td>
+                        <td>Fixed 21M supply cap</td>
+                    </tr>
+                    <tr>
+                        <td>Censorship</td>
+                        <td>Accounts frozen, transactions blocked</td>
+                        <td>Permissionless transactions</td>
+                    </tr>
+                    <tr>
+                        <td>Seizure</td>
+                        <td>Assets confiscated by decree</td>
+                        <td>Self-custody with cryptography</td>
+                    </tr>
+                    <tr>
+                        <td>Border control</td>
+                        <td>Capital controls, reporting requirements</td>
+                        <td>Borderless by design</td>
+                    </tr>
+                    <tr>
+                        <td>Counterparty risk</td>
+                        <td>Bank failures, bail-ins</td>
+                        <td>Bearer asset, no intermediary</td>
+                    </tr>
+                    <tr>
+                        <td>Settlement speed</td>
+                        <td>Days for international transfers</td>
+                        <td>~10 minute final settlement</td>
+                    </tr>
+                </tbody>
+            </table>
+        </section>
+
+        <section id="adoption-stages">
+            <h2>Stages of Adoption</h2>
+
+            <h3>The S-Curve Model</h3>
+
+            <p>Technology adoption typically follows an S-curve pattern:</p>
+
+            <div class="code-block">
+<pre>
+Bitcoin Adoption Stages:
+
+Stage 1: Innovators (2009-2012)
+├── Cypherpunks, cryptographers
+├── Ideological early adopters
+├── Price: $0 → $12
+└── Users: Thousands
+
+Stage 2: Early Adopters (2012-2017)
+├── Tech-savvy investors
+├── First exchanges, services
+├── Price: $12 → $1,000
+└── Users: Millions
+
+Stage 3: Early Majority (2017-2024)
+├── Retail speculation
+├── Institutional exploration
+├── Price: $1,000 → $70,000+
+└── Users: Tens of millions
+
+Stage 4: Late Majority (2024-2030?)
+├── Corporate treasury adoption
+├── Nation-state reserves
+├── ETFs, pension funds
+└── Users: Hundreds of millions
+
+Stage 5: Laggards (2030+?)
+├── Universal acceptance
+├── Unit of account
+├── Reserve currency
+└── Users: Billions
+</pre>
+            </div>
+
+            <h3>Current Position</h3>
+
+            <p>As of 2024, Bitcoin appears to be transitioning from Early Majority to Late Majority:</p>
+
+            <ul>
+                <li><strong>Spot ETFs approved:</strong> Institutional access simplified</li>
+                <li><strong>Corporate holdings:</strong> MicroStrategy, Tesla, others</li>
+                <li><strong>Nation-state adoption:</strong> El Salvador legal tender</li>
+                <li><strong>Market cap:</strong> ~$1+ trillion (top 10 global assets)</li>
+                <li><strong>Network effects:</strong> Self-reinforcing adoption dynamics</li>
+            </ul>
+        </section>
+
+        <section id="nation-state-game-theory">
+            <h2>Nation-State Game Theory</h2>
+
+            <h3>The Prisoner's Dilemma</h3>
+
+            <p>Nations face a strategic dilemma regarding Bitcoin:</p>
+
+            <div class="code-block">
+<pre>
+Nation-State Bitcoin Game:
+
+If ALL nations reject Bitcoin:
+├── Status quo maintained
+├── Dollar hegemony continues
+└── No nation gains/loses from BTC
+
+If SOME nations adopt while others reject:
+├── Adopters gain if BTC succeeds
+├── Adopters lose if BTC fails
+├── Rejecters lose if BTC succeeds
+└── First-mover advantage significant
+
+If ALL nations adopt Bitcoin:
+├── New monetary order
+├── Early adopters benefit most
+├── Late adopters pay premium
+└── No nation can stop it
+
+Dominant Strategy Analysis:
+├── If neighbors might adopt → consider adopting
+├── If BTC might succeed → early adoption advantageous
+├── Waiting has opportunity cost
+└── Game theoretically: adoption is rational hedge
+</pre>
+            </div>
+
+            <h3>Strategic Reserve Asset</h3>
+
+            <p>The case for Bitcoin in sovereign reserves:</p>
+
+            <table class="data-table">
+                <thead>
+                    <tr>
+                        <th>Consideration</th>
+                        <th>For Bitcoin</th>
+                        <th>Against Bitcoin</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>Sanction resistance</td>
+                        <td>Cannot be frozen by adversaries</td>
+                        <td>May invite sanctions for holding</td>
+                    </tr>
+                    <tr>
+                        <td>Diversification</td>
+                        <td>Non-correlated with traditional assets</td>
+                        <td>Highly volatile</td>
+                    </tr>
+                    <tr>
+                        <td>Settlement</td>
+                        <td>Direct, no intermediary risk</td>
+                        <td>Limited throughput</td>
+                    </tr>
+                    <tr>
+                        <td>Scarcity</td>
+                        <td>Cannot be inflated</td>
+                        <td>Cannot be expanded in crisis</td>
+                    </tr>
+                    <tr>
+                        <td>Sovereignty</td>
+                        <td>No issuer to impose conditions</td>
+                        <td>Rules cannot be changed if needed</td>
+                    </tr>
+                </tbody>
+            </table>
+
+            <h3>The Tipping Point</h3>
+
+            <div class="key-concept">
+                <h3>When Does FOMO Start?</h3>
+                <p>If one major economy adds Bitcoin to reserves, others face pressure to follow. The first major central bank (Fed, ECB, PBoC, BoJ) to accumulate Bitcoin could trigger a cascade of sovereign adoption—dramatically impacting price and legitimacy.</p>
+            </div>
+        </section>
+
+        <section id="scenarios">
+            <h2>Future Scenarios</h2>
+
+            <h3>Scenario 1: Digital Gold (High Probability)</h3>
+
+            <p>Bitcoin becomes a widely-held store of value alongside gold:</p>
+
+            <div class="code-block">
+<pre>
+Digital Gold Scenario:
+
+Market Position:
+├── 10-50% of gold's market cap ($1-6 trillion)
+├── Held by 5-10% of global population
+├── In 10-20% of investment portfolios
+└── Price: $100,000-500,000 per BTC
+
+Characteristics:
+├── Store of value, not medium of exchange
+├── "Digital property" narrative dominates
+├── Coexists with fiat currencies
+├── Limited payment usage (high-value settlement)
+└── Lightning Network for smaller transactions
+
+Implications:
+├── Wealth preservation tool
+├── Portfolio diversification asset
+├── Not disruptive to existing monetary order
+└── Fiat inflation continues, Bitcoin holders protected
+</pre>
+            </div>
+
+            <h3>Scenario 2: Global Reserve Asset (Medium Probability)</h3>
+
+            <p>Bitcoin joins or replaces gold in central bank reserves:</p>
+
+            <div class="code-block">
+<pre>
+Reserve Asset Scenario:
+
+Market Position:
+├── Equal to or greater than gold (~$15 trillion)
+├── Held by majority of central banks
+├── Strategic reserve for nations
+└── Price: $500,000-1,500,000 per BTC
+
+Characteristics:
+├── Settlement layer for international trade
+├── Neutral asset for adversarial nations
+├── Backing for fiat currencies (partial)
+├── Reduced dollar hegemony
+└── New Bretton Woods-style arrangements
+
+Implications:
+├── Fundamental shift in monetary order
+├── Reduced US exorbitant privilege
+├── Increased financial sovereignty for small nations
+├── More multipolar monetary system
+</pre>
+            </div>
+
+            <h3>Scenario 3: Global Base Money (Low-Medium Probability)</h3>
+
+            <p>Bitcoin becomes the primary global unit of account:</p>
+
+            <div class="code-block">
+<pre>
+Base Money Scenario:
+
+Market Position:
+├── Majority of global monetary base
+├── Universal unit of account
+├── Primary settlement for all trade
+└── Price: Measured in satoshis, not dollars
+
+Characteristics:
+├── Prices quoted in BTC/sats globally
+├── Fiat currencies pegged to Bitcoin
+├── Central banks manage BTC-backed currencies
+├── Layer 2 handles all daily transactions
+└── Layer 1 for final settlement only
+
+Implications:
+├── End of fiat monetary era
+├── Deflationary pressure (falling prices)
+├── Reduced credit expansion capability
+├── Fundamental economic restructuring
+├── Unknown social/political consequences
+</pre>
+            </div>
+
+            <h3>Scenario 4: Niche/Failure (Low Probability)</h3>
+
+            <p>Bitcoin remains marginal or declines:</p>
+
+            <div class="code-block">
+<pre>
+Failure Scenario:
+
+Possible Causes:
+├── Catastrophic bug/exploit discovered
+├── Quantum computing breaks ECDSA (no migration)
+├── Coordinated global ban (enforced)
+├── Superior technology replaces it
+├── Internal governance failure
+└── Fee market collapse, security degradation
+
+Market Position:
+├── <$100 billion market cap
+├── Limited to ideological users
+├── No mainstream adoption
+└── Viewed as failed experiment
+
+Probability Assessment:
+├── 15+ years of resilience argues against
+├── Network effects provide stability
+├── No superior alternative has emerged
+├── Global ban coordination unlikely
+└── Estimated probability: <10%
+</pre>
+            </div>
+        </section>
+
+        <section id="hyperbitcoinization">
+            <h2>Hyperbitcoinization</h2>
+
+            <h3>The Concept</h3>
+
+            <p>Hyperbitcoinization describes the theoretical tipping point where Bitcoin becomes the dominant global currency:</p>
+
+            <div class="key-concept">
+                <h3>Definition</h3>
+                <p>"Hyperbitcoinization is the point at which Bitcoin becomes the default value system of the world—not through force, but through voluntary adoption driven by superior monetary properties."</p>
+            </div>
+
+            <h3>Potential Triggers</h3>
+
+            <ol>
+                <li><strong>Fiat currency crisis:</strong> Major currency hyperinflation drives adoption</li>
+                <li><strong>Sovereign default cascade:</strong> Trust in government money collapses</li>
+                <li><strong>Weaponized dollar:</strong> Overuse of sanctions drives alternatives</li>
+                <li><strong>Institutional stampede:</strong> FOMO among pension funds, sovereign wealth</li>
+                <li><strong>Technological tipping point:</strong> UX reaches mass-market readiness</li>
+            </ol>
+
+            <h3>How It Might Unfold</h3>
+
+            <div class="code-block">
+<pre>
+Hyperbitcoinization Process:
+
+Phase 1: Speculative Store of Value
+├── Current state
+├── HODLers accumulate
+├── Volatility decreases over time
+└── Institutional adoption grows
+
+Phase 2: Treasury Reserve Asset
+├── Companies hold BTC
+├── Nations add to reserves
+├── Legitimacy established
+└── Infrastructure matures
+
+Phase 3: Medium of Exchange
+├── Lightning adoption scales
+├── Commerce integration
+├── Salary payments begin
+└── Dual pricing (fiat + BTC)
+
+Phase 4: Unit of Account
+├── Prices quoted in sats
+├── Fiat prices derived from BTC
+├── Accounting standards adapt
+└── Mental shift: BTC is "real money"
+
+Phase 5: Base Money Layer
+├── Settlement for all global trade
+├── Fiat currencies as stablecoins on BTC
+├── Central banks as BTC custodians
+└── New monetary order established
+</pre>
+            </div>
+        </section>
+
+        <section id="economic-implications">
+            <h2>Economic Implications</h2>
+
+            <h3>A Deflationary Standard</h3>
+
+            <p>If Bitcoin becomes dominant, its fixed supply creates a naturally deflationary environment:</p>
+
+            <table class="data-table">
+                <thead>
+                    <tr>
+                        <th>Characteristic</th>
+                        <th>Inflationary Fiat</th>
+                        <th>Bitcoin Standard</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>Purchasing power</td>
+                        <td>Decreases over time</td>
+                        <td>Increases over time</td>
+                    </tr>
+                    <tr>
+                        <td>Saving incentive</td>
+                        <td>Discouraged (invest or lose)</td>
+                        <td>Encouraged (value preserved)</td>
+                    </tr>
+                    <tr>
+                        <td>Time preference</td>
+                        <td>High (spend now)</td>
+                        <td>Low (save for future)</td>
+                    </tr>
+                    <tr>
+                        <td>Debt dynamics</td>
+                        <td>Debt inflated away</td>
+                        <td>Debt becomes heavier</td>
+                    </tr>
+                    <tr>
+                        <td>Price signals</td>
+                        <td>Distorted by inflation</td>
+                        <td>Clear, stable measurement</td>
+                    </tr>
+                    <tr>
+                        <td>Capital allocation</td>
+                        <td>Favors debtors</td>
+                        <td>Favors savers</td>
+                    </tr>
+                </tbody>
+            </table>
+
+            <h3>The Deflation Debate</h3>
+
+            <p>Critics argue deflation is dangerous:</p>
+
+            <ul>
+                <li><strong>Debt deflation spiral:</strong> Falling prices increase real debt burden</li>
+                <li><strong>Delayed consumption:</strong> Why buy today if cheaper tomorrow?</li>
+                <li><strong>Wage stickiness:</strong> Nominal wage cuts are psychologically difficult</li>
+            </ul>
+
+            <p>Proponents counter:</p>
+
+            <ul>
+                <li><strong>Productivity deflation:</strong> Falling prices from efficiency gains are healthy</li>
+                <li><strong>Low time preference:</strong> Encourages sustainable investment</li>
+                <li><strong>Historical examples:</strong> 19th century gold standard saw growth with mild deflation</li>
+                <li><strong>Technology prices:</strong> Computers get cheaper; people still buy them</li>
+            </ul>
+
+            <h3>Credit and Banking</h3>
+
+            <p>A Bitcoin standard would transform banking:</p>
+
+            <div class="code-block">
+<pre>
+Banking Under Bitcoin Standard:
+
+Traditional Fractional Reserve:
+├── Banks create money through lending
+├── Central bank as lender of last resort
+├── Deposit insurance backstops runs
+└── Money supply expands with credit
+
+Bitcoin Native Banking:
+├── Full reserve custody (no money creation)
+├── Credit still possible (term-matched loans)
+├── No lender of last resort for BTC
+├── Bank runs possible if fractional reserve attempted
+└── Higher lending rates, lower leverage
+
+Likely Hybrid:
+├── Bitcoin-backed fiat currencies
+├── Central banks hold BTC reserves
+├── Fractional reserve on fiat layer
+├── Bitcoin as final settlement asset
+└── Similar to gold standard historically
+</pre>
+            </div>
+        </section>
+
+        <section id="social-political">
+            <h2>Social and Political Implications</h2>
+
+            <h3>Separation of Money and State</h3>
+
+            <p>Bitcoin potentially represents a historic separation:</p>
+
+            <div class="key-concept">
+                <h3>The Monetary Reformation</h3>
+                <p>Just as separation of church and state limited religious authority, separation of money and state could limit monetary authority. Governments would lose the ability to print money, fundamentally constraining fiscal policy.</p>
+            </div>
+
+            <h3>Winners and Losers</h3>
+
+            <table class="data-table">
+                <thead>
+                    <tr>
+                        <th>Group</th>
+                        <th>Bitcoin Advantage</th>
+                        <th>Bitcoin Disadvantage</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>Savers</td>
+                        <td>Wealth preserved from inflation</td>
+                        <td>Must learn new technology</td>
+                    </tr>
+                    <tr>
+                        <td>Debtors</td>
+                        <td>Discipline in borrowing</td>
+                        <td>Debt becomes heavier</td>
+                    </tr>
+                    <tr>
+                        <td>Governments</td>
+                        <td>Budget discipline enforced</td>
+                        <td>Lose monetary flexibility</td>
+                    </tr>
+                    <tr>
+                        <td>Banks</td>
+                        <td>Custody business opportunity</td>
+                        <td>Reduced lending profits</td>
+                    </tr>
+                    <tr>
+                        <td>Developing nations</td>
+                        <td>Escape currency manipulation</td>
+                        <td>Lose competitive devaluation</td>
+                    </tr>
+                    <tr>
+                        <td>Early adopters</td>
+                        <td>Significant wealth gain</td>
+                        <td>Social/political backlash</td>
+                    </tr>
+                </tbody>
+            </table>
+
+            <h3>Governance Challenges</h3>
+
+            <p>A Bitcoin-dominated monetary system raises questions:</p>
+
+            <ul>
+                <li><strong>Crisis response:</strong> How do governments stimulate during recessions?</li>
+                <li><strong>War financing:</strong> Can nations fund large-scale conflicts?</li>
+                <li><strong>Wealth inequality:</strong> Early adopters gain disproportionately</li>
+                <li><strong>Democratic control:</strong> Monetary policy becomes protocol rules</li>
+                <li><strong>Transition pain:</strong> Existing debts become harder to repay</li>
+            </ul>
+        </section>
+
+        <section id="challenges">
+            <h2>Challenges to Widespread Adoption</h2>
+
+            <h3>Technical Challenges</h3>
+
+            <ul>
+                <li><strong>Scalability:</strong> Layer 1 limited to ~500K tx/day; Layer 2 still maturing</li>
+                <li><strong>UX:</strong> Key management too complex for average users</li>
+                <li><strong>Quantum computing:</strong> Requires cryptographic migration</li>
+                <li><strong>Security budget:</strong> Long-term sustainability uncertain</li>
+            </ul>
+
+            <h3>Economic Challenges</h3>
+
+            <ul>
+                <li><strong>Volatility:</strong> Unsuitable for pricing until stability achieved</li>
+                <li><strong>Network effects:</strong> Incumbent currencies have strong inertia</li>
+                <li><strong>Transition costs:</strong> Switching from fiat is expensive/disruptive</li>
+                <li><strong>Credit contraction:</strong> Less money creation means less credit</li>
+            </ul>
+
+            <h3>Political Challenges</h3>
+
+            <ul>
+                <li><strong>Regulatory hostility:</strong> Governments may restrict use</li>
+                <li><strong>CBDCs:</strong> Competing government digital currencies</li>
+                <li><strong>Geopolitical:</strong> May trigger international conflict</li>
+                <li><strong>Vested interests:</strong> Current system benefits from status quo</li>
+            </ul>
+
+            <h3>Social Challenges</h3>
+
+            <ul>
+                <li><strong>Education:</strong> Most people don't understand money</li>
+                <li><strong>Trust:</strong> "Magic internet money" perception persists</li>
+                <li><strong>Custody:</strong> "Be your own bank" is burdensome</li>
+                <li><strong>Inequality:</strong> Early adopter wealth creates resentment</li>
+            </ul>
+        </section>
+
+        <section id="coexistence">
+            <h2>The Coexistence Model</h2>
+
+            <h3>Bitcoin Among Monies</h3>
+
+            <p>The most likely near-term outcome is coexistence:</p>
+
+            <div class="code-block">
+<pre>
+Multi-Money Future:
+
+Bitcoin:
+├── Global settlement layer
+├── Store of value / digital gold
+├── Reserve asset for institutions
+└── Censorship-resistant savings
+
+Stablecoins:
+├── Dollar/euro/etc. on blockchain
+├── Daily transactions
+├── Commerce and payments
+└── Regulatory compliance built-in
+
+CBDCs:
+├── Government digital currencies
+├── Programmable, surveillable
+├── Welfare, taxation, control
+└── Competition with private money
+
+Local Fiat:
+├── Traditional currencies persist
+├── Gradually Bitcoin-backed
+├── Legal tender for taxes
+└── Managed float against BTC
+</pre>
+            </div>
+
+            <h3>The Layer Model</h3>
+
+            <div class="code-block">
+<pre>
+Monetary System Layers:
+
+Layer 0: Bitcoin base layer
+├── Final settlement
+├── Maximum security
+├── Minimum throughput
+└── Reserve asset status
+
+Layer 1: Lightning / State channels
+├── Fast payments
+├── Low fees
+├── BTC-denominated
+└── Self-custodial option
+
+Layer 2: Bitcoin banks / Custodians
+├── Fractional reserve possible
+├── Traditional banking services
+├── Regulated, insured
+└── Trade-off: convenience vs sovereignty
+
+Layer 3: Fiat / Stablecoins
+├── Unit of account for commerce
+├── Backed by BTC reserves
+├── Familiar user experience
+└── Bridge to legacy system
+</pre>
+            </div>
+        </section>
+
+        <section id="timeline">
+            <h2>Potential Timeline</h2>
+
+            <div class="code-block">
+<pre>
+Speculative Adoption Timeline:
+
+2024-2027: Institutional Foundation
+├── ETFs accumulate significant holdings
+├── More public companies add treasury BTC
+├── First G20 nation adds to reserves (speculation)
+├── Lightning Network reaches 10M+ users
+└── Price range: $50K-$200K
+
+2027-2032: Mainstream Legitimacy
+├── Multiple sovereign holders
+├── Pension fund allocations common
+├── Bitcoin savings accounts widespread
+├── Unit of account for some niches
+└── Price range: $200K-$1M
+
+2032-2040: Monetary Competition
+├── Bitcoin vs CBDC competition
+├── Some nations adopt BTC standard
+├── Fiat currencies weakened
+├── Layer 2 handles billions of users
+└── Price range: $500K-$5M
+
+2040+: New Monetary Order (if successful)
+├── Bitcoin as global reserve
+├── Fiat currencies pegged to BTC
+├── Price quoted in satoshis
+└── Generational wealth transfer complete
+</pre>
+            </div>
+
+            <div class="warning-box">
+                <h4>Uncertainty Acknowledgment</h4>
+                <p>These timelines are highly speculative. Bitcoin could achieve widespread adoption faster—or never achieve it at all. The future is inherently unpredictable, and this should inform investment and planning decisions.</p>
+            </div>
+        </section>
+
+        <section id="conclusion">
+            <h2>Conclusion: The Money of the Future</h2>
+
+            <h3>What Bitcoin Represents</h3>
+
+            <p>Beyond technology or investment, Bitcoin represents an idea: that money can be a protocol rather than a privilege, that monetary policy can be algorithmic rather than political, and that individuals can have true financial sovereignty.</p>
+
+            <div class="key-concept">
+                <h3>The Fundamental Innovation</h3>
+                <p>Bitcoin's core innovation isn't blockchain technology—it's the creation of absolute digital scarcity. For the first time in history, we have a digital asset that cannot be copied, counterfeited, or inflated. This property, combined with decentralized consensus, creates a new form of money that could persist for generations.</p>
+            </div>
+
+            <h3>The Path Forward</h3>
+
+            <p>Bitcoin's future depends on:</p>
+
+            <ol>
+                <li><strong>Technical evolution:</strong> Continued protocol development, Layer 2 maturation</li>
+                <li><strong>Economic resilience:</strong> Surviving market cycles, maintaining security budget</li>
+                <li><strong>Social adoption:</strong> Growing understanding and acceptance</li>
+                <li><strong>Political navigation:</strong> Working within or around regulatory frameworks</li>
+                <li><strong>Community cohesion:</strong> Maintaining consensus on core principles</li>
+            </ol>
+
+            <h3>Final Thoughts</h3>
+
+            <p>Bitcoin may ultimately succeed or fail. But it has already achieved something remarkable: it has proven that decentralized digital money is possible. Whatever happens to Bitcoin specifically, the genie cannot be put back in the bottle. The idea of programmable, scarce, permissionless money will persist.</p>
+
+            <p>For those who believe in this vision, the path forward is clear: continue building, continue learning, continue advocating for financial sovereignty. The monetary system of tomorrow will be shaped by the choices made today.</p>
+
+            <p>Whether Bitcoin becomes the foundation of a new global monetary order or remains a niche asset, it has already changed how we think about money. That intellectual revolution—the recognition that money itself can be reimagined—may prove to be Bitcoin's most enduring legacy.</p>
+        </section>
+
+        <section id="summary">
+            <h2>Summary: Elementary Bitcoin Complete</h2>
+
+            <div class="key-takeaways">
+                <h3>Volume V Key Points</h3>
+                <ul>
+                    <li><strong>Security threats</strong> like 51% attacks are real but expensive</li>
+                    <li><strong>Defense mechanisms</strong> include checkpoints, confirmations, and social consensus</li>
+                    <li><strong>Security budget</strong> must transition from subsidy to fees over 20-30 years</li>
+                    <li><strong>Quantum computing</strong> will require cryptographic migration—but we have time</li>
+                    <li><strong>Bitcoin's monetary future</strong> ranges from niche asset to global reserve currency</li>
+                    <li><strong>The outcome is not predetermined</strong>—it depends on technical, economic, and social factors</li>
+                </ul>
+            </div>
+
+            <div class="info-box">
+                <h4>The Journey Complete</h4>
+                <p>From cryptographic primitives to global monetary futures, Elementary Bitcoin has covered the technical foundations, economic principles, and philosophical implications of this revolutionary technology. The knowledge you've gained provides the foundation for understanding, using, and contributing to Bitcoin's ongoing development.</p>
+                <p><strong>The future is unwritten. Build wisely.</strong></p>
+            </div>
+        </section>
+
+        <nav class="chapter-navigation">
+            <a href="39-quantum-resistance.html" class="prev-chapter">&#8592; Previous: Quantum Resistance</a>
+            <a href="../index.html" class="next-chapter">Return to Index &#8594;</a>
+        </nav>
+    </article>
+
+    <footer>
+        <p>Elementary Bitcoin - Volume V: The Path to a Sustainable Future</p>
+        <p><em>The End... and The Beginning</em></p>
+    </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
Fixes from a computational re-review of chapters 6-10 (Ch 10 was fully clean):

**Ch 6 (HIGH)** — four truncated SHA-256 values had fabricated endings; verified against hashlib and corrected:
- `SHA256("")` → `...7852b855`, `SHA256("Bitcoin")` → `...4eb63aa4`, `SHA256("bitcoin")` → `...05ca107b`, Figure 6.2 `SHA256("Hellp")` → `2113cd4a7aebc3a4...`

**Ch 7** — nonce-reuse proof notation `d = r⁻¹(sk − z)` → `d = r⁻¹(s₁k − z₁)` (sk collided with the private-key symbol); low-S reworded as a standardness/relay policy rather than consensus rejection.

**Ch 8 (HIGH)** — MuSig definition claimed parties must prove knowledge of their discrete logs; MuSig's whole point is the plain public-key model where the coefficients aᵢ = H(L‖Pᵢ) defeat rogue-key attacks without proofs of knowledge. Also renamed the serialized public key to `pk` in Algorithms 8.1/8.2 so step 4's "r ≥ p" unambiguously refers to the field prime (matching BIP-340), and migrated §8.2 from Q to P.

**Ch 9** — public key K → P (Definition 9.2, Figure 9.1) completing the notation standardization; address-length table corrected (P2PKH 26–34 chars, P2SH exactly 34).

Fixes #89