### PR TITLE
Fix proof-rectitude findings in Ch 9-25

### DIFF
--- a/chapters/09-keys-addresses.html
+++ b/chapters/09-keys-addresses.html
@@ -668,13 +668,18 @@
             <div class="theorem">
                 <p class="theorem-title">Theorem 9.3 (Bech32 Error Detection)</p>
                 <p>
-                    Bech32 encoding guarantees detection of:
+                    For strings up to 90 characters, Bech32 encoding guarantees detection of:
                 </p>
                 <ul>
-                    <li>Any single character error</li>
+                    <li>Any single character substitution</li>
                     <li>Any single transposition of adjacent characters</li>
-                    <li>Any error affecting up to 4 characters</li>
+                    <li>Any substitution error affecting up to 4 characters</li>
                 </ul>
+                <p>
+                    Insertion errors are not covered&mdash;the original Bech32 checksum is
+                    malleable under certain trailing-character insertions, which is what
+                    Bech32m (used for Taproot addresses) fixes.
+                </p>
                 <p>
                     For longer error bursts, undetected errors occur with probability at most
                     1 in 10⁹.

--- a/chapters/12-merkle-trees.html
+++ b/chapters/12-merkle-trees.html
@@ -421,7 +421,9 @@ H(CD) = SHA256(SHA256(1c8d...2e3f || 9a4b...5c6d))</pre>
             <div class="theorem">
                 <p class="theorem-title">Theorem 12.2 (Merkle Proof Security)</p>
                 <p>
-                    If <span class="math">H</span> is a collision-resistant hash function, then it is
+                    If <span class="math">H</span> is a collision-resistant hash function <em>and</em>
+                    the verifier knows the tree depth (or leaves are domain-separated from
+                    interior nodes, or 64-byte transactions are excluded), then it is
                     computationally infeasible to produce a valid Merkle proof for a transaction
                     that is not in the committed set.
                 </p>
@@ -432,9 +434,15 @@ H(CD) = SHA256(SHA256(1c8d...2e3f || 9a4b...5c6d))</pre>
                 <p>
                     To forge a proof for a non-existent transaction <span class="math">tx'</span>,
                     the attacker must find hash values that combine to produce the correct root.
-                    This requires either finding a preimage (to make a valid leaf) or a collision
-                    (to substitute intermediate hashes). Both are infeasible under the assumption
-                    that <span class="math">H</span> is collision-resistant. □
+                    With the leaf/interior distinction enforced, this requires either finding a
+                    preimage (to make a valid leaf) or a collision (to substitute intermediate
+                    hashes), both infeasible under collision resistance. The extra hypothesis is
+                    necessary: Bitcoin's tree has no domain separation, so a 64-byte string that
+                    parses as a valid transaction can equal the concatenation
+                    <span class="math">left || right</span> of an interior node, yielding a
+                    "proof" for a transaction never in the block at roughly
+                    <span class="math">2⁷⁰</span>&ndash;<span class="math">2⁷⁵</span> work&mdash;far
+                    below the <span class="math">2¹²⁸</span> collision bound. □
                 </p>
             </div>
         </section>
@@ -639,13 +647,17 @@ H(CD) = SHA256(SHA256(1c8d...2e3f || 9a4b...5c6d))</pre>
             <h3>12.8.2 Leaf vs. Internal Node Ambiguity</h3>
 
             <p>
-                If an internal node hash happens to be a valid transaction hash, confusion
-                could arise. Bitcoin mitigates this by:
+                Bitcoin's Merkle tree does not distinguish leaves from internal nodes: an
+                interior node is the hash of a 64-byte string (two concatenated hashes), and
+                a 64-byte <em>transaction</em> that parses validly could occupy the same
+                position&mdash;enabling fake inclusion proofs at an estimated
+                2⁷⁰&ndash;2⁷⁵ work. Mitigations:
             </p>
 
             <ul>
-                <li>Using 32-byte hashes (collision probability negligible)</li>
-                <li>Transaction format constraints that make valid txids unlikely to occur as concatenated hashes</li>
+                <li>Verifiers can check the proof's depth against the block's transaction count</li>
+                <li>Relay policy rejects 64-byte transactions, and the Great Consensus Cleanup
+                    proposes making them consensus-invalid</li>
             </ul>
         </section>
 

