### PR TITLE
Fix Ch 28/29/35/36/39/Appendix review findings

### DIFF
--- a/chapters/28-segwit-deep-dive.html
+++ b/chapters/28-segwit-deep-dive.html
@@ -117,11 +117,13 @@
 Original:  sig = (r, s)       where s < n/2
 Malleated: sig = (r, n − s)   where n − s > n/2
 
-Verification computes: R = (z·s⁻¹)·G + (r·s⁻¹)·Q
-With s' = n − s:        R' = (z·s'⁻¹)·G + (r·s'⁻¹)·Q = −R
+Verification computes: R = (z·s⁻¹)·G + (r·s⁻¹)·P
+With s' = n − s:        R' = (z·s'⁻¹)·G + (r·s'⁻¹)·P = −R
 Since R'.x = R.x (negation preserves x), both pass.</pre>
                 <p>
-                    BIP-146 (low-S requirement) fixed this by requiring s ≤ n/2.
+                    Bitcoin Core's low-S standardness rule (proposed for consensus as
+                    BIP-146, which never activated) requires s ≤ n/2 as relay policy;
+                    SegWit removed signatures from the txid entirely.
                 </p>
             </div>
 
@@ -445,6 +447,8 @@ where:
                 </table>
                 <p>
                     vbytes = ⌈441/4⌉ = 111 vbytes (vs 192 actual bytes).
+                    (Input/output count varints are omitted for clarity; a complete
+                    serialization adds 2 base bytes.)
                 </p>
             </div>
 
@@ -455,7 +459,7 @@ where:
                 </p>
                 <ul>
                     <li><strong>All legacy:</strong> ~1 MB (1,000,000 bytes = 4,000,000 WU)</li>
-                    <li><strong>All P2WPKH:</strong> ~2.1 MB (~1,600 transactions)</li>
+                    <li><strong>All P2WPKH:</strong> ~2.1 MB (~7,000 transactions)</li>
                     <li><strong>All P2WSH multisig:</strong> ~3.7 MB</li>
                     <li><strong>Theoretical max:</strong> ~4 MB (all witness data)</li>
                 </ul>
@@ -758,7 +762,7 @@ witness:      <sig> <pubkey></pre>
                         </tr>
                         <tr>
                             <td>P2TR (Taproot)</td>
-                            <td>~111</td>
+                            <td>~154</td>
                             <td>bc1p...</td>
                         </tr>
                     </tbody>

--- a/chapters/29-taproot-architecture.html
+++ b/chapters/29-taproot-architecture.html
@@ -46,10 +46,10 @@
                     Given private key d, public key P = d·G, and message m:
                 </p>
                 <ol>
-                    <li>Choose random nonce k, compute R = k·G</li>
-                    <li>Compute challenge e = H<sub>BIP340/challenge</sub>(R || P || m)</li>
+                    <li>Choose random nonce k, compute R = k·G (negating k if R has an odd y-coordinate)</li>
+                    <li>Compute challenge e = H<sub>BIP340/challenge</sub>(x(R) || x(P) || m), hashing the x-only serializations</li>
                     <li>Compute s = k + e·d (mod n)</li>
-                    <li>Signature is (R, s), serialized as 64 bytes</li>
+                    <li>Signature is (x(R), s), serialized as 64 bytes</li>
                 </ol>
             </div>
 
@@ -445,7 +445,7 @@ Stack after:  [n] (or [n+1] if valid)
             <div class="remark">
                 <p class="remark-title">Remark 29.4 (OP_SUCCESS for Upgrades)</p>
                 <p>
-                    OP_SUCCESSx opcodes (80 of them) make scripts immediately succeed.
+                    OP_SUCCESSx opcodes (87 of them) make scripts immediately succeed.
                     Future soft forks can redefine them to have new meaning:
                 </p>
                 <ul>

--- a/chapters/35-consensus-cleanup.html
+++ b/chapters/35-consensus-cleanup.html
@@ -114,7 +114,8 @@ new_target = old_target × (actual_time / expected_time)
 
 where:
   expected_time = 2016 × 10 minutes = 2 weeks
-  actual_time = timestamp(block[2016]) - timestamp(block[0])</pre>
+  actual_time = timestamp(block[2015]) - timestamp(block[0])
+  (the first and last blocks of the same 2016-block period)</pre>
             </div>
 
             <div class="definition">
@@ -123,9 +124,9 @@ where:
                     The <strong>timewarp attack</strong> exploits a bug in difficulty calculation:
                 </p>
                 <ul>
