### PR TITLE
Fix Ch 11-15 review findings

### DIFF
--- a/chapters/11-script.html
+++ b/chapters/11-script.html
@@ -371,17 +371,17 @@
                         <td>|a|</td>
                     </tr>
                     <tr>
-                        <td><code>0x9a</code></td>
+                        <td><code>0xa3</code></td>
                         <td>OP_MIN</td>
                         <td>min(a, b)</td>
                     </tr>
                     <tr>
-                        <td><code>0x9b</code></td>
+                        <td><code>0xa4</code></td>
                         <td>OP_MAX</td>
                         <td>max(a, b)</td>
                     </tr>
                     <tr>
-                        <td><code>0xa0</code></td>
+                        <td><code>0xa5</code></td>
                         <td>OP_WITHIN</td>
                         <td>min ≤ x < max</td>
                     </tr>
@@ -740,7 +740,9 @@ OP_DUP OP_HASH160 &lt;pubkey_hash&gt; OP_EQUALVERIFY OP_CHECKSIG</pre>
                 <p class="definition-title">Definition 11.7 (OP_RETURN Output)</p>
                 <p>
                     An <strong>OP_RETURN output</strong> has a scriptPubKey beginning with
-                    <code>OP_RETURN</code> followed by up to 80 bytes of data. Such outputs:
+                    <code>OP_RETURN</code> followed by data (relay policy has historically
+                    limited this to 80 bytes by default; consensus imposes no such limit).
+                    Such outputs:
                 </p>
                 <ul>
                     <li>Are provably unspendable (execution always fails)</li>

--- a/chapters/12-merkle-trees.html
+++ b/chapters/12-merkle-trees.html
@@ -169,7 +169,7 @@
                     <li>If <span class="math">n = 1</span>, return <span class="math">h₁</span></li>
                     <li>If <span class="math">n</span> is odd, duplicate the last hash: <span class="math">hₙ₊₁ = hₙ</span></li>
                     <li>Pair adjacent hashes and compute: <span class="math">pᵢ = H(h₂ᵢ₋₁ || h₂ᵢ)</span></li>
-                    <li>Recursively compute the Merkle root of <span class="math">p₁, p₂, ..., p_{n/2}</span></li>
+                    <li>Recursively compute the Merkle root of the resulting <span class="math">⌈n/2⌉</span> hashes <span class="math">p₁, p₂, ...</span></li>
                 </ol>
             </div>
 
@@ -195,7 +195,7 @@
                     <text x="150" y="102" text-anchor="middle" font-family="Georgia" font-size="9">H(ABCD)</text>
 
                     <rect x="330" y="85" width="80" height="25" rx="4" fill="#fff8e8" stroke="#d4a574"/>
-                    <text x="370" y="102" text-anchor="middle" font-family="Georgia" font-size="9">H(EE)</text>
+                    <text x="370" y="102" text-anchor="middle" font-family="Georgia" font-size="9">H(EEEE)</text>
 
                     <line x1="230" y1="65" x2="150" y2="85" stroke="#666" stroke-width="1"/>
                     <line x1="290" y1="65" x2="370" y2="85" stroke="#666" stroke-width="1"/>
@@ -208,10 +208,10 @@
                     <text x="160" y="145" text-anchor="middle" font-family="Georgia" font-size="9">H(CD)</text>
 
                     <rect x="310" y="130" width="50" height="22" rx="3" fill="#e8f4e8" stroke="#5a8f5a"/>
-                    <text x="335" y="145" text-anchor="middle" font-family="Georgia" font-size="9">H(E)</text>
+                    <text x="335" y="145" text-anchor="middle" font-family="Georgia" font-size="9">H(EE)</text>
 
                     <rect x="380" y="130" width="50" height="22" rx="3" fill="#f5e8e8" stroke="#c44" stroke-dasharray="3,2"/>
-                    <text x="405" y="145" text-anchor="middle" font-family="Georgia" font-size="9" fill="#c44">H(E)</text>
+                    <text x="405" y="145" text-anchor="middle" font-family="Georgia" font-size="9" fill="#c44">H(EE)</text>
 
                     <line x1="120" y1="110" x2="80" y2="130" stroke="#666" stroke-width="1"/>
                     <line x1="180" y1="110" x2="160" y2="130" stroke="#666" stroke-width="1"/>
@@ -237,7 +237,7 @@
                     <!-- Duplicate annotation -->
                     <text x="405" y="178" text-anchor="middle" font-family="Georgia" font-size="8" fill="#c44">duplicated</text>
                 </svg>
