### PR TITLE
Fix proof-rectitude findings in Ch 1-8

### DIFF
--- a/chapters/01-groups.html
+++ b/chapters/01-groups.html
@@ -454,7 +454,12 @@
                     since integer addition is commutative.
                 </p>
                 <p>
-                    (2) Define <span class="math">φ : ℤₙ → G</span> by <span class="math">φ(k) = gᵏ</span>.
+                    (2) First note that the order of <span class="math">g</span> equals
+                    <span class="math">n</span>: the elements
+                    <span class="math">e, g, g², ..., g^(m−1)</span> with
+                    <span class="math">m = ord(g)</span> are distinct and exhaust
+                    <span class="math">⟨g⟩ = G</span>, so <span class="math">m = |G| = n</span>.
+                    Define <span class="math">φ : ℤₙ → G</span> by <span class="math">φ(k) = gᵏ</span>.
                     This map is <em>surjective</em> because every element of <span class="math">G</span>
                     is <span class="math">gᵏ</span> for some <span class="math">k</span>, by definition
                     of a cyclic group. It is <em>injective</em> because if
@@ -555,8 +560,11 @@
                     <span class="math">aH ∩ bH ≠ ∅</span>, so that
                     <span class="math">a ∗ h₁ = b ∗ h₂</span> for some
                     <span class="math">h₁, h₂ ∈ H</span>. Then
-                    <span class="math">a = b ∗ h₂ ∗ h₁⁻¹ ∈ bH</span>, and it follows
-                    that <span class="math">aH ⊆ bH</span>; by symmetry,
+                    <span class="math">a = b ∗ h₂ ∗ h₁⁻¹ ∈ bH</span>; writing
+                    <span class="math">a = b ∗ h₃</span> with <span class="math">h₃ = h₂ ∗ h₁⁻¹ ∈ H</span>,
+                    we get <span class="math">aH = b ∗ (h₃H) = bH</span> since
+                    <span class="math">h₃H = H</span> for any <span class="math">h₃ ∈ H</span>.
+                    Thus <span class="math">aH ⊆ bH</span>; by symmetry,
                     <span class="math">bH ⊆ aH</span>, so <span class="math">aH = bH</span>.
                 </p>
                 <p>

--- a/chapters/02-finite-fields.html
+++ b/chapters/02-finite-fields.html
@@ -159,7 +159,8 @@
                 <p>
                     The set <span class="math">ℤₙ = {0, 1, 2, ..., n−1}</span> denotes the
                     <strong>residue classes modulo n</strong>, also called the
-                    <strong>integers modulo n</strong>.
+                    <strong>integers modulo n</strong>; we identify each class with its
+                    smallest nonnegative representative.
                 </p>
             </div>
 
@@ -282,11 +283,15 @@
             <div class="proof">
                 <p class="proof-title"></p>
                 <p>
-                    <em>(⇒)</em> Suppose <span class="math">n</span> is not prime. Then
+                    <em>(⇒)</em> Suppose <span class="math">n</span> is not prime. If
+                    <span class="math">n = 1</span>, then <span class="math">ℤ₁ = {0}</span> has
+                    <span class="math">1 = 0</span>, so it is not a field. Otherwise
                     <span class="math">n = ab</span> for some <span class="math">1 < a, b < n</span>.
                     In <span class="math">ℤₙ</span>, we have <span class="math">a × b = n ≡ 0</span>,
                     so <span class="math">a</span> and <span class="math">b</span> are zero divisors.
-                    But a field cannot have zero divisors.
+                    But a field cannot have zero divisors: if <span class="math">ab = 0</span> with
+                    <span class="math">a ≠ 0</span>, then
+                    <span class="math">b = a⁻¹ab = a⁻¹ · 0 = 0</span>.
                 </p>
                 <p>
                     <em>(⇐)</em> Suppose <span class="math">n = p</span> is prime. For any

--- a/chapters/03-elliptic-curves-real.html
+++ b/chapters/03-elliptic-curves-real.html
@@ -252,9 +252,12 @@
                     <li><strong>Identity:</strong> <span class="math">P + 𝒪 = 𝒪 + P = P</span> for all points <span class="math">P</span>.</li>
                     <li><strong>Inverse:</strong> If <span class="math">P = (x, y)</span>, then
                         <span class="math">−P = (x, −y)</span>, and <span class="math">P + (−P) = 𝒪</span>.</li>
-                    <li><strong>General addition (P ≠ Q):</strong> Draw the line through <span class="math">P</span>
+                    <li><strong>General addition (P ≠ ±Q):</strong> Draw the line through <span class="math">P</span>
                         and <span class="math">Q</span>. This line intersects <span class="math">E</span> at
