### PR TITLE
Fix Ch 37/38/40 deep-review findings

### DIFF
--- a/chapters/37-defense-mechanisms.html
+++ b/chapters/37-defense-mechanisms.html
@@ -49,7 +49,10 @@
                 </p>
                 <ul>
                     <li>More confirmations = exponentially lower reversal probability</li>
-                    <li>Against attacker with hashrate q < 50%, k confirmations gives security ≈ (q/(1-q))<sup>k</sup></li>
+                    <li>Against an attacker with hashrate q &lt; 50%, the reversal probability is
+                    given by Nakamoto's formula (Theorem 36.1); it decays roughly geometrically
+                    in k, but the naive catch-up bound (q/(1-q))<sup>k</sup> understates it
+                    (q = 10%, k = 6: about 0.02%, not 0.0002%)</li>
                     <li>6 confirmations (~1 hour): Standard for large transactions</li>
                     <li>1 confirmation (~10 min): Often sufficient for small amounts</li>
                 </ul>
@@ -103,11 +106,11 @@
                     <text x="60" y="85" text-anchor="middle" font-family="Georgia" font-size="8" transform="rotate(-90, 60, 85)">P(reversal)</text>
 
                     <!-- Curve for q=25% -->
-                    <path d="M 80 60 Q 120 80 160 100 T 280 120 T 400 128" stroke="#c44" stroke-width="2" fill="none"/>
+                    <path d="M 80 50 Q 120 80 160 100 T 280 120 T 400 128" stroke="#c44" stroke-width="2" fill="none"/>
                     <text x="420" y="125" font-family="Georgia" font-size="7" fill="#c44">q=25%</text>
 
                     <!-- Curve for q=10% -->
-                    <path d="M 80 50 Q 100 90 130 115 T 200 128" stroke="#f39c12" stroke-width="2" fill="none"/>
+                    <path d="M 80 50 Q 100 100 130 122 T 200 130" stroke="#f39c12" stroke-width="2" fill="none"/>
                     <text x="220" y="125" font-family="Georgia" font-size="7" fill="#f39c12">q=10%</text>
 
                     <!-- Markers -->

--- a/chapters/38-security-budget.html
+++ b/chapters/38-security-budget.html
@@ -91,7 +91,7 @@
                         <td>2024</td>
                         <td>3.125 BTC</td>
                         <td>450 BTC</td>
-                        <td>~0.85%</td>
+                        <td>~0.83%</td>
                     </tr>
                     <tr>
                         <td>5th</td>
@@ -197,13 +197,13 @@
                         <td>2021</td>
                         <td>0.00022</td>
                         <td>~21,000</td>
-                        <td>6.1%</td>
+                        <td>6.0%</td>
                     </tr>
                     <tr>
                         <td>2023 (Ordinals)</td>
                         <td>0.00015</td>
                         <td>~23,000</td>
-                        <td>6.7%</td>
+                        <td>6.5%</td>
                     </tr>
                     <tr>
                         <td>2024 (Runes, halving)</td>
@@ -325,9 +325,9 @@ Fee Determination:
                     </tr>
                     <tr>
                         <td>2018</td>
-                        <td>$70B</td>
+                        <td>$130B (avg)</td>
                         <td>$5.5B</td>
-                        <td>7.9%</td>
+                        <td>~4.0%</td>
                     </tr>
                     <tr>
                         <td>2021</td>
@@ -385,8 +385,8 @@ Fee-Only Mining Game Theory:
 
             <div class="formula-block">
                 <p><strong>Fee Sniping Condition:</strong></p>
-                <code>Attack profitable when: Fees_block_n > Subsidy + Expected_Fees_block_n+1</code>
-                <p>In a mature fee market with minimal subsidy, blocks with unusually high fees become attack targets.</p>
+                <code>Sniping attractive when: Fees_block_n − E[Fees] ≫ expected race-loss cost (∝ subsidy + E[Fees])</code>
+                <p>The sniper also collects the subsidy on the re-mined block, so the subsidy enters only through the cost of losing the race. In a mature fee market with minimal subsidy, blocks with unusually high fees become attack targets.</p>
             </div>
 
             <h3>Mitigation: Anti-Fee-Sniping Locktime</h3>
@@ -424,7 +424,7 @@ if (GetRandInt(10) == 0)
 
             <div class="info-box">
                 <h4>The "It Will Work Out" Argument</h4>
-                <p>Bitcoin has survived every challenge so far. The fee market, while imperfect, has functioned for 15 years. As Bitcoin becomes more valuable, rational users will pay appropriate fees for the security they require.</p>
+                <p>Bitcoin has survived every challenge so far. The fee market, while imperfect, has functioned for more than fifteen years. As Bitcoin becomes more valuable, rational users will pay appropriate fees for the security they require.</p>
             </div>
 
             <h3>Solution 2: Increase Block Size</h3>
@@ -527,7 +527,7 @@ Layer 2 Fee Model:
 
             <h3>Defining "Sufficient" Security</h3>
 
-            <p>Security requirements depend on the threat model:</p>
+            <p>Security requirements depend on the threat model (defense levels assume the attacker must sustain a multi-week 51% attack to profit):</p>
 
             <table class="data-table">
                 <thead>