-                    <li>Difficulty compares block[2016] to block[0], not block[2015]</li>
-                    <li>Block[2016] is the <em>first</em> block of the new period</li>
-                    <li>Attacker can manipulate block[2016]'s timestamp</li>
+                    <li>The retarget measures block[0] to block[2015] of the <em>same</em> period&mdash;the gap between block[2015] and block[2016] is never measured</li>
+                    <li>Attacker future-dates block[2015] to inflate the measured timespan</li>
+                    <li>Block[2016] starts the next window with no constraint relative to block[2015], so its timestamp can snap back to real time</li>
                     <li>Result: artificially reduce difficulty over time</li>
                 </ul>
             </div>
@@ -143,22 +144,23 @@ where:
                     <circle cx="40" cy="70" r="6" fill="#5a8f5a"/>
                     <text x="40" y="110" text-anchor="middle" font-family="Georgia" font-size="7">Block 0</text>
 
-                    <circle cx="220" cy="70" r="6" fill="#5a8f5a"/>
-                    <text x="220" y="110" text-anchor="middle" font-family="Georgia" font-size="7">Block 2015</text>
+                    <circle cx="220" cy="70" r="8" fill="#c44" stroke="#a33" stroke-width="2"/>
+                    <text x="220" y="110" text-anchor="middle" font-family="Georgia" font-size="7" fill="#c44">Block 2015</text>
+                    <text x="220" y="123" text-anchor="middle" font-family="Georgia" font-size="6" fill="#c44">(future-dated)</text>
 
-                    <circle cx="260" cy="70" r="8" fill="#c44" stroke="#a33" stroke-width="2"/>
-                    <text x="260" y="115" text-anchor="middle" font-family="Georgia" font-size="7" fill="#c44">Block 2016</text>
-                    <text x="260" y="128" text-anchor="middle" font-family="Georgia" font-size="6" fill="#c44">(manipulated)</text>
+                    <circle cx="260" cy="70" r="6" fill="#5a8f5a"/>
+                    <text x="265" y="135" text-anchor="middle" font-family="Georgia" font-size="7">Block 2016</text>
+                    <text x="265" y="148" text-anchor="middle" font-family="Georgia" font-size="6" fill="#666">(snaps back)</text>
 
                     <!-- Calculation -->
-                    <path d="M 40 70 Q 150 20 260 70" stroke="#c44" stroke-width="2" stroke-dasharray="4,2" fill="none"/>
-                    <text x="150" y="35" text-anchor="middle" font-family="Georgia" font-size="8" fill="#c44">Difficulty compares these</text>
+                    <path d="M 40 70 Q 130 20 220 70" stroke="#c44" stroke-width="2" stroke-dasharray="4,2" fill="none"/>
+                    <text x="130" y="35" text-anchor="middle" font-family="Georgia" font-size="8" fill="#c44">Retarget measures only this span</text>
 
                     <!-- Correct comparison -->
-                    <text x="400" y="140" text-anchor="middle" font-family="Georgia" font-size="8" fill="#666">Should compare: block[0] to block[2015]</text>
-                    <text x="400" y="155" text-anchor="middle" font-family="Georgia" font-size="8" fill="#c44">Actually compares: block[0] to block[2016]</text>
+                    <text x="400" y="165" text-anchor="middle" font-family="Georgia" font-size="8" fill="#666">Measured: block[0] to block[2015] (2015 intervals)</text>
+                    <text x="400" y="178" text-anchor="middle" font-family="Georgia" font-size="8" fill="#c44">Never measured: block[2015] → block[2016] gap</text>
                 </svg>
-                <figcaption>Figure 35.1: The off-by-one error in difficulty calculation.</figcaption>
+                <figcaption>Figure 35.1: The retarget window never measures the gap between periods, enabling the timewarp attack.</figcaption>
             </figure>
 
             <div class="theorem">
@@ -314,12 +316,12 @@ Different blocks, same merkle root → attack vector</pre>
             <div class="definition">
                 <p class="definition-title">Definition 35.8 (Fix Status)</p>
                 <p>
-                    Partial fix applied (BIP-30, BIP-34):
+                    Mitigations:
                 </p>
                 <ul>
-                    <li>BIP-30: No duplicate txids in UTXO set</li>
-                    <li>BIP-34: Coinbase must include block height (unique)</li>
-                    <li>Remaining issue: Interior node duplication still possible</li>
+                    <li>Bitcoin Core detects mutated blocks (duplicated merkle branches) during validation and does not mark the block hash as permanently invalid</li>
+                    <li>Separately, BIP-30/BIP-34 address duplicate <em>txids</em> (CVE-2012-1909), a different bug</li>
+                    <li>Remaining issue: the merkle construction itself still permits interior-node duplication</li>
                 </ul>
                 <p>
                     Great Consensus Cleanup proposes additional restrictions.