-                        exactly one more point <span class="math">R</span>. Then <span class="math">P + Q = −R</span>.</li>
+                        exactly one more point <span class="math">R</span> (if the line is tangent
+                        at <span class="math">P</span> or <span class="math">Q</span>, that point
+                        counts twice and is itself <span class="math">R</span>).
+                        Then <span class="math">P + Q = −R</span>.</li>
                     <li><strong>Point doubling (P = Q):</strong> Draw the tangent line to <span class="math">E</span>
                         at <span class="math">P</span>. This line intersects <span class="math">E</span> at
                         one more point <span class="math">R</span>. Then <span class="math">P + P = 2P = −R</span>.</li>
@@ -346,9 +349,10 @@
                 <p>
                     Any non-vertical line intersects an elliptic curve in exactly three
                     points over <span class="math">ℂ</span> (counting multiplicity). Over
-                    <span class="math">ℝ</span>, there are either one or three real intersection
-                    points. In the case relevant to point addition—when two of the
-                    intersection points are known to be real—the third is guaranteed real as well.
+                    <span class="math">ℝ</span>, counting multiplicity, there are either one
+                    or three real intersection points. In the case relevant to point
+                    addition—when two of the intersection points (with multiplicity) are
+                    known to be real—the third is guaranteed real as well.
                 </p>
             </div>
 
@@ -366,8 +370,12 @@
                 </p>
                 <p>
                     This is a cubic in <span class="math">x</span>, which has exactly three roots
-                    (counting multiplicity) in any algebraically closed field, and at least one
-                    real root. <span class="qed"></span>
+                    (counting multiplicity) over <span class="math">ℂ</span>. Because the
+                    coefficients are real, non-real roots occur in conjugate pairs, so the
+                    number of real roots (with multiplicity) is one or three. In particular,
+                    if two roots are real, the conjugate-pair constraint forces the third to
+                    be real as well&mdash;explicitly, <span class="math">x₃ = m² − x₁ − x₂</span>
+                    is real. <span class="qed"></span>
                 </p>
             </div>
         </section>

--- a/chapters/04-elliptic-curves-finite.html
+++ b/chapters/04-elliptic-curves-finite.html
@@ -216,11 +216,11 @@
                     be points on <span class="math">E(𝔽ₚ)</span>. Then <span class="math">P + Q = (x₃, y₃)</span>
                     where:
                 </p>
-                <p><strong>If P ≠ Q:</strong></p>
+                <p><strong>If P ≠ ±Q:</strong></p>
                 <p style="text-align: center;">
                     <span class="math">λ = (y₂ − y₁) · (x₂ − x₁)⁻¹ mod p</span>
                 </p>
-                <p><strong>If P = Q:</strong></p>
+                <p><strong>If P = Q and y₁ ≠ 0:</strong></p>
                 <p style="text-align: center;">
                     <span class="math">λ = (3x₁² + a) · (2y₁)⁻¹ mod p</span>
                 </p>
@@ -230,6 +230,11 @@
                 </p>
                 <p style="text-align: center;">
                     <span class="math">y₃ = λ(x₁ − x₃) − y₁ mod p</span>
+                </p>
+                <p>
+                    The remaining cases are: <span class="math">P + (−P) = 𝒪</span>,
+                    <span class="math">P + 𝒪 = P</span>, and
+                    <span class="math">2(x, 0) = 𝒪</span>.
                 </p>
             </div>
 

--- a/chapters/06-hash-functions.html
+++ b/chapters/06-hash-functions.html
@@ -307,8 +307,10 @@
                 <p>
                     Satoshi Nakamoto implemented double hashing as a defense against <em>length
                     extension attacks</em>. For Merkle-Damgård constructions like SHA-256, if you
