### PR TITLE
Align Ch 36 Volume V title with canonical name

### DIFF
--- a/chapters/36-security-threats.html
+++ b/chapters/36-security-threats.html
@@ -11,7 +11,7 @@
     <nav class="chapter-nav">
         <a href="../index.html">Contents</a>
         <span class="nav-separator">·</span>
-        <span class="volume-indicator">Volume V: The Path to Sustainability</span>
+        <span class="volume-indicator">Volume V: The Path to a Sustainable Future</span>
     </nav>
 
     <header class="chapter-header">
@@ -512,7 +512,7 @@
     </main>
 
     <footer>
-        <p>Elementary Bitcoin · Volume V: The Path to Sustainability (Draft)</p>
+        <p>Elementary Bitcoin · Volume V: The Path to a Sustainable Future (Draft)</p>
     </footer>
 </body>
 </html>


### PR DESCRIPTION
## Summary
Chapter 36 called Volume V "The Path to Sustainability" in its header and footer, while chapters 38-40 and the v4 index draft use "Volume V: The Path to a Sustainable Future". Aligned both occurrences with the canonical title. (Draft chapter 37 updated in the working tree alongside.)

Fixes #105