--- a/chapters/13-blocks.html
+++ b/chapters/13-blocks.html
@@ -393,8 +393,9 @@ target = 0x00ffff × 256^(29-3)
                 <p class="proof-title">Proof.</p>
                 <p>
                     Modifying any data in <span class="math">B_{n-1}</span> changes its header (via the
-                    Merkle root if transactions change, or directly if header fields change). This changes
-                    <span class="math">H(B_{n-1})</span>. Since <span class="math">B_n</span> commits to
+                    Merkle root if transactions change, or directly if header fields change). Assuming
+                    <span class="math">H</span> is collision-resistant, this changes
+                    <span class="math">H(B_{n-1})</span> except with negligible probability. Since <span class="math">B_n</span> commits to
                     the original hash, the link breaks. Repairing requires new proof of work for
                     <span class="math">B_n</span> and all descendants. □
                 </p>

--- a/chapters/14-proof-of-work.html
+++ b/chapters/14-proof-of-work.html
@@ -546,10 +546,12 @@ Daily profit = $3.60 - $3.60 = $0.00</pre>
                     has success probability:
                 </p>
                 <p class="math-block">
-                    P(success) = 1 − Σₖ₌₀^z [λᵏe^(-λ)/k! × (1 − (q/p)^(z-k))]
+                    P(success) ≈ 1 − Σₖ₌₀^z [λᵏe^(-λ)/k! × (1 − (q/p)^(z-k))]
                 </p>
                 <p>
                     where <span class="math">λ = z(q/p)</span> and <span class="math">p = 1 − q</span>.
+                    (This is Nakamoto's Poisson approximation of the attacker's progress; the
+                    exact distribution is negative binomial, but the difference is small.)
                 </p>
             </div>
 
@@ -645,16 +647,21 @@ Daily profit = $3.60 - $3.60 = $0.00</pre>
                 </p>
             </div>
 
-            <div class="theorem">
-                <p class="theorem-title">Theorem 14.6 (Security Budget)</p>
+            <div class="remark">
+                <p class="remark-title">Remark 14.4 (Security Budget).</p>
                 <p>
-                    The cost to attack Bitcoin is bounded below by the mining revenue:
+                    As a first-order heuristic, the cost to attack Bitcoin scales with
+                    mining revenue:
                 </p>
                 <p class="math-block">
-                    attack_cost ≥ mining_revenue × attack_duration / block_time
+                    attack_cost ≈ mining_revenue × attack_duration / block_time
                 </p>
                 <p>
-                    This creates a "security budget" paid by inflation (subsidy) and fees.
+                    This holds under zero-margin mining (free entry drives cost toward
+                    revenue) with rented hashrate and no recapture of block rewards by the
+                    attacker; real attacks also face a duration-independent hardware floor.
+                    This revenue stream is the "security budget" paid by inflation (subsidy)
+                    and fees (see Remark 25.10 for the demand-side condition).
                 </p>
             </div>
         </section>

--- a/chapters/15-consensus-parameters.html
+++ b/chapters/15-consensus-parameters.html
@@ -659,15 +659,18 @@ Time between halvings: 210,000 × 10 min = 2,100,000 min
             <div class="theorem">
                 <p class="theorem-title">Theorem 15.4 (Consensus Incompatibility)</p>
                 <p>
-                    If any consensus parameter changes:
+                    If a consensus parameter change <em>expands</em> the set of valid
+                    blocks (for example, raising the block weight limit or altering the
+                    supply schedule):
                 </p>
                 <ul>
-                    <li>Nodes running old software reject new blocks</li>
-                    <li>Nodes running new software may reject old blocks</li>
-                    <li>The network splits into incompatible chains</li>
+                    <li>Nodes running old software reject the new blocks</li>
+                    <li>The network can split into incompatible chains</li>
                 </ul>
                 <p>
-                    This is a <strong>hard fork</strong>, creating a new currency.
+                    This is a <strong>hard fork</strong>, potentially creating a new
+                    currency. By contrast, <em>tightening</em> a parameter is a soft fork:
+                    old nodes still accept the new, stricter blocks (Chapter 16).
                 </p>
             </div>
 

--- a/chapters/16-soft-forks.html
+++ b/chapters/16-soft-forks.html
@@ -217,7 +217,8 @@
                 <ul>
                     <li>Upgraded nodes enforce new stricter rules</li>
                     <li>Non-upgraded nodes see a valid (if possibly confusing) chain</li>
-                    <li>The network remains unified on one chain</li>
+                    <li>The network converges on one chain (transient divergence is possible:
+                        in 2015 a 6-block invalid chain briefly formed after BIP-66 activation)</li>
                 </ul>
             </div>
 
@@ -227,7 +228,9 @@
                     New rules are a subset of old rules. Any block valid under new rules is
                     therefore valid under old rules. Old nodes accept the chain built by
                     upgraded miners. Since upgraded miners have majority hash power, their
