### PR TITLE
Fix Ch 16-20 review findings

### DIFF
--- a/chapters/16-soft-forks.html
+++ b/chapters/16-soft-forks.html
@@ -136,7 +136,7 @@
                             <td>✗ Non-standard</td>
                         </tr>
                         <tr>
-                            <td>Coinbase spending <100 conf</td>
+                            <td>Coinbase spending &lt;100 conf</td>
                             <td>✗ Invalid</td>
                             <td>N/A</td>
                         </tr>
@@ -246,7 +246,7 @@
                 <p class="definition-title">Definition 16.5 (Flag Day)</p>
                 <p>
                     A <strong>flag day activation</strong> enables new rules at a predetermined
-                    block height or time. Used in early soft forks (BIP-30, BIP-34).
+                    block height or time. Used in early soft forks (BIP-16, BIP-30).
                 </p>
             </div>
 

--- a/chapters/17-spv-theory.html
+++ b/chapters/17-spv-theory.html
@@ -40,7 +40,7 @@
             <p class="chapter-intro">
                 Section 8 of the Bitcoin whitepaper describes "Simplified Payment Verification"—a
                 method for verifying payments without running a full node. This section, spanning
-                just 479 words, has generated enormous controversy and widespread misunderstanding.
+                just over two hundred words, has generated enormous controversy and widespread misunderstanding.
                 In this chapter, we examine SPV with mathematical precision: what it proves, what
                 it assumes, and what it does not guarantee.
             </p>
@@ -140,7 +140,7 @@
                     <rect x="295" y="130" width="150" height="25" rx="4" fill="#f5f5f5" stroke="#999"/>
                     <text x="370" y="147" text-anchor="middle" font-family="Georgia" font-size="10" fill="#666">Merkle proofs</text>
 
-                    <text x="370" y="175" text-anchor="middle" font-family="Georgia" font-size="10" fill="#5a8f5a">~50 MB + txs</text>
+                    <text x="370" y="175" text-anchor="middle" font-family="Georgia" font-size="10" fill="#5a8f5a">~65 MB + txs</text>
 
                     <!-- Comparison arrow -->
                     <text x="250" y="115" text-anchor="middle" font-family="Georgia" font-size="20" fill="#888">→</text>