@@ -655,7 +655,7 @@ Security Budget Timeline:
 │
 ├── 2032-2040: Subsidy < 1 BTC
 │   ├── Fees must dominate revenue
-│   ├── $100K+ BTC price helps
+│   ├── Sustained six-figure BTC prices help
 │   └── Fee sniping becomes real concern
 │
 └── 2040+: Subsidy negligible

--- a/chapters/40-monetary-future.html
+++ b/chapters/40-monetary-future.html
@@ -30,7 +30,7 @@
         <section id="introduction">
             <h2>The Unfinished Revolution</h2>
 
-            <p>Fifteen years after its creation, Bitcoin has exceeded nearly every early expectation—yet its ultimate role in the global monetary system remains undefined. Is Bitcoin digital gold? A global settlement layer? An alternative reserve currency? The base money of a new financial system?</p>
+            <p>More than fifteen years after its creation, Bitcoin has exceeded nearly every early expectation—yet its ultimate role in the global monetary system remains undefined. Is Bitcoin digital gold? A global settlement layer? An alternative reserve currency? The base money of a new financial system?</p>
 
             <p>This final chapter explores Bitcoin's potential futures: the scenarios, the obstacles, the game theory of adoption, and the profound implications for human civilization if Bitcoin achieves its maximum potential.</p>
 
@@ -118,7 +118,7 @@ Monetary Evolution:
                     <tr>
                         <td>Settlement speed</td>
                         <td>Days for international transfers</td>
-                        <td>~10 minute final settlement</td>
+                        <td>~1 hour (6 confirmations) vs days for wires</td>
                     </tr>
                 </tbody>
             </table>
@@ -169,13 +169,13 @@ Stage 5: Laggards (2030+?)
 
             <h3>Current Position</h3>
 
-            <p>As of 2024, Bitcoin appears to be transitioning from Early Majority to Late Majority:</p>
+            <p>As of the mid-2020s, Bitcoin appears to be transitioning from Early Majority to Late Majority:</p>
 
             <ul>
                 <li><strong>Spot ETFs approved:</strong> Institutional access simplified</li>
                 <li><strong>Corporate holdings:</strong> MicroStrategy, Tesla, others</li>
-                <li><strong>Nation-state adoption:</strong> El Salvador legal tender</li>
-                <li><strong>Market cap:</strong> ~$1+ trillion (top 10 global assets)</li>
+                <li><strong>Nation-state adoption:</strong> El Salvador (legal tender 2021&ndash;2025, now voluntary)</li>
+                <li><strong>Market cap:</strong> ~$2 trillion (top 10 global assets)</li>
                 <li><strong>Network effects:</strong> Self-reinforcing adoption dynamics</li>
             </ul>
         </section>
@@ -277,7 +277,7 @@ Dominant Strategy Analysis:
 Digital Gold Scenario:
 
 Market Position:
-├── 10-50% of gold's market cap ($1-6 trillion)
+├── 10-40% of gold's market cap of ~$15T ($1.5-6 trillion)
 ├── Held by 5-10% of global population
 ├── In 10-20% of investment portfolios
 └── Price: $50,000-300,000 per BTC
@@ -737,7 +737,7 @@ Speculative Adoption Timeline:
 2024-2027: Institutional Foundation
 ├── ETFs accumulate significant holdings
 ├── More public companies add treasury BTC
-├── First G20 nation adds to reserves (speculation)
+├── United States establishes Strategic Bitcoin Reserve (2025)
 ├── Lightning Network reaches 10M+ users
 └── Price range: $50K-$200K
 


### PR DESCRIPTION
## Summary
Round-2 deep review fixes for chapters 37, 38, 40:

**HIGH**
- Ch 37 stated "k confirmations gives security ≈ (q/(1−q))^k" — the naive catch-up bound that understates the true reversal probability by up to 129× (q=10%, k=6: exact 0.024% vs 0.0002%) and directly contradicts Ch 36's warning about this exact approximation. Now cites Nakamoto's formula with a worked comparison. Figure 37.1's curves also corrected (both start at P=1, q=10% strictly below q=25%).
- Ch 38 Model 3's 2018 row ($70B / $5.5B / 7.9%) was economically impossible — security% ≈ issuance/supply ≈ 4% in 2018 regardless of price. Corrected to $130B (avg) / $5.5B / ~4.0%; the declining-trend narrative is unaffected.

**MEDIUM**
- Fee-sniping condition restated: the sniper collects the subsidy on the re-mined block, so the subsidy cancels at first order and properly enters as race-loss cost.
- Threat-model table now states its multi-week-attack duration assumption.
- Ch 40: gold market cap unified at ~$15T across scenarios; on-chain settlement is ~1 hour (6 conf), matching Ch 37; El Salvador status updated (legal tender 2021–2025, voluntary since the Jan 2025 amendment); market cap ~$2T; the "first G20 nation adds reserves (speculation)" bullet replaced by the 2025 US Strategic Bitcoin Reserve.

**LOW** — exact inflation 0.83%, fee-table rounding (6.0%/6.5%), stale "15 years"/"$100K+ helps" phrasings.

Fixes #111