### PR TITLE
Fix Ch 26-27 deep-review findings

### DIFF
--- a/chapters/26-fork-theory.html
+++ b/chapters/26-fork-theory.html
@@ -240,6 +240,13 @@
                     <li><strong>Hard fork:</strong> R<sub>old</sub> ⊂ R<sub>new</sub> (new rules are looser)</li>
                     <li><strong>Bilateral fork:</strong> R<sub>old</sub> ∩ R<sub>new</sub> = ∅ (each rule set rejects the other's blocks)</li>
                 </ul>
+                <p>
+                    In practice, "hard forks" generally satisfy the weaker condition
+                    R<sub>new</sub> ⊄ R<sub>old</sub> and may simultaneously tighten other
+                    rules. Strong replay protection (such as Bitcoin Cash's mandatory
+                    SIGHASH_FORKID) deliberately converts an expanding hard fork into a
+                    bilateral one.
+                </p>
             </div>
 
             <figure>
@@ -289,19 +296,25 @@
                 <p>
                     Blocks valid under R<sub>new</sub> are valid under R<sub>old</sub> by definition.
                     Thus, the chain built by the majority (enforcing R<sub>new</sub>) is accepted
-                    by all nodes. Any competing chain violating R<sub>new</sub> will be shorter
-                    in expectation (built by minority hash power) and rejected by upgraded nodes.
-                    Old nodes might temporarily follow the invalid chain during propagation delays,
-                    but will converge once they see the longer valid chain. □
+                    by all nodes. Any competing chain violating R<sub>new</sub> will have less cumulative
+                    work in expectation (built by minority hash power) and be rejected by upgraded
+                    nodes. Old nodes might temporarily follow the invalid chain during propagation
+                    delays, but will converge once they see the valid chain with more work. □
                 </p>
             </div>
 
-            <div class="theorem">
-                <p class="theorem-title">Theorem 26.3 (Hard Fork Necessity)</p>
+            <div class="remark">
+                <p class="remark-title">Remark 26.2 (Hard Fork Splits).</p>
                 <p>
-                    A hard fork causes a permanent chain split unless 100% of nodes upgrade.
-                    Old nodes will reject blocks valid only under R<sub>new</sub>, following
-                    their own (potentially stagnant) chain.
+                    A hard fork produces a permanent chain split when the new-rules side
+                    persistently holds the most-work chain <em>and</em> some hash power keeps
+                    extending an old-rules-only chain. Old nodes reject blocks valid only
+                    under R<sub>new</sub> and follow their own chain. If instead old-rules
+                    miners retain the majority, upgraded nodes (which still accept old-rules
+                    blocks when R<sub>old</sub> ⊂ R<sub>new</sub>) reorg back to the old
+                    chain and the fork simply dies&mdash;which is why expanding hard forks in
+                    practice pair with majority hash power, a fork-point checkpoint, or
+                    bilateral replay protection.
                 </p>
             </div>
         </section>
@@ -330,7 +343,7 @@
             </div>
 
             <div class="remark">
-                <p class="remark-title">Remark 26.2 (Network Effect Dominance)</p>
+                <p class="remark-title">Remark 26.3 (Network Effect Dominance)</p>
                 <p>
                     In fork adoption games with strong network effects, equilibria tend toward:
                 </p>
@@ -376,7 +389,7 @@
             </div>
 
             <div class="remark">
-                <p class="remark-title">Remark 26.3 (Incumbent Advantage)</p>
+                <p class="remark-title">Remark 26.4 (Incumbent Advantage)</p>
                 <p>
                     The status quo chain has inherent advantages:
                 </p>
@@ -478,7 +491,7 @@
             </figure>
 
             <div class="remark">
-                <p class="remark-title">Remark 26.4 (Bitcoin Cash Replay Protection)</p>
+                <p class="remark-title">Remark 26.5 (Bitcoin Cash Replay Protection)</p>
                 <p>
                     Bitcoin Cash (BCH) implemented strong replay protection via a new sighash
                     flag (SIGHASH_FORKID). Transactions include a fork identifier, making them
@@ -514,12 +527,12 @@
                     FCR<sub>Nakamoto</sub>(C) = argmax<sub>c∈C</sub> Σ<sub>b∈c</sub> work(b)
                 </p>
                 <p>
-                    where work(b) = 2<sup>256</sup> / target(b) for block b.
+                    where work(b) = 2<sup>256</sup> / target(b) for block b (approximately; Bitcoin Core uses 2<sup>256</sup> / (target + 1)).
                 </p>
             </div>
 
             <div class="remark">
-                <p class="remark-title">Remark 26.5 (Work vs. Length)</p>
+                <p class="remark-title">Remark 26.6 (Work vs. Length)</p>
                 <p>
                     The "longest chain" description is imprecise. The correct rule is "most
                     cumulative work." These differ when difficulty changes:
@@ -534,7 +547,7 @@
             </div>
 
             <div class="remark">
-                <p class="remark-title">Remark 26.6 (Alternative Fork Choice Rules)</p>
+                <p class="remark-title">Remark 26.7 (Alternative Fork Choice Rules)</p>
                 <p>
                     Other blockchain systems use different rules:
                 </p>
@@ -567,7 +580,7 @@
             </div>
 
             <div class="theorem">
-                <p class="theorem-title">Theorem 26.4 (Double-Spend Probability)</p>
+                <p class="theorem-title">Theorem 26.3 (Double-Spend Probability)</p>
                 <p>
                     Let q be the fraction of hash power controlled by an attacker, p = 1 − q
                     with q &lt; p, and k be the number of confirmations. The probability that
@@ -621,7 +634,7 @@
             </table>
 
             <div class="remark">
-                <p class="remark-title">Remark 26.7 (Deep Reorgs)</p>
+                <p class="remark-title">Remark 26.8 (Deep Reorgs)</p>
                 <p>
                     The deepest reorg in Bitcoin mainnet history was 53 blocks (2010), caused
                     by a bug. Since protocol stabilization, reorgs deeper than 1-2 blocks
@@ -656,7 +669,7 @@
             </div>
 
             <div class="remark">
-                <p class="remark-title">Remark 26.8 (Difficulty Death Spiral)</p>
+                <p class="remark-title">Remark 26.9 (Difficulty Death Spiral)</p>
                 <p>
                     A minority fork sharing Bitcoin's difficulty adjustment algorithm faces a
                     potential "death spiral":
@@ -708,7 +721,7 @@
             </div>
 
             <div class="remark">
-                <p class="remark-title">Remark 26.9 (Contentious Fork Outcomes)</p>
+                <p class="remark-title">Remark 26.10 (Contentious Fork Outcomes)</p>
                 <p>
                     Historical patterns for contentious forks:
                 </p>
@@ -736,7 +749,7 @@
                         </tr>
                         <tr>
                             <td>Bitcoin Unlimited</td>
-                            <td>2016</td>
+                            <td>2015-16</td>
                             <td>High</td>
                             <td>Marginal</td>
                         </tr>
@@ -769,7 +782,7 @@
             </div>
 
             <div class="remark">
-                <p class="remark-title">Remark 26.10 (Schelling Point Preservation)</p>
+                <p class="remark-title">Remark 26.11 (Schelling Point Preservation)</p>
                 <p>
                     Non-contentious soft forks preserve the Schelling point (focal point for
                     coordination) because:

--- a/chapters/27-historical-forks.html
+++ b/chapters/27-historical-forks.html
@@ -184,7 +184,7 @@ if (block.GetSerializeSize() > MAX_BLOCK_SIZE)
                 </ul>
             </div>
 
-            <h3>27.2.3 Bitcoin Unlimited (December 2015)</h3>
+            <h3>27.2.3 Bitcoin Unlimited (announced December 2015, released January 2016)</h3>
 
             <div class="definition">
                 <p class="definition-title">Definition 27.5 (Bitcoin Unlimited)</p>
@@ -301,7 +301,7 @@ if (timeSince6Blocks > 12 hours):
                     <li>BCH less profitable → miners return to BTC → cycle repeats</li>
                 </ol>
                 <p>
-                    Result: 92,000 "extra" BCH mined in first months due to fast blocks.
+                    Result: roughly 100,000+ "extra" BCH mined ahead of schedule by the time the EDA was retired (November 2017).
                 </p>
             </div>
 
@@ -346,7 +346,7 @@ if (timeSince6Blocks > 12 hours):
                     <tr>
                         <td>Hash rate (% of BTC)</td>
                         <td>~5%</td>
-                        <td>~20%</td>
+                        <td>~50-100% briefly (EDA oscillations)</td>
                         <td>~1%</td>
                     </tr>
                     <tr>
@@ -538,17 +538,17 @@ if (timeSince6Blocks > 12 hours):
                         <tr>
                             <td>May 2018</td>
                             <td>~$18 million</td>
-                            <td>22 blocks</td>
+                            <td>~20+ blocks</td>
                         </tr>
                         <tr>
                             <td>January 2020</td>
                             <td>~$72,000</td>
-                            <td>14 blocks</td>
+                            <td>14-15 blocks (two reorgs)</td>
                         </tr>
                         <tr>
                             <td>July 2020</td>
-                            <td>~$10,000</td>
-                            <td>10 blocks</td>
+                            <td>none (thwarted)</td>
+                            <td>~1,300-block secret chain rejected via checkpoint at 640,650</td>
                         </tr>
                     </tbody>
                 </table>
@@ -709,7 +709,7 @@ if (timeSince6Blocks > 12 hours):
                     <tr>
                         <td>Bitcoin SV</td>
                         <td>Ideological</td>
-                        <td>~10%</td>
+                        <td>~5%</td>
                         <td>~0.1%</td>
                         <td>Marginal</td>
                     </tr>
@@ -724,7 +724,7 @@ if (timeSince6Blocks > 12 hours):
                         <td>Bitcoin Diamond</td>
                         <td>Commercial</td>
                         <td>~1%</td>
-                        <td>~0.001%</td>
+                        <td>~0.0002%</td>
                         <td>Zombie</td>
                     </tr>
                     <tr>
@@ -754,7 +754,7 @@ if (timeSince6Blocks > 12 hours):
                     V<sub>fork</sub>(t) / V<sub>BTC</sub>(t) ∝ e<sup>-λt</sup>
                 </p>
                 <p>
-                    where λ varies by fork (BCH: ~0.3/year, BTG: ~0.7/year).
+                    where λ varies by fork (BCH: ~0.4/year, BTG: ~0.7/year).
                 </p>
                 <p>
                     This suggests that network effects compound over time, increasingly
@@ -823,8 +823,8 @@ if (timeSince6Blocks > 12 hours):
                 <p class="exercise-title">Exercise 27.1</p>
                 <p>
                     Calculate the cost (in USD) to perform a 51% attack on Bitcoin Gold for
-                    1 hour, given that BTG hash rate is approximately 2 MS/s and Equihash
-                    ASIC rental costs $0.10 per MS/s per hour. Compare to the cost of
+                    1 hour, given that BTG hash rate is approximately 2 MS/s (2,000 kS/s)
+                    and Equihash ASIC rental costs $0.10 per kS/s per hour. Compare to the cost of
                     attacking Bitcoin.
                 </p>
             </div>


### PR DESCRIPTION
## Summary
Round-2 deep review fixes for the fork-theory chapters:

**HIGH**
- The "July 2020 | ~$10,000 | 10 blocks" BTG attack row was fabricated: that attack was *thwarted* — a ~1,300-block secret chain was rejected after developers circulated a checkpoint at block 640,650. Row now records the thwarted attack.
- Exercise 27.1's rental units produced a $0.20/hour 51%-attack cost (absurd); corrected to $0.10 per kS/s per hour (~$200/hour, matching real-world estimates).

**MEDIUM**
- Ch 26 Theorem 26.3 claimed any hard fork splits permanently unless 100% upgrade — false for expanding hard forks when old-rules miners keep the most-work chain (upgraded nodes reorg back and the fork dies). Now a remark with the persistence conditions, which also explains why real forks pair with majority hash power, checkpoints, or replay protection.
- Definition 26.5's clean trichotomy made BCH formally bilateral (mandatory SIGHASH_FORKID) while Ch 27 calls it the canonical hard fork; added the reconciling note.
- BSV peak value ratio ~5% (not 10%); BCH decay constant ~0.4/yr (the chapter's own data implies it); BCH hashrate briefly reached ~50-100% of BTC during EDA oscillations (not ~20%).

**LOW** — cumulative-work wording in the Soft Fork Safety proof; Core's target+1 chainwork; BTG attack block counts per the MIT DCI / Lovejoy reports; ~100,000+ extra BCH by DAA activation; BCD ratio; Bitcoin Unlimited dates. Labels renumbered sequentially (Theorems 26.1-26.3, Remarks 26.1-26.11).

All probability tables, fork heights/dates, and the 1 MB-limit commit history were re-verified clean.

Fixes #115