@@ -446,7 +448,7 @@ Different blocks, same merkle root → attack vector</pre>
                 <p class="exercise-title">Exercise 35.1</p>
                 <p>
                     Demonstrate the timewarp attack on a simplified model. If difficulty
-                    adjusts every 10 blocks and timestamps can be up to 2 hours in the past,
+                    adjusts every 10 blocks and timestamps can be up to 2 hours in the future,
                     how many periods before difficulty reaches minimum?
                 </p>
             </div>

--- a/chapters/36-security-threats.html
+++ b/chapters/36-security-threats.html
@@ -144,8 +144,9 @@
                 </p>
                 <p>
                     where λ = k · (q/p). The simplified approximation (q/p)<sup>k</sup>
-                    overestimates the probability for small k and underestimates the
-                    catch-up component; the table below uses the exact Poisson formula.
+                    underestimates the probability because it ignores the attacker's
+                    Poisson-distributed progress during the k confirmations; the table
+                    below uses the exact Poisson formula.
                 </p>
             </div>
 
@@ -220,14 +221,14 @@
                     </thead>
                     <tbody>
                         <tr>
-                            <td>March 2013</td>
-                            <td>24 blocks</td>
-                            <td>Version 0.8 bug (accidental fork)</td>
-                        </tr>
-                        <tr>
                             <td>August 2010</td>
                             <td>53 blocks</td>
                             <td>Value overflow bug (184B BTC created)</td>
+                        </tr>
+                        <tr>
+                            <td>March 2013</td>
+                            <td>24 blocks</td>
+                            <td>Version 0.8 bug (accidental fork)</td>
                         </tr>
                         <tr>
                             <td>Normal</td>

--- a/chapters/39-quantum-resistance.html
+++ b/chapters/39-quantum-resistance.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Chapter 39: Quantum Resistance - Elementary Bitcoin</title>
-    <link rel="stylesheet" href="../css/style.css">
+    <link rel="stylesheet" href="../style.css">
     <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>&#8383;</text></svg>">
 </head>
 <body>
@@ -133,9 +133,9 @@ Common Quantum Gates:
 
             <div class="formula-block">
                 <p><strong>The Discrete Log Problem:</strong></p>
-                <code>Given public key P = k × G, find private key k</code>
+                <code>Given public key P = d × G, find private key d</code>
                 <p>Classical: ~2¹²⁸ operations for 256-bit curve</p>
-                <p>Quantum (Shor): ~2⁵³ operations with enough qubits</p>
+                <p>Quantum (Shor): ~10¹² gate operations with enough qubits</p>
             </div>
 
             <h3>Algorithm Overview</h3>
@@ -145,19 +145,19 @@ Common Quantum Gates:
 Shor's Algorithm for Discrete Log:
 
 1. Quantum Phase Estimation
-   ├── Create superposition of all possible k values
-   ├── Apply controlled multiplication
-   └── Measure to find period r
+   ├── Create superposition over pairs (a, b)
+   ├── Apply controlled group operations
+   └── Measure to learn the period
 
 2. Period Finding
-   ├── Find r such that G^r ≡ 1 (mod N)
+   ├── Find the period of f(a, b) = aG + bP
    ├── Uses Quantum Fourier Transform
    └── Polynomial time vs exponential classical
 
 3. Extract Private Key
-   ├── Given P = k × G and period r
-   ├── Compute k from phase relationship
-   └── Verify: k × G = P ✓
+   ├── The period of f encodes d (since P = dG)
+   ├── Compute d from the measured phase
+   └── Verify: d × G = P ✓
 
 Resource Requirements (256-bit ECDSA):
 ├── Qubits needed: ~2,330 logical qubits
@@ -281,7 +281,7 @@ Practical Reality:
 ├── Grover requires coherent computation
 ├── Can't simply "add more qubits" for speedup
 ├── One quantum computer = √N speedup
-├── Multiple quantum computers = same total work as classical
+├── M quantum computers: only √M collective speedup (vs M× classically)
 └── ASICs likely remain competitive for mining
 </pre>
             </div>
@@ -404,7 +404,7 @@ For Breaking 256-bit ECDSA (Roetteler et al., 2017):
                     <tr>
                         <td>IBM Roadmap (2023)</td>
                         <td>2033</td>
