### PR TITLE
Fix cross-chapter inconsistencies

### DIFF
--- a/chapters/12-merkle-trees.html
+++ b/chapters/12-merkle-trees.html
@@ -620,7 +620,7 @@ H(CD) = SHA256(SHA256(1c8d...2e3f || 9a4b...5c6d))</pre>
                 </ul>
                 <p>
                     Compare this to downloading the full block (1–2 MB) or the entire blockchain
-                    (500+ GB as of 2024). The efficiency gain is dramatic.
+                    (~550 GB as of 2024). The efficiency gain is dramatic.
                 </p>
             </div>
         </section>

--- a/chapters/13-blocks.html
+++ b/chapters/13-blocks.html
@@ -466,7 +466,7 @@ target = 0x00ffff × 256^(29-3)
             <div class="remark">
                 <p class="remark-title">Remark 13.3 (Effective Size Increase)</p>
                 <p>
-                    The weight system allows blocks up to approximately 2.3 MB in practice
+                    The weight system allows blocks up to approximately 2.3 MB with typical transaction mixes (observed blocks average 1.5-2 MB)
                     (with typical transaction mixes), while maintaining backward compatibility
                     with the 1 MB limit for non-witness data.
                 </p>

--- a/chapters/15-consensus-parameters.html
+++ b/chapters/15-consensus-parameters.html
@@ -736,7 +736,7 @@ Time between halvings: 210,000 × 10 min = 2,100,000 min
                     <tr>
                         <td>Max block weight</td>
                         <td>4,000,000 WU</td>
-                        <td>~2-2.3 MB effective</td>
+                        <td>~1.5-2 MB typical (up to ~2.3 MB)</td>
                     </tr>
                     <tr>
                         <td>Coinbase maturity</td>

--- a/chapters/16-soft-forks.html
+++ b/chapters/16-soft-forks.html
@@ -709,7 +709,7 @@
 
         <nav class="chapter-navigation">
             <a href="15-consensus-parameters.html" class="prev-chapter">← Chapter 15: Consensus Parameters</a>
-            <a href="../index.html" class="next-chapter">Back to Contents →</a>
+            <a href="17-spv-theory.html" class="next-chapter">Chapter 17: SPV Theory →</a>
         </nav>
     </main>
 

--- a/chapters/17-spv-theory.html
+++ b/chapters/17-spv-theory.html
@@ -125,7 +125,7 @@
                     <rect x="45" y="130" width="150" height="25" rx="4" fill="#fff8e8" stroke="#d4a574"/>
                     <text x="120" y="147" text-anchor="middle" font-family="Georgia" font-size="10">UTXO set</text>
 
-                    <text x="120" y="175" text-anchor="middle" font-family="Georgia" font-size="10" fill="#666">~500+ GB</text>
+                    <text x="120" y="175" text-anchor="middle" font-family="Georgia" font-size="10" fill="#666">~550 GB</text>
 
                     <!-- SPV client -->
                     <rect x="280" y="30" width="180" height="160" rx="8" fill="#f5f8f0" stroke="#5a8f5a" stroke-width="2"/>
@@ -579,12 +579,12 @@
                 <tbody>
                     <tr>
                         <td>Storage required</td>
-                        <td>~500+ GB</td>
+                        <td>~550 GB</td>
                         <td>~65 MB + txs</td>
                     </tr>
                     <tr>
                         <td>Bandwidth (sync)</td>
-                        <td>~500+ GB</td>
+                        <td>~550 GB</td>
                         <td>~65 MB</td>
                     </tr>
                     <tr>

--- a/chapters/19-compact-filters.html
+++ b/chapters/19-compact-filters.html
@@ -656,7 +656,7 @@
                     filter_header<sub>N</sub> = SHA256d(SHA256d(filter<sub>N</sub>) || filter_header<sub>N-1</sub>)
                 </div>
                 <p>
-                    Where SHA256d(x) = SHA256(SHA256(x)), filter<sub>N</sub> is the raw filter bytes, and filter_header<sub>-1</sub> = 0x00...00 (32 zero bytes).
+                    Where SHA256d(x) = SHA256(SHA256(x)) (the HASH256 function of Chapter 6), filter<sub>N</sub> is the raw filter bytes, and filter_header<sub>-1</sub> = 0x00...00 (32 zero bytes).
                 </p>
             </div>
 