-                    chain will be longest/heaviest, and all nodes follow it. □
+                    chain accumulates the most work <em>in expectation</em>, and all nodes
+                    eventually follow it&mdash;though non-enforcing miners can briefly extend
+                    an invalid chain, as in the 2015 BIP-66 incident. □
                 </p>
             </div>
         </section>

--- a/chapters/17-spv-theory.html
+++ b/chapters/17-spv-theory.html
@@ -192,7 +192,8 @@
                 </ul>
                 <p>
                     Then <span class="math">tx</span> is included in the block represented by <span class="math">H</span>,
-                    assuming the hash function is collision-resistant.
+                    assuming the hash function is collision-resistant and the proof depth is
+                    validated (see the leaf/interior caveat in Theorem 12.2).
                 </p>
             </div>
 
@@ -468,7 +469,7 @@
                     confirmations decreases exponentially with <span class="math">k</span>:
                 </p>
                 <p class="math-block">
-                    P(reversal) = 1 − Σₘ₌₀ᵏ [λᵐe^(−λ)/m! × (1 − (q/p)^(k−m))]
+                    P(reversal) ≈ 1 − Σₘ₌₀ᵏ [λᵐe^(−λ)/m! × (1 − (q/p)^(k−m))]
                 </p>
                 <p>
                     where <span class="math">λ = k(q/p)</span> and <span class="math">p = 1 − q</span>

--- a/chapters/18-bloom-filters.html
+++ b/chapters/18-bloom-filters.html
@@ -251,7 +251,13 @@
                 <p>
                     Thus the probability a specific bit is 1 is approximately (1 - e<sup>-kn/m</sup>).
                     A false positive occurs when all <var>k</var> bits checked for a non-member
-                    happen to be 1, giving probability (1 - e<sup>-kn/m</sup>)<sup>k</sup>. ∎
+                    happen to be 1, giving probability (1 - e<sup>-kn/m</sup>)<sup>k</sup>.
+                    Two approximations are hidden here: the <var>k</var> probed bits are treated
+                    as independent (they are not), and the random set-bit fraction is replaced
+                    by its expectation. The classical formula is in fact a slight
+                    <em>under</em>estimate of the true rate (Bose et al., 2008)&mdash;about 30%
+                    low at the parameters of Example 18.1&mdash;which is why the theorem says
+                    "approximately." ∎
                 </p>
             </div>
 
@@ -653,14 +659,13 @@
 
             <h3>Quantifying the Privacy Loss</h3>
 
-            <div class="theorem">
-                <p><strong>Theorem 18.4</strong> (Practical Privacy Bound)</p>
+            <div class="remark">
+                <p><strong>Remark 18.1</strong> (Practical Privacy Bound)</p>
                 <p>
-                    Under realistic conditions (persistent connections, repeated queries, filter
-                    updates), the expected number of address queries before a malicious node
-                    identifies all wallet addresses is O(n), where n is the wallet size.
-                    In practice, studies have shown identification within minutes for typical
-                    wallets.
+                    Empirically, under realistic conditions (persistent connections, repeated
+                    queries, filter updates), a malicious node identifies all wallet addresses
+                    after a number of queries roughly linear in the wallet size&mdash;within
+                    minutes for typical wallets (Gervais et al., 2014).
                 </p>
             </div>
 
@@ -688,7 +693,7 @@
             <h3>Computational Asymmetry</h3>
 
             <div class="theorem">
-                <p><strong>Theorem 18.5</strong> (DoS Amplification)</p>
+                <p><strong>Theorem 18.4</strong> (DoS Amplification)</p>
                 <p>
                     Processing a Bloom filter request against a block requires:
                 </p>

--- a/chapters/19-compact-filters.html
+++ b/chapters/19-compact-filters.html
@@ -194,7 +194,8 @@
             <div class="theorem">
                 <p><strong>Theorem 19.1</strong> (Privacy Guarantee)</p>
                 <p>
-                    In the BIP-157/158 model, a server cannot distinguish between:
+                    In the BIP-157/158 model, <em>during the filter-download phase</em> a server
+                    cannot distinguish between:
                 </p>
                 <ol>
                     <li>A client interested in address A</li>
@@ -213,9 +214,10 @@
                     Every client receives the identical filter. The client's query (getcfilters)
                     specifies only the block height range, which is identical regardless of
                     what addresses the client cares about. The filtering operation happens