-                <figcaption>Figure 12.2: When the transaction count is odd, the last hash is duplicated.</figcaption>
+                <figcaption>Figure 12.2: With five transactions, E is duplicated at the leaf level to form H(EE), which is itself duplicated at the next level.</figcaption>
             </figure>
 
             <div class="example">

--- a/chapters/13-blocks.html
+++ b/chapters/13-blocks.html
@@ -556,7 +556,7 @@ target = 0x00ffff × 256^(29-3)
                         </tr>
                         <tr>
                             <td>Merkle Root</td>
-                            <td>4a5e1e...b9b63</td>
+                            <td>4a5e1e...da33b</td>
                         </tr>
                         <tr>
                             <td>Timestamp</td>
@@ -734,7 +734,7 @@ target = 0x00ffff × 256^(29-3)
                 </p>
                 <pre class="code-block">version: 01000000
 prev_hash: 0000...0000 (32 bytes of zeros)
-merkle_root: 3ba3...f63 (32 bytes)
+merkle_root: 3ba3...5e4a (32 bytes)
 time: 29ab5f49
 bits: ffff001d
 nonce: 1dac2b7c</pre>

--- a/chapters/14-proof-of-work.html
+++ b/chapters/14-proof-of-work.html
@@ -215,7 +215,7 @@
                 <ul>
                     <li>Finding a valid block is 50 trillion times harder than at difficulty 1</li>
                     <li>Expected hashes: ~50 trillion × (genesis difficulty hashes)</li>
-                    <li>At 500 EH/s network hashrate: ~10 minutes per block</li>
+                    <li>At ~360 EH/s network hashrate: ~10 minutes per block</li>
                 </ul>
             </div>
 
@@ -231,7 +231,11 @@
                     Genesis block hash (2009, difficulty 1):
                 </p>
                 <pre class="code-block">000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f
-^^^^^^^^ 8 leading hex zeros (32 leading binary zeros)</pre>
+^^^^^^^^^^ 10 leading hex zeros (43 leading binary zeros)</pre>
+                <p>
+                    The difficulty-1 target only requires about 32 leading zero bits;
+                    the genesis hash overshot it considerably.
+                </p>
 
                 <p>A modern block (difficulty ~50T):</p>
                 <pre class="code-block">0000000000000000000234abc...
@@ -261,11 +265,12 @@
             </div>
 
             <div class="remark">
-                <p class="remark-title">Off-by-one error.</p>
+                <p class="remark-title">Remark 14.1 (Off-by-One Error).</p>
                 <p>
                     Bitcoin Core's implementation measures
-                    <span class="math">actual_time = timestamp(block[h]) − timestamp(block[h − 2016])</span>,
-                    which spans 2015 inter-block intervals rather than 2016. This makes
+                    <span class="math">actual_time = timestamp(block[h]) − timestamp(block[h − 2015])</span>,
+                    the first and last blocks of the <em>same</em> 2016-block window,
+                    which spans only 2015 inter-block intervals rather than 2016. This makes
                     difficulty systematically ~0.05% too low. The bug has been preserved
                     for consensus compatibility.
                 </p>
@@ -610,7 +615,7 @@ Daily profit = $3.60 - $3.60 = $0.00</pre>
             <h3>14.8.3 Selfish Mining</h3>
 
             <div class="remark">
-                <p class="remark-title">Remark 14.1 (Selfish Mining)</p>
+                <p class="remark-title">Remark 14.2 (Selfish Mining)</p>
                 <p>
                     Eyal and Sirer (2014) showed that miners with >33% hash power can gain
                     disproportionate rewards by strategically withholding blocks. This reduces
@@ -628,7 +633,7 @@ Daily profit = $3.60 - $3.60 = $0.00</pre>
             </p>
 
             <div class="remark">
-                <p class="remark-title">Remark 14.2 (Energy Consumption)</p>
+                <p class="remark-title">Remark 14.3 (Energy Consumption)</p>
                 <p>
                     Bitcoin's energy consumption is a feature, not a bug. The energy spent
                     mining represents a real-world cost that attackers must also pay. Security
@@ -699,7 +704,7 @@ Daily profit = $3.60 - $3.60 = $0.00</pre>
             </table>
 
             <p>
-                Modern ASICs are roughly 10 billion times more efficient than the CPUs
+                Modern ASICs hash roughly 100 million times faster than the CPUs
                 Satoshi used in 2009.
             </p>
         </section>

--- a/chapters/15-consensus-parameters.html
+++ b/chapters/15-consensus-parameters.html
@@ -94,10 +94,12 @@
             <div class="remark">
                 <p class="remark-title">Remark 15.1 (Why Not Exactly 21 Million?)</p>
                 <p>
