### PR TITLE
Fix Ch 30-34 deep-review findings

### DIFF
--- a/chapters/30-covenants.html
+++ b/chapters/30-covenants.html
@@ -187,7 +187,7 @@ DefaultCheckTemplateVerifyHash(tx, input_index):
 
                     <!-- Note -->
                     <text x="250" y="195" font-family="Georgia" font-size="8" fill="#666">CTV constrains outputs but NOT which inputs fund the tx</text>
-                    <text x="250" y="210" font-family="Georgia" font-size="8" fill="#666">→ Enables fee bumping via additional inputs</text>
+                    <text x="250" y="210" font-family="Georgia" font-size="8" fill="#666">→ Input count IS committed; fee bumping uses CPFP or a pre-committed input slot</text>
 
                     <defs>
                         <marker id="arrow30b" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
@@ -262,16 +262,19 @@ DefaultCheckTemplateVerifyHash(tx, input_index):
                     A basic vault with CTV:
                 </p>
                 <pre style="background: #f5f5f5; padding: 1rem; font-family: monospace; font-size: 0.85rem;">
-Vault Script:
+Vault Output (CTV-only; no key can spend it directly):
+  &lt;ctv_hash&gt; CTV               // Can only go to the staged withdrawal
+
+Staged Withdrawal Output:
   IF
-    &lt;hot_key&gt; CHECKSIG         // Immediate spend (compromised!)
+    &lt;delay&gt; CSV DROP
+    &lt;hot_key&gt; CHECKSIG         // Withdrawal: hot key, after the delay
   ELSE
-    &lt;ctv_hash&gt; CTV             // Must go to staged withdrawal
+    &lt;ctv_to_cold_hash&gt; CTV     // Clawback to cold storage: immediate
   ENDIF
 
-Staged Withdrawal (CTV-enforced):
-  - Output 1: Time-locked return to vault (clawback)
-  - Output 2: Time-locked to destination (actual withdrawal)</pre>
+A thief who steals the hot key must wait out the CSV delay,
+during which the owner claws the funds back to cold storage.</pre>
             </div>
 
             <h3>30.2.2 CTV Controversy</h3>
@@ -313,16 +316,20 @@ Stack after:  [x || y]</pre>
             </div>
 
             <div class="theorem">
-                <p class="theorem-title">Theorem 30.1 (CAT Enables Covenants)</p>
+                <p class="theorem-title">Proposition 30.1 (CAT Enables Covenants)</p>
                 <p>
                     OP_CAT combined with Schnorr signatures enables introspection through
-                    signature reconstruction:
+                    on-stack sighash construction (the "Schnorr trick"):
                 </p>
                 <ol>
-                    <li>Schnorr signature: (R, s) where s = k + H(R||P||m)·d</li>
-                    <li>Script reconstructs m (the sighash) using CAT</li>
-                    <li>Script verifies the signature against reconstructed message</li>
-                    <li>If valid, script has verified properties of m (the transaction)</li>
+                    <li>Schnorr signature: (R, s) where s = k + H(R||P||m)·d, with the
+                        nonce fixed to R = G so s is predictable from m</li>
+                    <li>Script assembles the claimed sighash components from witness data
+                        using CAT</li>
+                    <li>The assembled signature is passed to CHECKSIG, which only succeeds
+                        if the claimed message equals the transaction's true sighash</li>
+                    <li>Equality forces the witness-supplied components to describe the real
+                        transaction&mdash;so the script has verified properties of it</li>
                 </ol>
             </div>
 
@@ -527,37 +534,37 @@ Stack: [1 if valid]</pre>
                         <td>CTV (BIP-119)</td>
                         <td>Low</td>
                         <td>Limited covenants</td>
-                        <td>Proposed, stalled</td>
+                        <td>Draft, stalled</td>
                     </tr>
                     <tr>
                         <td>CAT (BIP-347)</td>
                         <td>Low opcode, high usage</td>
                         <td>General covenants</td>
-                        <td>Proposed</td>
+                        <td>Complete (spec)</td>
                     </tr>
                     <tr>
                         <td>VAULT (BIP-345)</td>
                         <td>Medium</td>
                         <td>Custody-specific</td>
-                        <td>Proposed</td>
+                        <td>Closed (no longer pursued)</td>
                     </tr>
                     <tr>
                         <td>APO (BIP-118)</td>
                         <td>Low</td>
                         <td>LN-Symmetry</td>