@@ -550,7 +550,7 @@
             <div class="remark">
                 <p class="remark-title">Remark 17.4 (Fraud Proofs Don't Exist Yet)</p>
                 <p>
-                    Despite decades of research, general-purpose fraud proofs for Bitcoin do not
+                    Despite years of research, general-purpose fraud proofs for Bitcoin do not
                     exist. The problem is that proving a transaction is invalid requires proving
                     a negative—that a UTXO doesn't exist—which requires either:
                 </p>
@@ -579,12 +579,12 @@
                     <tr>
                         <td>Storage required</td>
                         <td>~500+ GB</td>
-                        <td>~50 MB + txs</td>
+                        <td>~65 MB + txs</td>
                     </tr>
                     <tr>
                         <td>Bandwidth (sync)</td>
                         <td>~500+ GB</td>
-                        <td>~50 MB</td>
+                        <td>~65 MB</td>
                     </tr>
                     <tr>
                         <td>Validates transactions</td>

--- a/chapters/18-bloom-filters.html
+++ b/chapters/18-bloom-filters.html
@@ -797,7 +797,9 @@
 
     // Process remaining bytes
     k = 0
-    for remaining bytes (little-endian):
+    for each remaining byte i (little-endian):
+        k = k XOR (byte[i] << (8 * i))
+    if k ≠ 0:
         k = k * c1
         k = rotl32(k, r1)
         k = k * c2
@@ -928,8 +930,8 @@
                         <td>BIP-37 proposed by Mike Hearn and Matt Corallo</td>
                     </tr>
                     <tr>
-                        <td>2012-12</td>
-                        <td>Implemented in Bitcoin Core 0.8.0</td>
+                        <td>2013-02</td>
+                        <td>Released in Bitcoin Core 0.8.0</td>
                     </tr>
                     <tr>
                         <td>2014</td>

--- a/chapters/19-compact-filters.html
+++ b/chapters/19-compact-filters.html
@@ -74,7 +74,7 @@
             <h4>Privacy Advantage</h4>
             <p>
                 <strong>The server learns nothing about client interests.</strong> A client that
-                downloads filter for block N is indistinguishable from any other client downloading
+                downloads the filter for block N is indistinguishable from any other client downloading
                 that filter. When the client requests the full block, the server learns only that
                 "something in this block is interesting"—not which transactions, addresses, or
                 scripts.
@@ -331,8 +331,8 @@
 
                     <!-- Step 2: Hash -->
                     <g transform="translate(30, 115)">
-                        <text x="0" y="0" font-size="11" font-weight="bold">2. Hash to [0, N·M):</text>
-                        <text x="0" y="20" font-size="10" fill="#666">With N=3, M=16, range = [0, 48)</text>
+                        <text x="0" y="0" font-size="11" font-weight="bold">2. Hash to [0, N·F):</text>
+                        <text x="0" y="20" font-size="10" fill="#666">With N=3, F=16, range = [0, 48)</text>
                         <rect x="0" y="30" width="60" height="25" fill="#fff3e0" stroke="#ef6c00" rx="3"/>
                         <text x="30" y="47" text-anchor="middle" font-size="10">7</text>
                         <rect x="90" y="30" width="60" height="25" fill="#fff3e0" stroke="#ef6c00" rx="3"/>
@@ -391,31 +391,35 @@
             <div class="theorem">
                 <p><strong>Theorem 19.3</strong> (GCS Space Efficiency)</p>
                 <p>
-                    A Golomb-Coded Set with N elements and false positive rate 1/M requires
-                    approximately N · (1 + log₂(M)) bits, plus a small constant overhead.
+                    A Golomb-Coded Set with N elements and false positive rate 1/F requires
+                    approximately N · (1 + log₂(F)) bits, plus a small constant overhead.
                 </p>
             </div>
 
             <div class="proof">
                 <p><strong>Proof sketch.</strong></p>
                 <p>
-                    Each delta has expected value M (since N elements are spread over range N·M).
-                    Golomb-Rice with P = log₂(M) encodes values near M optimally. The expected
-                    code length per delta is approximately 1 + P = 1 + log₂(M) bits.
-                    With N deltas, total size ≈ N · (1 + log₂(M)) bits. ∎
+                    Each delta has expected value F (since N elements are spread over range N·F).
+                    Golomb-Rice with P = log₂(F) (so that the divisor M = 2^P ≈ F) encodes
+                    values near F optimally. The expected code length per delta is
+                    approximately 1 + P = 1 + log₂(F) bits.
+                    With N deltas, total size ≈ N · (1 + log₂(F)) bits. ∎
                 </p>
             </div>
 
             <div class="example">
                 <p><strong>Example 19.2</strong> (BIP-158 Filter Size)</p>
                 <p>
-                    BIP-158 uses P = 19 (M = 2¹⁹ ≈ 524,288) and parameter F = M.
+                    BIP-158 uses P = 19 (M = 2¹⁹ = 524,288) and false-positive
+                    parameter F = 784,931 (≈ 1.5 × 2¹⁹).
                     For a block with N = 2000 scriptPubKeys:
                 </p>
                 <ul>
                     <li>Filter size ≈ 2000 × (1 + 19) = 40,000 bits = 5,000 bytes</li>
                     <li>Compared to full block: ~1-2 MB</li>
-                    <li>Ratio: ~1/200 to 1/400</li>
+                    <li>Ratio: ~1/200 to 1/400 for this N; real blocks contain
+                    more filter elements (~5,000&ndash;10,000), giving the
+                    ~1/80 ratio quoted elsewhere</li>
                 </ul>
             </div>
         </section>
@@ -645,10 +649,10 @@
                     The filter header for block N is:
                 </p>
                 <div class="formula">
-                    filter_header<sub>N</sub> = SHA256(SHA256(filter<sub>N</sub>) || filter_header<sub>N-1</sub>)
+                    filter_header<sub>N</sub> = SHA256d(SHA256d(filter<sub>N</sub>) || filter_header<sub>N-1</sub>)
                 </div>
                 <p>
-                    Where filter<sub>N</sub> is the raw filter bytes and filter_header<sub>-1</sub> = 0x00...00 (32 zero bytes).
+                    Where SHA256d(x) = SHA256(SHA256(x)), filter<sub>N</sub> is the raw filter bytes, and filter_header<sub>-1</sub> = 0x00...00 (32 zero bytes).
                 </p>
             </div>
 
@@ -665,7 +669,7 @@
 
                         <rect x="0" y="50" width="100" height="40" fill="#e8f5e9" stroke="#4caf50" rx="3"/>
                         <text x="50" y="73" text-anchor="middle" font-size="9">Header₀ =</text>
-                        <text x="50" y="85" text-anchor="middle" font-size="8">H(F₀ || 0x00...)</text>
+                        <text x="50" y="85" text-anchor="middle" font-size="8">H(H(F₀) || 0x00...)</text>
                     </g>
 
                     <!-- Arrow -->
@@ -678,7 +682,7 @@
 
                         <rect x="0" y="50" width="100" height="40" fill="#e8f5e9" stroke="#4caf50" rx="3"/>
                         <text x="50" y="73" text-anchor="middle" font-size="9">Header₁ =</text>
-                        <text x="50" y="85" text-anchor="middle" font-size="8">H(F₁ || H₀)</text>
+                        <text x="50" y="85" text-anchor="middle" font-size="8">H(H(F₁) || H₀)</text>
                     </g>
 
                     <!-- Arrow -->
@@ -691,7 +695,7 @@
 
                         <rect x="0" y="50" width="100" height="40" fill="#e8f5e9" stroke="#4caf50" rx="3"/>
                         <text x="50" y="73" text-anchor="middle" font-size="9">Header₂ =</text>
-                        <text x="50" y="85" text-anchor="middle" font-size="8">H(F₂ || H₁)</text>
+                        <text x="50" y="85" text-anchor="middle" font-size="8">H(H(F₂) || H₁)</text>
                     </g>
 
                     <!-- Arrow -->
@@ -969,8 +973,8 @@
     for height in range(wallet.last_synced + 1, tip.height + 1):
         filter = GetFilter(height)
 
-        // Verify filter matches header
-        assert SHA256d(filter) == filter_headers[height]
+        // Verify filter against the committed header chain
+        assert SHA256d(SHA256d(filter) || filter_headers[height - 1]) == filter_headers[height]
 
         // Test wallet addresses against filter
         if MatchFilter(filter, wallet.scriptPubKeys):
@@ -1041,8 +1045,8 @@
                 <p><strong>Exercise 19.3</strong></p>
                 <p>
                     Prove that if a client queries k independent peers for filter headers and
-                    at least one is honest, any filter manipulation will be detected with
-                    probability 1 - (1/k).
+                    at least one is honest, any filter manipulation is detected with
+                    certainty (the client observes conflicting headers).
                 </p>
             </div>
 

--- a/chapters/20-light-clients.html
+++ b/chapters/20-light-clients.html
@@ -452,7 +452,7 @@ script_hash (little-endian hex) = 56f4de...23c1ab</code></pre>
                 <p>
                     The privacy concerns above apply to <em>public</em> Electrum servers.
                     Running your own server (ElectrumX, Fulcrum, electrs) connected to your
-                    own full node eliminates third-party privacy leakage, though requires
+                    own full node eliminates third-party privacy leakage, though it requires
                     the resources to run both services.
                 </p>
             </div>
@@ -703,7 +703,7 @@ Response:
             </p>
 
             <div class="definition">
-                <p><strong>Definition 20.8</strong> (Validation Capability Classes)</p>
+                <p><strong>Definition 20.7</strong> (Validation Capability Classes)</p>
                 <p>
                     We classify consensus checks into four classes based on the data
                     required to verify them:
@@ -759,7 +759,7 @@ Response:
                         <td>SHA-256 midstate proof (BIP 180)</td>
                     </tr>
                     <tr>
-                        <td>Coinbase reward does not exceed subsidy + fees</td>
+                        <td>Coinbase reward does not exceed subsidy (fee component is Class U)</td>
                         <td>F</td>
                         <td>Coinbase transaction + merkle proof</td>
                     </tr>
@@ -822,7 +822,7 @@ Response:
             </p>
 
             <div class="definition">
-                <p><strong>Definition 20.9</strong> (Fraud Proof)</p>
+                <p><strong>Definition 20.8</strong> (Fraud Proof)</p>
                 <p>
                     A <em>fraud proof</em> for a consensus rule <em>R</em> applied to block <em>B</em>
                     is a data structure <em>P</em> such that:
@@ -853,8 +853,11 @@ Response:
                 200&ndash;500 bytes) and its merkle inclusion proof (about 11 hashes for
                 a block of 2000 transactions). The light client verifies the merkle proof
                 against the header it already holds, parses the coinbase outputs, and