-                        <td>"100,000 logical qubits"</td>
+                        <td>"100,000 physical qubits"</td>
                     </tr>
                     <tr>
                         <td>Mosca Theorem</td>
@@ -491,8 +491,8 @@ Quantum: Still exponential (no known efficient algorithm)
 
 ML-DSA (Dilithium) for Bitcoin:
 ├── Security: 128-256 bit post-quantum
-├── Public key: 1,952 bytes (vs 33 bytes ECDSA)
-├── Signature: 4,627 bytes (vs 72 bytes ECDSA)
+├── Public key: 2,592 bytes (vs 33 bytes ECDSA)
+├── Signature: 4,627 bytes (vs 72 bytes ECDSA)   [ML-DSA-87]
 └── Verification: Fast, similar to ECDSA
 </pre>
             </div>

--- a/chapters/appendix-a-notation.html
+++ b/chapters/appendix-a-notation.html
@@ -63,7 +63,7 @@
                 <tr>
                     <td><span class="math">ℚ</span></td>
                     <td>The rational numbers</td>
-                    <td>Ex. 1.1</td>
+                    <td>Exer. 1.1</td>
                 </tr>
                 <tr>
                     <td><span class="math">ℝ</span></td>
@@ -78,12 +78,12 @@
                 <tr>
                     <td><span class="math">ℤₙ</span></td>
                     <td>The integers modulo <span class="math">n</span>, i.e. <span class="math">{0, 1, ..., n−1}</span></td>
-                    <td>Ex. 1.1</td>
+                    <td>Ex. 1.6</td>
                 </tr>
                 <tr>
                     <td><span class="math">ℤₙ*</span></td>
                     <td>The multiplicative group of integers modulo <span class="math">n</span> (elements coprime to <span class="math">n</span>)</td>
-                    <td>Ex. 1.8</td>
+                    <td>Ex. 1.10</td>
                 </tr>
             </table>
         </section>
@@ -145,7 +145,7 @@
                 <tr>
                     <td><span class="math">log_g(h)</span></td>
                     <td>The discrete logarithm of <span class="math">h</span> to base <span class="math">g</span></td>
-                    <td>Def. 1.8</td>
+                    <td>Def. 1.9</td>
                 </tr>
             </table>
         </section>


### PR DESCRIPTION
## Summary
Fixes from a computational re-review of chapters 28, 29, 35, 36, 39, and Appendix A:

**HIGH**
- **Ch 35**: the timewarp/difficulty description was inverted. Bitcoin Core measures `timestamp(block[2015]) − timestamp(block[0])` — first and last blocks of the *same* 2016-block window (2015 intervals) — and never measures the gap to block[2016]. Definitions 35.2/35.3 and Figure 35.1 said the opposite (contradicting the chapter's own Theorem 35.1, which was correct). All corrected.
- **Ch 39**: stylesheet link pointed at a nonexistent `../css/style.css`; the page rendered unstyled. Now `../style.css`.
- **Ch 28**: comparison table listed P2TR 1-in-2-out as ~111 vB (the 1-in-1-out figure); corrected to ~154 vB.

**MEDIUM**
- Ch 29: 87 OP_SUCCESS opcodes (BIP-342), not 80.
- Ch 36: (q/p)^k *under*estimates the exact Nakamoto probability (it ignores the attacker's Poisson head start during the k confirmations).
- Ch 35: CVE-2012-2459 mitigation is Core's mutated-block detection; BIP-30/34 address the separate duplicate-txid bug.
- Ch 28: ~7,000 P2WPKH transactions per block (was ~1,600); BIP-146 never activated — low-S is relay policy.
- Ch 39: ML-DSA sizes now consistently ML-DSA-87 (pk 2,592 B / sig 4,627 B); Shor cost ~10¹² gates (was ~2⁵³, contradicting the same section); IBM 2033 roadmap targets 100,000 *physical* qubits; parallel Grover with M machines gives a √M collective speedup, not parity with classical.
- Appendix A: four stale references corrected (Def. 1.9, Ex. 1.10, Ex. 1.6, Exer. 1.1).

**LOW**
- Ch 28: malleability equations Q→P; Example 28.2 notes omitted count varints. Ch 29: Definition 29.1 includes BIP-340 even-y negation and x-only challenge. Ch 35: Exercise 35.1 timestamp bound is 2 hours in the *future*. Ch 36: reorg table chronological. Ch 39: private-key symbol d; EC-style period finding.

Fixes #99