-                    The actual maximum is slightly less due to:
+                    The protocol maximum falls short of 21 million solely because of
+                    integer truncation in the subsidy calculation (subsidies are whole
+                    satoshis, halved by integer division). The <em>spendable</em> supply
+                    is lower still due to:
                 </p>
                 <ul>
-                    <li>Integer truncation in subsidy calculation (satoshis, not fractional)</li>
                     <li>Lost genesis block reward (50 BTC unspendable)</li>
                     <li>Miners occasionally claiming less than full subsidy</li>
                     <li>Provably burned coins</li>
@@ -355,14 +357,14 @@ Time between halvings: 210,000 × 10 min = 2,100,000 min
                         <td>Backward compatibility</td>
                     </tr>
                     <tr>
-                        <td>Max transaction size</td>
-                        <td>~400,000 bytes</td>
+                        <td>Max transaction size (policy)</td>
+                        <td>400,000 weight units (~100 kvB)</td>
                         <td>Prevent abuse</td>
                     </tr>
                     <tr>
-                        <td>Min transaction size</td>
-                        <td>82 bytes</td>
-                        <td>Prevent CVE-2017-12842</td>
+                        <td>Min transaction size (policy)</td>
+                        <td>65 non-witness bytes</td>
+                        <td>Prevent CVE-2017-12842 (64-byte txs)</td>
                     </tr>
                 </tbody>
             </table>
@@ -418,7 +420,7 @@ Time between halvings: 210,000 × 10 min = 2,100,000 min
                     Block timestamps must not exceed:
                 </p>
                 <p class="math-block">
-                    network\_adjusted\_time + 2 hours
+                    network_adjusted_time + 2 hours
                 </p>
                 <p>
                     where network-adjusted time is derived from peer clocks.
@@ -550,7 +552,7 @@ Time between halvings: 210,000 × 10 min = 2,100,000 min
                     </tr>
                     <tr>
                         <td>Max message size</td>
-                        <td>32 MB</td>
+                        <td>4 MB</td>
                     </tr>
                     <tr>
                         <td>Max headers per message</td>
@@ -773,8 +775,8 @@ Time between halvings: 210,000 × 10 min = 2,100,000 min
             <div class="exercise">
                 <p class="exercise-title">Exercise 15.4</p>
                 <p>
-                    Why is 100 satoshi million (1 BTC = 10⁸ satoshis) a good choice for
-                    divisibility? What problems might arise with fewer or more decimal places?
+                    Why is 100 million satoshis per bitcoin (1 BTC = 10⁸ satoshis) a good
+                    choice for divisibility? What problems might arise with fewer or more decimal places?
                 </p>
             </div>
 


### PR DESCRIPTION
## Summary
Fixes from a computational re-review of chapters 11-15:

**HIGH**
- Ch 11: OP_MIN, OP_MAX, OP_WITHIN had the opcode values of OP_BOOLAND, OP_BOOLOR, OP_GREATERTHAN; corrected to 0xa3/0xa4/0xa5 (Bitcoin Core script.h).
- Ch 13: two genesis Merkle root truncations had fabricated endings; corrected to the real digest (`4a5e1e...da33b` display order, `3ba3...5e4a` serialized).
- Ch 14: the genesis block hash has 10 leading hex zeros / 43 leading zero bits, not 8/32; added a note that the difficulty-1 target only requires ~32 bits.
- Ch 14: the off-by-one remark stated the formula that does NOT exhibit the off-by-one; now correctly spans the first and last block of the same 2016-block window (2015 intervals).

**MEDIUM**
- Ch 14 Example 14.1: 50 T difficulty corresponds to ~10-minute blocks at ~360 EH/s (500 EH/s gives ~7.2 min).
- Ch 12 Figure 12.2: tree now duplicates at the leaf level (pairs (A,B), (C,D), (E,E)) per Algorithm 12.1, with H(EE) duplicated again at the next level.
- Ch 14: "Off-by-one error." remark numbered; remarks now 14.1-14.3.
- Ch 15: standardness limits corrected — max tx 400,000 weight units (~100 kvB, policy), min tx 65 non-witness bytes (policy, Core 24.0+), max P2P message 4 MB.

**LOW**
- Ch 11 OP_RETURN limit reworded as relay policy; Ch 12 Algorithm 12.1 step-4 count ⌈n/2⌉; Ch 14 ASIC speedup ~10⁸; Ch 15 backslash rendering, Exercise 15.4 wording, Remark 15.1 protocol-max vs spendable-supply distinction.

Fixes #93