-                checks that the total does not exceed the known subsidy for that block
-                height plus the claimed fee total.
+                checks the coinbase outputs against the known subsidy for that block
+                height. Note the limit: verifying the <em>fee</em> component would require
+                the input values of every transaction in the block, so a compact fraud
+                proof can only catch coinbase outputs exceeding the subsidy plus an
+                independently proven fee total.
             </p>
 
             <div class="theorem">
@@ -933,7 +936,7 @@ Response:
             </p>
 
             <div class="definition">
-                <p><strong>Definition 20.10</strong> (Compact Client)</p>
+                <p><strong>Definition 20.9</strong> (Compact Client)</p>
                 <p>
                     A <em>compact client</em> is a light client that:
                 </p>
@@ -1122,7 +1125,7 @@ Response:
             <h3>Decision Framework</h3>
 
             <div class="definition">
-                <p><strong>Definition 20.11</strong> (Architecture Selection Criteria)</p>
+                <p><strong>Definition 20.10</strong> (Architecture Selection Criteria)</p>
                 <p>Consider these factors when choosing a light client architecture:</p>
                 <ol>
                     <li><strong>Privacy requirements:</strong> Who can see your addresses?</li>


### PR DESCRIPTION
## Summary
Fixes from a computational re-review of chapters 16-20:

