### PR TITLE
Escape angle-bracket placeholders that vanished when rendered

### DIFF
--- a/chapters/28-segwit-deep-dive.html
+++ b/chapters/28-segwit-deep-dive.html
@@ -278,7 +278,7 @@ Since R'.x = R.x (negation preserves x), both pass.</pre>
                     A <strong>witness program</strong> is a scriptPubKey of the form:
                 </p>
                 <pre style="background: #f5f5f5; padding: 1rem; font-family: monospace; font-size: 0.85rem;">
-OP_n <data>
+OP_n &lt;data&gt;
 
 where:
   OP_n = witness version (OP_0 through OP_16)
@@ -723,9 +723,9 @@ SHA256d(
                     <strong>P2SH-P2WPKH</strong> wraps a SegWit program in P2SH:
                 </p>
                 <pre style="background: #f5f5f5; padding: 1rem; font-family: monospace; font-size: 0.85rem;">
-scriptPubKey: OP_HASH160 <hash> OP_EQUAL
+scriptPubKey: OP_HASH160 &lt;hash&gt; OP_EQUAL
 redeemScript: OP_0 <20-byte-key-hash>
-witness:      <sig> <pubkey></pre>
+witness:      &lt;sig&gt; &lt;pubkey&gt;</pre>
                 <p>
                     Address format: starts with '3' (vs 'bc1' for native).
                 </p>

--- a/chapters/29-taproot-architecture.html
+++ b/chapters/29-taproot-architecture.html
@@ -402,10 +402,10 @@ Operation:    if sig valid for pubkey: n = n + 1
 Stack after:  [n] (or [n+1] if valid)
 
 2-of-3 Tapscript:
-  <sig_C> <sig_B> <sig_A>
-  <pk_A> OP_CHECKSIG
-  <pk_B> OP_CHECKSIGADD
-  <pk_C> OP_CHECKSIGADD
+  &lt;sig_C&gt; &lt;sig_B&gt; &lt;sig_A&gt;
+  &lt;pk_A&gt; OP_CHECKSIG
+  &lt;pk_B&gt; OP_CHECKSIGADD
+  &lt;pk_C&gt; OP_CHECKSIGADD
   2 OP_NUMEQUAL</pre>
             </div>
 

--- a/chapters/39-quantum-resistance.html
+++ b/chapters/39-quantum-resistance.html
@@ -586,7 +586,7 @@ Proposed P2QRH (Quantum Resistant Hash):
 
 Implementation:
 witness_v2 = OP_2 <32-byte PQ key hash>
-spending = <PQ signature> <PQ public key>
+spending = &lt;PQ signature&gt; &lt;PQ public key&gt;
 </pre>
             </div>
 
@@ -784,7 +784,7 @@ DIY Quantum Protection (Advanced):
    └── One-time use hash-based signature
 
 2. Create P2SH address
-   ├── Script: IF <lamport verify> ELSE <ECDSA> ENDIF
+   ├── Script: IF &lt;lamport verify&gt; ELSE &lt;ECDSA&gt; ENDIF
    └── Hidden until spending
 
 3. When quantum threat arrives


### PR DESCRIPTION
## Summary
Script and witness listings in Ch 28, 29, and 39 used literal angle-bracket placeholders (`<data>`, `<hash>`, `<sig> <pubkey>`, `<sig_C> <sig_B> <sig_A>`, `<pk_A>`...`<pk_C>`, `<PQ signature>`, `<lamport verify>`, `<ECDSA>`). Browsers parse these as HTML tags, so the placeholders were invisible on the rendered page — e.g. the Tapscript multisig listing rendered as just `OP_CHECKSIG / OP_CHECKSIGADD` lines with no keys. All are now escaped as `&lt;...&gt;`.

Found via an HTML tag-balance scan across all tracked chapters; these were the only occurrences.

Fixes #103