-                    entirely on the client side. The only information leaked is when a client
-                    requests a full block, which reveals "I care about something in this
-                    block" but not what. ∎
+                    entirely on the client side. The guarantee is scoped to this phase: once a
+                    client requests full blocks, the <em>pattern</em> of those requests leaks
+                    information (Theorem 19.6), which is why the claim does not extend to the
+                    protocol as a whole. ∎
                 </p>
             </div>
         </section>
@@ -401,9 +403,11 @@
                 <p>
                     Each delta has expected value F (since N elements are spread over range N·F).
                     Golomb-Rice with P = log₂(F) (so that the divisor M = 2^P ≈ F) encodes
-                    values near F optimally. The expected code length per delta is
-                    approximately 1 + P = 1 + log₂(F) bits.
-                    With N deltas, total size ≈ N · (1 + log₂(F)) bits. ∎
+                    values near F optimally. Each code is a unary quotient (expected
+                    E[q] + 1 ≈ 2 bits when M ≈ F, since E[q] = e^(−M/F)/(1−e^(−M/F)) ≈ 1)
+                    followed by P remainder bits, so the expected length per delta is
+                    approximately P + 2 bits.
+                    With N deltas, total size ≈ N · (log₂(F) + 2) bits. ∎
                 </p>
             </div>
 
@@ -415,7 +419,7 @@
                     For a block with N = 2000 scriptPubKeys:
                 </p>
                 <ul>
-                    <li>Filter size ≈ 2000 × (1 + 19) = 40,000 bits = 5,000 bytes</li>
+                    <li>Filter size ≈ 2000 × (19 + 2) = 42,000 bits ≈ 5,250 bytes</li>
                     <li>Compared to full block: ~1-2 MB</li>
                     <li>Ratio: ~1/200 to 1/400 for this N; real blocks contain
                     more filter elements (~5,000&ndash;10,000), giving the
@@ -851,8 +855,10 @@
                     <li>Verifying received filter hashes to filter_header<sub>N</sub></li>
                 </ol>
                 <p>
-                    If k honest peers exist among n queried, detection probability approaches
-                    1 as k increases.
+                    If at least one honest peer is among those queried, the manipulation is
+                    detected with certainty&mdash;the client observes conflicting headers.
+                    (More honest peers help <em>resolve</em> which chain is correct, not
+                    detect the conflict.)
                 </p>
             </div>
 
@@ -871,8 +877,10 @@
                 </p>
                 <ul>
                     <li><strong>Filter download:</strong> Zero bits (all clients download same filter)</li>
-                    <li><strong>Full block request after match:</strong> log₂(N) bits where N is
-                        number of scriptPubKeys in block (server learns "client cares about one of N scripts")</li>
+                    <li><strong>Full block request after match:</strong> the server learns
+                        "the client cares about one of this block's N scriptPubKeys"&mdash;an
+                        anonymity set of size N, so a <em>larger</em> block leaks
+                        <em>less</em> about the client</li>
                 </ul>
             </div>
 
@@ -881,10 +889,11 @@
             </p>
 
             <ul>
-                <li>Average block has ~2000-3000 unique scriptPubKeys</li>
-                <li>Information leaked: ~11-12 bits per matched block</li>
-                <li>With multiple matches per block: even less specific</li>
+                <li>Average block has ~2000-3000 unique scriptPubKeys, a sizable anonymity set</li>
                 <li>False positives provide additional cover</li>
+                <li>The real deanonymization vector is <em>intersection</em>: the pattern of
+                    full-block requests across many blocks can be intersected to isolate the
+                    client's addresses, so block requests should be batched or padded</li>
             </ul>
         </section>
 

--- a/chapters/20-light-clients.html
+++ b/chapters/20-light-clients.html
@@ -888,12 +888,15 @@ Response:
                     headers. For Class F, the fraud proof provides a compact witness linking
                     the violation to the block header via merkle inclusion; the client verifies
                     the merkle path and checks the rule. For Class T, the fraud proof includes
-                    the offending transaction, its merkle path, and any referenced output data;
-                    the client verifies inclusion and re-executes the relevant check. For Class U,
+                    the offending transaction, its merkle path, and the referenced outputs
+                    <em>together with their own merkle inclusion proofs</em> (without these, a
+                    malicious prover could fabricate input data to "prove" a valid transaction
+                    invalid); the client verifies all inclusions and re-executes the relevant
+                    check. For Class U,
                     proving that a UTXO does <em>not</em> exist requires enumerating the
                     entire set or referencing a commitment that does not currently exist in
                     Bitcoin's block structure. Without such a commitment, no compact
-                    non-existence proof is possible. ∎
+                    non-existence proof is known. ∎
                 </p>
             </div>
 