**HIGH**
- **Ch 19**: BIP-157 filter headers are double-SHA256 at both levels: `filter_header_N = SHA256d(SHA256d(filter_N) || filter_header_{N-1})`. Definition 19.7 had single SHA256 at both levels; Figure 19.3 labels and Algorithm 19.3's verification assertion (which compared a filter *hash* to a filter *header*) corrected to match.
- **Ch 19**: Example 19.2 claimed BIP-158 sets F = M = 2¹⁹; BIP-158 deliberately uses F = 784,931 ≈ 1.5 × 2¹⁹ (matching the chapter's own Definition 19.5).

**MEDIUM**
- Ch 16: BIP-34 activated via miner voting, not a flag day — example replaced with BIP-16.
- Ch 17: whitepaper Section 8 is ~210 words (the chapter quotes it in full), not 479; header-chain size unified at ~65 MB matching Theorem 17.1.
- Ch 19: F (false-positive parameter) and M (Golomb divisor 2^P) disambiguated in Theorem 19.3, its proof, and Figure 19.2 — these differ in BIP-158.
- Ch 20: definition numbering no longer skips 20.7; coinbase-inflation fraud proof now states the fee-component limitation (input values are Class U).

**LOW**
- Ch 18: Core 0.8.0 release date (Feb 2013); MurmurHash3 pseudocode tail bytes now actually enter the hash. Ch 19: Exercise 19.3 detection is deterministic, not 1−1/k; compression-ratio reconciliation; article fix. Ch 16: HTML escape. Ch 17: "years of research". Ch 20: grammar.

Fixes #95