-                    know <span class="math">H(m)</span>, you can compute <span class="math">H(m || padding || m')</span>
-                    without knowing <span class="math">m</span>. Double hashing prevents this.
+                    know <span class="math">H(m)</span> and the <em>length</em> of
+                    <span class="math">m</span>, you can compute
+                    <span class="math">H(m || padding || m')</span>
+                    without knowing <span class="math">m</span> itself. Double hashing prevents this.
                 </p>
                 <p>
                     Modern cryptographers debate whether this precaution was necessary, but

--- a/chapters/07-ecdsa.html
+++ b/chapters/07-ecdsa.html
@@ -471,7 +471,9 @@ Verify(P, m, (r, s)):
                 <p class="theorem-title">Theorem 7.2 (Nonce Reuse Attack)</p>
                 <p>
                     If the same nonce <span class="math">k</span> is used to sign two different
-                    messages <span class="math">m₁</span> and <span class="math">m₂</span>,
+                    messages <span class="math">m₁</span> and <span class="math">m₂</span>
+                    with <span class="math">z₁ ≢ z₂ (mod n)</span> (which holds for distinct
+                    messages except with negligible probability),
                     the private key can be recovered.
                 </p>
             </div>
@@ -493,7 +495,9 @@ Verify(P, m, (r, s)):
                 <p style="text-align: center;">
                     <span class="math">s₁ - s₂ = k⁻¹(z₁ - z₂) mod n</span>
                 </p>
-                <p>Solving for k:</p>
+                <p>Solving for <span class="math">k</span> (the hypothesis
+                    <span class="math">z₁ ≢ z₂</span> guarantees
+                    <span class="math">s₁ − s₂ ≠ 0</span>, so the inverse exists):</p>
                 <p style="text-align: center;">
                     <span class="math">k = (z₁ - z₂)(s₁ - s₂)⁻¹ mod n</span>
                 </p>

--- a/chapters/08-schnorr.html
+++ b/chapters/08-schnorr.html
@@ -442,7 +442,7 @@ Verify(pk, m, sig):
                 <p>
                     If <span class="math">(r, s)</span> is a valid BIP-340 signature on
                     <span class="math">m</span> with key <span class="math">d</span>, then
-                    verification with <span class="math">p = x(dG)</span> returns true.
+                    verification with <span class="math">pk = x(dG)</span> returns true.
                 </p>
             </div>
 
@@ -450,7 +450,7 @@ Verify(pk, m, sig):
                 <p class="proof-title"></p>
                 <p>
                     From signing: <span class="math">s = k + ed mod n</span>, where
-                    <span class="math">R = kG</span> and <span class="math">e = H(r||p||m)</span>.
+                    <span class="math">R = kG</span> and <span class="math">e = H(r||pk||m)</span>.
                 </p>
                 <p>
                     Verification computes <span class="math">sG - eP</span>:
@@ -635,13 +635,17 @@ Verify(pk, m, sig):
                     we can verify all simultaneously:
                 </p>
                 <ol>
-                    <li>Generate random weights <span class="math">cᵢ</span></li>
-                    <li>Check: <span class="math">(Σ cᵢsᵢ)G = Σ cᵢRᵢ + Σ cᵢeᵢPᵢ</span></li>
+                    <li>Generate random weights <span class="math">cᵢ</span> uniformly from <span class="math">[1, 2¹²⁸]</span></li>
+                    <li>Check: <span class="math">(Σ cᵢsᵢ)G = Σ cᵢRᵢ + Σ cᵢeᵢPᵢ</span>,
+                        where <span class="math">Rᵢ = lift_x(rᵢ)</span> and
+                        <span class="math">eᵢ</span> is signature <span class="math">i</span>'s challenge</li>
                 </ol>
                 <p>
-                    This requires only one expensive multi-scalar multiplication instead of
-                    <span class="math">n</span> separate verifications, yielding approximately
-                    2× speedup for large batches.
+                    If every signature is valid, the check always passes; if any signature is
+                    invalid, a random choice of weights passes with probability at most
+                    <span class="math">2⁻¹²⁸</span>. This requires only one expensive
+                    multi-scalar multiplication instead of <span class="math">n</span> separate
+                    verifications, yielding approximately 2× speedup for large batches.
                 </p>
             </div>
 


### PR DESCRIPTION
## Summary
A proof-validity referee pass over chapters 1-8 (checking logic, not just arithmetic) found one false theorem statement and several proof gaps; all fixed:

**HIGH — Ch 4 Theorem 4.1** stated the EC addition formulas for all pairs of points, but the "P ≠ Q" branch divides by x₂−x₁ = 0 for the legitimate input Q = −P, and the doubling branch divides by zero when y₁ = 0 (the correct result in both cases is 𝒪, not an affine point). Chapter 3 had the hypotheses right; Ch 4 had dropped them. The theorem now requires P ≠ ±Q (resp. y₁ ≠ 0) and lists the special cases.

**MEDIUM** — Ch 3 Definition 3.4's case split was not well-defined for Q = −P (rule 3 now requires P ≠ ±Q, with a note on tangency multiplicity); Theorem 3.1's "one or three real points" needed the multiplicity qualifier and its proof the conjugate-pair argument; Ch 2 Theorem 2.1's forward direction now covers n = 1 and proves the no-zero-divisors fact it relied on.

**LOW** — Ch 1: ord(g) = |G| established before it's used; Lagrange coset step justified. Ch 7 Theorem 7.2: z₁ ≢ z₂ (mod n) hypothesis (needed for (s₁−s₂)⁻¹). Ch 8: Theorem 8.1 uses pk (avoiding the field-prime collision); Theorem 8.3 now defines Rᵢ and states the 2⁻¹²⁸ soundness bound that is the theorem's actual content. Ch 6: length extension requires knowing |m|. Ch 2: representative-vs-class identification noted.

Everything else in Ch 1-8 was verified sound symbol-by-symbol (Lagrange partition, Fermat bijection, cyclicity counting argument, Vieta arguments, ECDSA/Schnorr correctness and malleability derivations, twist-security factorization re-confirmed by computation).

Fixes #109