-                        <td>Proposed</td>
+                        <td>Draft</td>
                     </tr>
                     <tr>
-                        <td>TXHASH</td>
+                        <td>TXHASH (BIP-346)</td>
                         <td>Medium</td>
                         <td>Flexible covenants</td>
                         <td>Draft</td>
                     </tr>
                     <tr>
-                        <td>CSFS</td>
+                        <td>CSFS (BIP-348)</td>
                         <td>Low</td>
                         <td>Oracles, delegation</td>
-                        <td>Discussion</td>
+                        <td>Draft</td>
                     </tr>
                 </tbody>
             </table>

--- a/chapters/31-sidechains.html
+++ b/chapters/31-sidechains.html
@@ -185,7 +185,7 @@
                     </thead>
                     <tbody>
                         <tr>
-                            <td>1-minute finality</td>
+                            <td>1-minute blocks (2-block finality)</td>
                             <td>Federated trust model</td>
                         </tr>
                         <tr>
@@ -198,7 +198,7 @@
                         </tr>
                         <tr>
                             <td>Production-tested</td>
-                            <td>~$100M+ AUM risk concentration</td>
+                            <td>Hundreds of millions of dollars of AUM risk concentration</td>
                         </tr>
                     </tbody>
                 </table>
@@ -313,7 +313,7 @@
                 </p>
                 <ul>
                     <li>Miners commit BTC to participate in Stacks consensus</li>
-                    <li>BTC goes to STX stakers (recycled security)</li>
+                    <li>BTC goes to STX Stackers (recycled security)</li>
                     <li>Stacks blocks anchor to Bitcoin blocks</li>
                     <li>Not a traditional sidechain—no direct BTC peg until sBTC</li>
                 </ul>
@@ -326,7 +326,7 @@
                 </p>
                 <ul>
                     <li>Threshold signature scheme for peg custody</li>
-                    <li>Decentralized signer set (STX stakers)</li>
+                    <li>Signer set of STX Stackers (launched Dec 2024 with a curated ~15-signer set; decentralization is the end-goal)</li>
                     <li>Economic penalties for misbehavior</li>
                 </ul>
             </div>

--- a/chapters/32-beyond-lightning.html
+++ b/chapters/32-beyond-lightning.html
@@ -229,7 +229,7 @@
                 </p>
                 <ul>
                     <li>UTXO is locked to a 2-of-2: user key + statechain entity (SE) key</li>