--- a/chapters/20-light-clients.html
+++ b/chapters/20-light-clients.html
@@ -104,7 +104,7 @@
                 <div class="trust-card trust-medium">
                     <h4>SPV / Light Node</h4>
                     <p><strong>Trust:</strong> Miners (majority honest)</p>
-                    <p><strong>Resources:</strong> ~60 MB headers + filters</p>
+                    <p><strong>Resources:</strong> ~65 MB headers + filters</p>
                     <p><strong>Example:</strong> Neutrino, BIP-157</p>
                 </div>
 

--- a/chapters/21-node-optimizations.html
+++ b/chapters/21-node-optimizations.html
@@ -94,7 +94,7 @@
                     IBD is the process of bootstrapping a new node by:
                 </p>
                 <ol>
-                    <li>Downloading all block headers (~60 MB)</li>
+                    <li>Downloading all block headers (~65 MB)</li>
                     <li>Downloading all block data (~550 GB)</li>
                     <li>Validating every transaction in every block</li>
                     <li>Building the UTXO set from genesis</li>
@@ -152,7 +152,7 @@
                         <rect x="0" y="0" width="140" height="80" fill="#e3f2fd" stroke="#1976d2" rx="5"/>
                         <text x="70" y="25" text-anchor="middle" font-size="10" font-weight="bold">Phase 1</text>
                         <text x="70" y="45" text-anchor="middle" font-size="9">Header Download</text>
-                        <text x="70" y="60" text-anchor="middle" font-size="8" fill="#666">~60 MB</text>
+                        <text x="70" y="60" text-anchor="middle" font-size="8" fill="#666">~65 MB</text>
                         <text x="70" y="73" text-anchor="middle" font-size="8" fill="#666">~minutes</text>
                     </g>
 
@@ -579,8 +579,8 @@ bitcoin-cli loadtxoutset /path/to/utxo.dat
                 <tbody>
                     <tr>
                         <td>Block headers</td>
-                        <td>All (~60 MB)</td>
-                        <td>All (~60 MB)</td>
+                        <td>All (~65 MB)</td>
+                        <td>All (~65 MB)</td>
                     </tr>
                     <tr>
                         <td>Block data</td>
@@ -847,13 +847,13 @@ prune=550</code></pre>
                     <tr>
                         <td>Full validation</td>
                         <td>~Days</td>
-                        <td>~560 GB</td>
+                        <td>~550 GB</td>
                         <td>None</td>
                     </tr>
                     <tr>
                         <td>+ AssumeValid</td>
                         <td>~Hours</td>
-                        <td>~560 GB</td>
+                        <td>~550 GB</td>
                         <td>Minimal*</td>
                     </tr>
                     <tr>
@@ -865,7 +865,7 @@ prune=550</code></pre>
                     <tr>
                         <td>AssumeUTXO</td>
                         <td>~Minutes†</td>
-                        <td>~560 GB</td>
+                        <td>~550 GB</td>
                         <td>Temporary‡</td>
                     </tr>
                     <tr>

--- a/chapters/25-debunking-myths.html
+++ b/chapters/25-debunking-myths.html
@@ -842,7 +842,7 @@
         <nav class="chapter-nav">
             <a href="24-lightning.html">← Chapter 24: Lightning Network</a>
             <a href="../index.html">Index</a>
-            <span style="color: #999;">Volume III Complete</span>
+            <a href="26-fork-theory.html">Chapter 26: Fork Theory →</a>
         </nav>
     </main>
 

--- a/chapters/36-security-threats.html
+++ b/chapters/36-security-threats.html
@@ -233,7 +233,7 @@
                         <tr>
                             <td>Normal</td>
                             <td>1 block</td>
-                            <td>~0.5% of blocks (stale blocks)</td>
+                            <td>&lt;0.05% of blocks today (stale blocks; ~0.5% before compact-block relay)</td>
                         </tr>
                     </tbody>
                 </table>

--- a/chapters/38-security-budget.html
+++ b/chapters/38-security-budget.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Chapter 38: The Security Budget Problem - Elementary Bitcoin</title>
+    <title>Chapter 38: The Security Budget Problem | Elementary Bitcoin</title>
     <link rel="stylesheet" href="../style.css">
     <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>&#8383;</text></svg>">
 </head>
