### PR TITLE
Fix Ch 21-25 review findings

### DIFF
--- a/chapters/21-node-optimizations.html
+++ b/chapters/21-node-optimizations.html
@@ -884,7 +884,7 @@ prune=550</code></pre>
             <h3>Recommendations</h3>
 
             <div class="definition">
-                <p><strong>Definition 21.9</strong> (Node Configuration Recommendations)</p>
+                <p><strong>Remark 21.1</strong> (Node Configuration Recommendations)</p>
                 <table class="bitcoin-table">
                     <thead>
                         <tr>

--- a/chapters/22-client-side-validation.html
+++ b/chapters/22-client-side-validation.html
@@ -174,7 +174,7 @@
                     A <em>single-use seal</em> is a cryptographic primitive that can be:
                 </p>
                 <ul>
-                    <li><strong>Opened:</strong> Closed over a message exactly once</li>
+                    <li><strong>Single-use:</strong> Can be closed over a message exactly once</li>
                     <li><strong>Verified:</strong> Anyone can check if a seal was closed over message m</li>
                     <li><strong>Unique:</strong> A seal cannot be closed over two different messages</li>
                 </ul>
@@ -356,7 +356,7 @@
             <div class="definition">
                 <p><strong>Definition 22.5</strong> (RGB)</p>
                 <p>
-                    RGB (Really Good Bitcoin) is a client-side validation system where:
+                    RGB (named for the red-green-blue colors of its colored-coin heritage; officially not an acronym) is a client-side validation system where:
                 </p>
                 <ul>
                     <li><strong>State:</strong> Asset ownership, contract data stored off-chain</li>

--- a/chapters/23-payment-channels.html
+++ b/chapters/23-payment-channels.html
@@ -102,13 +102,13 @@
                     With ~4 million weight units per block and ~10 minutes per block:
                 </p>
                 <ul>
-                    <li>Average transaction: ~500-1000 weight units</li>
+                    <li>Average transaction: ~1000-2000 weight units (~250-500 vbytes)</li>
                     <li>Transactions per block: ~2000-4000</li>
                     <li>Transactions per second: ~3-7 TPS</li>
                     <li>Transactions per day: ~300,000-600,000</li>
                 </ul>
                 <p>
-                    This is roughly 7 orders of magnitude below global payment demand.
+                    This is roughly 4 orders of magnitude below global payment demand.
                 </p>
             </div>
 
@@ -299,7 +299,7 @@ OP_ENDIF</code></pre>
                     <li>Day 26: Shop broadcasts final state, closes channel</li>
                 </ol>
                 <p>
-                    30 coffees, 2 on-chain transactions.
+                    20 coffees, 2 on-chain transactions.
                 </p>
             </div>
         </section>

--- a/chapters/24-lightning.html
+++ b/chapters/24-lightning.html
@@ -523,7 +523,7 @@ lnbc1pvjluezsp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygspp5qqqsyqcyq5
                     Large payments can be split across multiple routes:
                 </p>
                 <ul>
-                    <li>Same payment_hash, different payment_secret per shard</li>
+                    <li>Same payment_hash and same payment_secret (from the invoice) across all shards; total_msat tells the receiver the full amount</li>
                     <li>Receiver waits for all shards before revealing preimage</li>
                     <li>Enables payments larger than any single channel capacity</li>
                     <li>Improves privacy by obscuring payment amounts</li>
@@ -556,7 +556,7 @@ lnbc1pvjluezsp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygspp5qqqsyqcyq5
 
                     <!-- Receiver -->
                     <circle cx="500" cy="100" r="25" fill="#ff9800" stroke="#f57c00" stroke-width="2"/>
-                    <text x="500" y="105" text-anchor="middle" font-size="10" fill="white">Dave</text>
+                    <text x="500" y="105" text-anchor="middle" font-size="10" fill="white">Zoe</text>
 
                     <!-- Path 1 arrows -->
                     <path d="M 75 85 L 175 55" stroke="#4caf50" stroke-width="2" marker-end="url(#arr-g)"/>
@@ -820,8 +820,9 @@ lnbc1pvjluezsp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygspp5qqqsyqcyq5
             <div class="exercise">
                 <p><strong>Exercise 24.6</strong></p>
                 <p>