--- a/chapters/21-node-optimizations.html
+++ b/chapters/21-node-optimizations.html
@@ -304,10 +304,12 @@
                     <li>PoW target, difficulty adjustment: checked</li>
                 </ul>
                 <p>
-                    An attacker would need to produce a chain with valid PoW leading to
-                    a different assumevalid block. This requires rewriting history with
-                    hundreds of exahashes of work—far exceeding the cost of a 51% attack
-                    on current blocks. ∎
+                    The hardcoded hash pins its entire ancestor set: no alternate history can
+                    become an ancestor of that block, so no amount of proof-of-work enables
+                    invalid scripts to slip beneath it. The residual trust is therefore not in
+                    PoW at all but in the correctness of the hardcoded hash shipped with the
+                    software release&mdash;an assumption already implied by running the
+                    software, and one that is auditable by anyone who fully validates. ∎
                 </p>
             </div>
 

--- a/chapters/23-payment-channels.html
+++ b/chapters/23-payment-channels.html
@@ -256,7 +256,7 @@
                     In a unidirectional channel:
                 </p>
                 <ul>
-                    <li><strong>Bob's guarantee:</strong> Can always claim the latest payment Alice signed</li>
+                    <li><strong>Bob's guarantee:</strong> Can always claim the latest payment Alice signed (provided he closes the channel before any refund locktime, added below, expires)</li>
                     <li><strong>Alice's guarantee:</strong> Bob can only claim what Alice signed</li>
                     <li><strong>Problem:</strong> Alice cannot recover uncommitted funds if Bob disappears</li>
                 </ul>
@@ -322,7 +322,7 @@ OP_ENDIF</code></pre>
             </div>
 
             <div class="example">
-                <p><strong>Example 23.2</strong> (The Double-Spend Attack)</p>
+                <p><strong>Example 23.2</strong> (The Old-State Broadcast Attack)</p>
                 <p>
                     Alice and Bob open a channel with 0.5 BTC each:
                 </p>


### PR DESCRIPTION
## Summary
A proof-validity referee pass over chapters 9-25 (logic, hypotheses, and hidden assumptions — arithmetic was verified in round 1):

**HIGH**
- **Ch 19 Theorem 19.6** quantified privacy leakage backwards: it claimed a full-block request leaks log₂(N) bits where N is the block's scriptPubKey count — but N is the *anonymity set*, so larger blocks leak less, and a 1-tx block (0 bits under the formula) actually reveals the client's exact interest. Restated correctly, with cross-block intersection identified as the real deanonymization vector.
- **Ch 15 Theorem 15.4** claimed *any* consensus-parameter change is a hard fork — false (tightening is a soft fork, as Ch 16 itself teaches). Now requires the change to expand the valid set.

**MEDIUM**
- **Ch 12/17 Merkle security**: collision resistance is not a sufficient hypothesis — Bitcoin's tree lacks leaf/interior domain separation, and 64-byte-transaction ambiguity admits fake inclusion proofs at ~2⁷⁰–2⁷⁵ work. Theorems 12.2/17.2 gain the hypothesis; §12.8.2 rewritten with the real attack and actual mitigations (proof-depth validation; 64-byte txs nonstandard, consensus-cleanup proposed).
- Ch 18 Bloom FP proof now flags its bit-independence and expectation approximations (the classical formula *under*estimates, ~30% at Example 18.1's parameters).
- Ch 19 GCS size proof includes the expected unary quotient: E[len] ≈ P + 2 bits per element (Example 19.2 ≈ 5,250 bytes); Theorem 19.1's indistinguishability scoped to the filter-download phase; Theorem 19.5 detection is *certain* with one honest peer (matching Exercise 19.3).
- Ch 14 security-budget inequality demoted to a remark with its hypotheses (zero-margin mining, rented hashrate, no reward recapture) — matching Ch 25's correct framing.
- Ch 21 AssumeValid proof: the described PoW attack was incoherent (the hardcoded hash pins its ancestor set); replaced with the actual residual-trust analysis.

**LOW** — Nakamoto formula marked as the Poisson approximation (Ch 14/17); Ch 13 collision-resistance hypothesis; Ch 9 Bech32 guarantees scoped (substitutions, ≤90 chars, Bech32m insertion caveat); Ch 16 soft-fork convergence is eventual (2015 BIP-66 incident); Ch 18 empirical privacy bound → Remark with citation; Ch 23 channel guarantee locktime hypothesis + example retitled; Ch 20 fraud-proof completeness (inclusion proofs for referenced outputs; "no compact proof is known").

Fixes #117