@@ -766,8 +766,8 @@ Security Budget Timeline:
         </section>
 
         <nav class="chapter-navigation">
-            <a href="37-defense-mechanisms.html" class="prev-chapter">&#8592; Previous: Defense Mechanisms</a>
-            <a href="39-quantum-resistance.html" class="next-chapter">Next: Quantum Resistance &#8594;</a>
+            <a href="37-defense-mechanisms.html" class="prev-chapter">&#8592; Chapter 37: Defense Mechanisms</a>
+            <a href="39-quantum-resistance.html" class="next-chapter">Chapter 39: Quantum Resistance &#8594;</a>
         </nav>
     </article>
 

--- a/chapters/39-quantum-resistance.html
+++ b/chapters/39-quantum-resistance.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Chapter 39: Quantum Resistance - Elementary Bitcoin</title>
+    <title>Chapter 39: Quantum Resistance | Elementary Bitcoin</title>
     <link rel="stylesheet" href="../style.css">
     <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>&#8383;</text></svg>">
 </head>
@@ -872,8 +872,8 @@ Recommended Preparation Timeline:
         </section>
 
         <nav class="chapter-navigation">
-            <a href="38-security-budget.html" class="prev-chapter">&#8592; Previous: Security Budget Problem</a>
-            <a href="40-monetary-future.html" class="next-chapter">Next: Bitcoin's Monetary Future &#8594;</a>
+            <a href="38-security-budget.html" class="prev-chapter">&#8592; Chapter 38: The Security Budget Problem</a>
+            <a href="40-monetary-future.html" class="next-chapter">Chapter 40: Bitcoin's Monetary Future &#8594;</a>
         </nav>
     </article>
 

--- a/chapters/40-monetary-future.html
+++ b/chapters/40-monetary-future.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Chapter 40: Bitcoin's Monetary Future - Elementary Bitcoin</title>
+    <title>Chapter 40: Bitcoin's Monetary Future | Elementary Bitcoin</title>
     <link rel="stylesheet" href="../style.css">
     <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>&#8383;</text></svg>">
 </head>
@@ -825,7 +825,7 @@ Speculative Adoption Timeline:
         </section>
 
         <nav class="chapter-navigation">
-            <a href="39-quantum-resistance.html" class="prev-chapter">&#8592; Previous: Quantum Resistance</a>
+            <a href="39-quantum-resistance.html" class="prev-chapter">&#8592; Chapter 39: Quantum Resistance</a>
             <a href="../index.html" class="next-chapter">Return to Index &#8594;</a>
         </nav>
     </article>


### PR DESCRIPTION
## Summary
A consistency audit compared every constant, notation, and protocol claim repeated across the 41 chapters. Disagreements fixed:

- **Stale-block rate (HIGH)**: Ch 36 presented ~0.5% as the current normal rate; correct modern figure is <0.05% (compact blocks/FIBRE), as Ch 26's measured table shows. Now notes the historical figure explicitly.
- **Header chain size**: unified at ~65 MB (Ch 17 was right; Ch 20/21 said ~60 MB in five places).
- **Blockchain size**: unified at ~550 GB (was "500+ GB", "~550 GB", and "~560 GB" across Ch 12/17/19/20/21 — Ch 21 disagreed with itself).
- **SegWit capacity**: Ch 13/15 aligned with Ch 28's accurate framing (observed averages 1.5-2 MB; ~2.3 MB typical-mix ceiling).
- **Naming**: Ch 19's SHA256d now explicitly identified with Ch 6's defined HASH256.
- **Navigation**: Ch 16 → Ch 17 restored (Ch 8 crosses its volume boundary normally, so the "Back to Contents" was an inconsistency); Ch 25 now links onward to Ch 26, completing the 1→40 chain now that Volumes IV/V are committed.
- **Style**: Ch 38-40 title separator and prev/next link conventions matched to the rest of the book.

Confirmed consistent with no action needed: subsidy 3.125 BTC, halving schedule and 2140 end date, d/P/k/G/n/p notation, secp256k1 constants, weight/vsize formulas, soft/hard-fork definitions (Ch 16 vs 26), timewarp description (Ch 14 vs 35 now agree), TPS figures, BIP facts and activation history, volume titles.

Fixes #119