-                    Explain why multi-path payments must use the same payment_hash but
-                    different payment_secrets. What attack would be possible otherwise?
+                    Explain why multi-path payments include a payment_secret (identical
+                    across shards) in the final-hop payload. What probing or
+                    fee-stealing attack does this prevent?
                 </p>
             </div>
         </section>

--- a/chapters/25-debunking-myths.html
+++ b/chapters/25-debunking-myths.html
@@ -332,15 +332,16 @@
                     With an LN-Penalty channel:
                 </p>
                 <ul>
-                    <li><strong>Minimum:</strong> Check blockchain once per CLTV delta (typically 1-2 weeks)</li>
+                    <li><strong>Minimum:</strong> Check the blockchain once per to_self_delay (the CSV delay on revoked commitments, commonly 144&ndash;2016 blocks: 1 day to 2 weeks)</li>
                     <li><strong>With watchtower:</strong> Watchtower monitors on your behalf</li>
                     <li><strong>eltoo channels:</strong> No punishment needed, just supersede old states</li>
                 </ul>
             </div>
 
             <p>
-                The risk is real but manageable. Checking once per week is sufficient for
-                typical 2016-block (2 week) timelocks. Watchtowers (Chapter 23) eliminate
+                The risk is real but manageable. Checking more often than the negotiated
+                to_self_delay is sufficient&mdash;once per week comfortably covers a
+                2016-block (2 week) delay. Watchtowers (Chapter 23) eliminate
                 even this requirement for most users.
             </p>
         </section>
@@ -547,8 +548,12 @@
                     Security budget sustainability requires:
                 </p>
                 <div class="formula">
-                    Total Fees ≥ Cost of Attack × Acceptable Attack Probability
+                    Cost of Attack ≥ Value Extractable by an Attack
                 </div>
+                <p>
+                    where the cost of attack is determined by the hashrate that fee
+                    revenue (plus subsidy) can sustain.
+                </p>
                 <p>
                     This depends on:
                 </p>
@@ -566,8 +571,8 @@
                     Historical fee revenue during high demand:
                 </p>
                 <ul>
-                    <li>2017 peak: ~30 BTC/block in fees</li>
-                    <li>2021 peak: ~10-15 BTC/block in fees</li>
+                    <li>2017 peak: ~10 BTC/block in fees (daily average, Dec 2017)</li>
+                    <li>2021 peak: ~2 BTC/block in fees (daily average, Apr 2021)</li>
                     <li>Regularly exceeds 1 BTC/block during congestion</li>
                 </ul>
                 <p>


### PR DESCRIPTION
## Summary
Fixes from a computational re-review of chapters 21-25:

**HIGH**
- **Ch 23**: "average transaction ~500-1000 WU" contradicted the adjacent "~2000-4000 tx/block" (4M / 500-1000 = 4000-8000); corrected to ~1000-2000 WU (~250-500 vB), which matches the TPS and tx/day figures. Coffee-shop example arithmetic: 0.08 BTC at 0.004/coffee = 20 coffees, not 30.
- **Ch 24**: Definition 24.9 claimed MPP shards use different payment_secrets; per BOLT 4 all shards carry the *same* payment_secret from the invoice (it prevents intermediate-node probing/stealing, not shard distinction). Exercise 24.6 was built on the same false premise and was reworded.
- **Ch 25**: historical fee peaks corrected against blockchain data — ~10 BTC/block (Dec 2017) and ~2 BTC/block (Apr 2021), not 30 and 10-15.

**MEDIUM**
- Ch 25: the revoked-commitment monitoring window is the to_self_delay (CSV), not the CLTV delta; typical value range aligned with Ch 23/24 (144-2016 blocks).
- Ch 22: single-use-seal property "Opened: closed over a message exactly once" relabeled "Single-use"; "RGB (Really Good Bitcoin)" replaced — RGB officially stands for nothing (colored-coins heritage).
- Ch 23: on-chain throughput is ~4 orders of magnitude below global payment demand, not 7.

**LOW**
- Ch 21: recommendations table relabeled Remark 21.1 (was Definition 21.9). Ch 24: MPP figure receiver renamed Zoe to avoid colliding with routing node D. Ch 25: security-budget inequality restated as "Cost of Attack ≥ Value Extractable" (the old form was circular).

Fixes #97