-                    <li>Transfer: user sends their key share to recipient, SE updates co-signer</li>
+                    <li>Transfer: user sends their key share to recipient, and the SE atomically re-randomizes the shares so the old owner's copy becomes useless</li>
                     <li>SE cannot steal (doesn't know full key) but can censor</li>
                     <li>Backup transaction allows unilateral on-chain claim</li>
                 </ul>
@@ -349,7 +349,7 @@
             <div class="remark">
                 <p class="remark-title">Remark 32.4 (Factory Scaling)</p>
                 <p>
-                    For a factory with n participants and m internal channels:
+                    For a factory with n participants:
                 </p>
                 <ul>
                     <li><strong>On-chain cost:</strong> 1 UTXO (amortized over n users)</li>

--- a/chapters/33-governance.html
+++ b/chapters/33-governance.html
@@ -120,14 +120,13 @@
             <div class="definition">
                 <p class="definition-title">Definition 33.3 (BIP Types)</p>
                 <p>
-                    <strong>Standards Track:</strong> Changes affecting implementations
+                    Under BIP-3 (the current process BIP, deployed 2025), BIPs have three types:
                 </p>
-                <ul>
-                    <li>Consensus (soft/hard fork)</li>
-                    <li>Peer Services (network protocol)</li>
-                    <li>API/RPC</li>
-                    <li>Applications</li>
-                </ul>
+                <p>
+                    <strong>Specification:</strong> Changes affecting implementations
+                    (consensus rules, peer services, API/RPC, applications)&mdash;called
+                    "Standards Track" under the older BIP-2 process
+                </p>
                 <p>
                     <strong>Informational:</strong> General guidelines or information
                 </p>
@@ -143,20 +142,20 @@
                     <text x="65" y="85" text-anchor="middle" font-family="Georgia" font-size="8">Draft</text>
 
                     <rect x="130" y="60" width="70" height="40" rx="4" fill="#fff3cd" stroke="#f39c12"/>
-                    <text x="165" y="85" text-anchor="middle" font-family="Georgia" font-size="8">Proposed</text>
+                    <text x="165" y="85" text-anchor="middle" font-family="Georgia" font-size="8">Complete</text>
 
                     <rect x="230" y="60" width="70" height="40" rx="4" fill="#d4edda" stroke="#28a745"/>
-                    <text x="265" y="85" text-anchor="middle" font-family="Georgia" font-size="8">Final</text>
+                    <text x="265" y="85" text-anchor="middle" font-family="Georgia" font-size="8">Deployed</text>
 
                     <rect x="330" y="60" width="70" height="40" rx="4" fill="#d1ecf1" stroke="#17a2b8"/>
-                    <text x="365" y="85" text-anchor="middle" font-family="Georgia" font-size="8">Active</text>
+                    <text x="365" y="85" text-anchor="middle" font-family="Georgia" font-size="8">(in use)</text>
 
                     <!-- Alternative outcomes -->
                     <rect x="130" y="120" width="70" height="30" rx="4" fill="#ffe8e8" stroke="#c44"/>
-                    <text x="165" y="140" text-anchor="middle" font-family="Georgia" font-size="7">Rejected</text>
+                    <text x="165" y="140" text-anchor="middle" font-family="Georgia" font-size="7">Closed</text>
 
                     <rect x="230" y="120" width="70" height="30" rx="4" fill="#f5f5f5" stroke="#999"/>
-                    <text x="265" y="140" text-anchor="middle" font-family="Georgia" font-size="7">Withdrawn</text>
+                    <text x="265" y="140" text-anchor="middle" font-family="Georgia" font-size="7">(withdrawn = Closed)</text>
 
                     <!-- Arrows -->
                     <path d="M 100 80 L 130 80" stroke="#5a8f5a" stroke-width="1.5" marker-end="url(#arrowGreen33)"/>
@@ -201,22 +200,22 @@
                         <tr>
                             <td>32</td>
                             <td>HD Wallets</td>
-                            <td>Final</td>
+                            <td>Deployed</td>
                         </tr>
                         <tr>
                             <td>39</td>
                             <td>Mnemonic Seed Phrases</td>
-                            <td>Proposed</td>
+                            <td>Deployed</td>
                         </tr>
                         <tr>
                             <td>141</td>
                             <td>Segregated Witness</td>
-                            <td>Final</td>
+                            <td>Deployed</td>
                         </tr>
                         <tr>
                             <td>341</td>
                             <td>Taproot</td>
-                            <td>Final</td>
+                            <td>Deployed</td>
                         </tr>
                         <tr>
                             <td>119</td>

--- a/chapters/34-drivechains.html
+++ b/chapters/34-drivechains.html
@@ -25,8 +25,9 @@
             <p class="chapter-intro">
                 Drivechains propose a radical alternative to federated sidechains: let Bitcoin
                 miners themselves custody the two-way peg. Through "hashrate escrow," miners
-                collectively control sidechain withdrawals, theoretically providing trustless
-                interoperability without Bitcoin consensus changes beyond two new opcodes.
+                collectively control sidechain withdrawals, providing trust-minimized
+                (miner-majority) interoperability with only one new opcode (OP_DRIVECHAIN)
+                plus a small set of new coinbase-message rules.
                 This chapter examines BIP-300/301's mechanism, security model, and the
                 intense controversy surrounding the proposal.
             </p>
@@ -114,20 +115,21 @@
                 </p>
                 <pre style="background: #f5f5f5; padding: 1rem; font-family: monospace; font-size: 0.85rem;">
 Sidechain deposit address:
-  OP_DRIVECHAIN &lt;sidechain_id&gt;
+  OP_DRIVECHAIN &lt;sidechain_id&gt; OP_TRUE
 
 Withdrawal process:
   1. User requests withdrawal on sidechain
   2. Sidechain bundles requests into withdrawal bundle
   3. Bundle hash published to mainchain
-  4. Miners ACK/NACK in coinbase for ~13,150 blocks (~3 months)
+  4. Miners ACK/NACK in coinbase; bundle needs 13,150 ACKs
+     within a 26,300-block (~6-month) window
   5. If ACKs > threshold, withdrawal executes</pre>
             </div>
 
             <div class="definition">
                 <p class="definition-title">Definition 34.4 (Withdrawal Bundle)</p>
                 <p>
-                    A <strong>withdrawal bundle</strong> (WT^) aggregates multiple withdrawals:
+                    A <strong>withdrawal bundle</strong> (historically written WT^; current BIP-300 simply says "bundle", capped at 6,000 withdrawals) aggregates multiple withdrawals:
                 </p>
                 <ul>
                     <li>Created by sidechain nodes</li>
@@ -144,7 +146,7 @@ Withdrawal process:
                 </p>
                 <ol>
                     <li>Create a fraudulent withdrawal bundle</li>
-                    <li>Accumulate ~13,150 ACKs over ~3 months</li>
+                    <li>Accumulate 13,150 ACKs within the 26,300-block (~6-month) window (a bare-majority coalition takes ~6 months; ~3 months requires near-unanimous ACKing)</li>
                     <li>Maintain >50% hashrate commitment throughout</li>
                 </ol>
                 <p>
@@ -169,7 +171,7 @@ Withdrawal process:
                     <!-- Threshold reached -->
                     <circle cx="370" cy="80" r="8" fill="#28a745"/>
                     <text x="370" y="60" text-anchor="middle" font-family="Georgia" font-size="8">Threshold</text>
-                    <text x="370" y="110" text-anchor="middle" font-family="Georgia" font-size="7">~3 months</text>
+                    <text x="370" y="110" text-anchor="middle" font-family="Georgia" font-size="7">~3-6 months</text>
 
                     <!-- Execution -->
                     <circle cx="420" cy="80" r="8" fill="#3498db"/>
@@ -178,7 +180,7 @@ Withdrawal process:
                     <!-- ACK counter -->
                     <text x="225" y="140" text-anchor="middle" font-family="Georgia" font-size="9">ACK score: 0 → 13,150 (threshold)</text>
                 </svg>
-                <figcaption>Figure 34.2: Withdrawal voting timeline (~3 months).</figcaption>
+                <figcaption>Figure 34.2: Withdrawal voting: 13,150 ACKs within a 26,300-block (~6-month) window.</figcaption>
             </figure>
         </section>
 
@@ -253,11 +255,11 @@ OP_RETURN &lt;BMM_TAG&gt; &lt;sidechain_id&gt; &lt;block_hash&gt;
                 </p>
                 <ol>
                     <li>Malicious miners create false withdrawal to themselves</li>
-                    <li>Vote for it over ~3 months</li>
+                    <li>Vote for it over ~3-6 months</li>
                     <li>If successful, steal all sidechain deposits</li>
                 </ol>
                 <p>
-                    Cost: Must maintain >50% hashrate for 3 months while attack is visible.
+                    Cost: Must maintain >50% hashrate for 3-6 months while the attack is visible.
                 </p>
             </div>
 


### PR DESCRIPTION
## Summary
Round-2 deep review fixes for chapters 30-34, verified against the bitcoin/bips repo:

**HIGH** — Ch 30's CTV vault example was security-inverted (a hot-key branch on the vault output meant a stolen hot key spends instantly, and the clawback was time-locked when it must be immediate); now matches the canonical simple-ctv-vault design. Ch 34's "two new opcodes" corrected — BIP-300 adds one (OP_DRIVECHAIN), BIP-301 adds none.

**MEDIUM** — CTV fee-bumping note (input count is committed); CAT covenant mechanism restated as the actual Schnorr trick (the description previously required CSFS-style free-message verification); proposal status table refreshed (BIP-345 Closed, BIP-347 Complete, CSFS=BIP-348, TXHASH=BIP-346); Ch 33 modernized from the superseded BIP-2 process to BIP-3 (types, lifecycle figure, example statuses); Ch 34 voting arithmetic fixed (13,150 ACKs is the threshold within a 26,300-block ~6-month window, per BIP-300's own 50%-hashrate equivalence).

**LOW** — Liquid 2-block finality, Stacks "Stackers" terminology and sBTC curated signer set, BIP-300 deposit script trailing OP_TRUE, WT^ legacy naming, trust-minimized wording, statechain share re-randomization, unused variable removed.

Everything else verified clean: BIP-119 template fields exactly match DefaultCheckTemplateVerifyHash, federation thresholds, 13,150/26,300-block time conversions, SegWit/Taproot activation history, all numbering and nav links.

Fixes #113