### PR TITLE
Fix formula formatting: display-math CSS, LaTeX leaks, minus signs

### DIFF
--- a/chapters/01-groups.html
+++ b/chapters/01-groups.html
@@ -78,7 +78,7 @@
                 <p class="example-title">Example 1.1</p>
                 <p>The following are sets:</p>
                 <ul>
-                    <li><span class="math">ℤ = {..., -2, -1, 0, 1, 2, ...}</span>, the integers</li>
+                    <li><span class="math">ℤ = {..., −2, −1, 0, 1, 2, ...}</span>, the integers</li>
                     <li><span class="math">ℕ = {0, 1, 2, 3, ...}</span>, the natural numbers</li>
                     <li><span class="math">ℝ</span>, the real numbers</li>
                     <li><span class="math">{0, 1}</span>, the binary digits</li>
@@ -465,7 +465,7 @@
                 <p>
                     (2) First note that the order of <span class="math">g</span> equals
                     <span class="math">n</span>: the elements
-                    <span class="math">e, g, g², ..., g^(m−1)</span> with
+                    <span class="math">e, g, g², ..., gᵐ⁻¹</span> with
                     <span class="math">m = ord(g)</span> are distinct and exhaust
                     <span class="math">⟨g⟩ = G</span>, so <span class="math">m = |G| = n</span>.
                     Define <span class="math">φ : ℤₙ → G</span> by <span class="math">φ(k) = gᵏ</span>.
@@ -527,8 +527,8 @@
                     In the group <span class="math">(ℤ, +)</span>:
                 </p>
                 <ul>
-                    <li>The even integers <span class="math">2ℤ = {..., -4, -2, 0, 2, 4, ...}</span> form a subgroup.</li>
-                    <li>More generally, <span class="math">nℤ = {..., -2n, -n, 0, n, 2n, ...}</span> is a subgroup for any positive integer <span class="math">n</span>.</li>
+                    <li>The even integers <span class="math">2ℤ = {..., −4, −2, 0, 2, 4, ...}</span> form a subgroup.</li>
+                    <li>More generally, <span class="math">nℤ = {..., −2n, −n, 0, n, 2n, ...}</span> is a subgroup for any positive integer <span class="math">n</span>.</li>
                     <li>The odd integers do <em>not</em> form a subgroup (why not?).</li>
                 </ul>
             </div>

--- a/chapters/02-finite-fields.html
+++ b/chapters/02-finite-fields.html
@@ -877,7 +877,7 @@ function power_mod(a, k, n):
 
             <div class="exercise">
                 <span class="exercise-number">2.7.</span>
-                Prove Wilson's theorem: <span class="math">(p-1)! ≡ -1 (mod p)</span> for any prime <span class="math">p</span>.
+                Prove Wilson's theorem: <span class="math">(p−1)! ≡ −1 (mod p)</span> for any prime <span class="math">p</span>.
                 <em>Hint: Pair each element with its inverse.</em>
             </div>
 

--- a/chapters/04-elliptic-curves-finite.html
+++ b/chapters/04-elliptic-curves-finite.html
@@ -249,8 +249,8 @@
                 <ul>
                     <li><span class="math">y₂ − y₁ = 7 − 10 = −3 ≡ 20 (mod 23)</span></li>
                     <li><span class="math">x₂ − x₁ = 9 − 3 = 6</span></li>
-                    <li>Find <span class="math">6⁻¹ mod 23</span>: Since <span class="math">6 × 4 = 24 ≡ 1</span>, we have <span class="math">6⁻¹ = 4</span>.</li>
-                    <li><span class="math">λ = 20 × 4 = 80 ≡ 11 (mod 23)</span></li>
+                    <li>Find <span class="math">6⁻¹ mod 23</span>: Since <span class="math">6 · 4 = 24 ≡ 1</span>, we have <span class="math">6⁻¹ = 4</span>.</li>
+                    <li><span class="math">λ = 20 · 4 = 80 ≡ 11 (mod 23)</span></li>
                 </ul>
                 <p><strong>Step 2:</strong> Compute x₃.</p>
                 <ul>
@@ -682,8 +682,8 @@
 
             <div class="exercise">
                 <span class="exercise-number">4.7.</span>
-                Using Hasse's theorem, give bounds on <span class="math">#E(𝔽_{101})</span> for any
-                elliptic curve over <span class="math">𝔽_{101}</span>.
+                Using Hasse's theorem, give bounds on <span class="math">#E(𝔽₁₀₁)</span> for any
+                elliptic curve over <span class="math">𝔽₁₀₁</span>.
             </div>
 
             <div class="exercise">

--- a/chapters/05-secp256k1.html
+++ b/chapters/05-secp256k1.html
@@ -315,10 +315,10 @@ FD17B448 A6855419 9C47D08F FB10D4B8</pre>
 
             <p>
                 The fact that <span class="math">n < p</span> might seem surprising. Hasse's
-                theorem guarantees that <span class="math">|n - (p+1)| ≤ 2√p</span>, but it
+                theorem guarantees that <span class="math">|n − (p+1)| ≤ 2√p</span>, but it
                 doesn't specify whether <span class="math">n</span> is slightly above or
                 below <span class="math">p + 1</span>. For secp256k1, we have
-                <span class="math">n ≈ p - 4.3 × 10³⁸</span>.
+                <span class="math">n ≈ p − 4.3 × 10³⁸</span>.
             </p>
 
             <div class="theorem">
@@ -544,7 +544,7 @@ FD17B448 A6855419 9C47D08F FB10D4B8</pre>
                 </p>
                 <ol>
                     <li>Compute <span class="math">y² = x³ + 7 mod p</span></li>
-                    <li>Compute <span class="math">y = (y²)^{(p+1)/4} mod p</span> (valid since <span class="math">p ≡ 3 (mod 4)</span>)</li>
+                    <li>Compute <span class="math">y = (y²)^((p+1)/4) mod p</span> (valid since <span class="math">p ≡ 3 (mod 4)</span>)</li>
                     <li>If the parity of <span class="math">y</span> doesn't match the prefix, use <span class="math">p − y</span></li>
                 </ol>
                 <p>

--- a/chapters/07-ecdsa.html
+++ b/chapters/07-ecdsa.html
@@ -493,19 +493,19 @@ Verify(P, m, (r, s)):
                 </p>
                 <p>Subtracting:</p>
                 <p style="text-align: center;">
-                    <span class="math">s₁ - s₂ = k⁻¹(z₁ - z₂) mod n</span>
+                    <span class="math">s₁ − s₂ = k⁻¹(z₁ − z₂) mod n</span>
                 </p>
                 <p>Solving for <span class="math">k</span> (the hypothesis
                     <span class="math">z₁ ≢ z₂</span> guarantees
                     <span class="math">s₁ − s₂ ≠ 0</span>, so the inverse exists):</p>
                 <p style="text-align: center;">
-                    <span class="math">k = (z₁ - z₂)(s₁ - s₂)⁻¹ mod n</span>
+                    <span class="math">k = (z₁ − z₂)(s₁ − s₂)⁻¹ mod n</span>
                 </p>
                 <p>
                     Once <span class="math">k</span> is known, the private key follows:
                 </p>
                 <p style="text-align: center;">
-                    <span class="math">d = r⁻¹(s₁k - z₁) mod n</span>
+                    <span class="math">d = r⁻¹(s₁k − z₁) mod n</span>
                     <span class="qed"></span>
                 </p>
             </div>
@@ -599,7 +599,7 @@ Verify(P, m, (r, s)):
                 <p class="theorem-title">Theorem 7.3 (Signature Malleability)</p>
                 <p>
                     If <span class="math">(r, s)</span> is a valid ECDSA signature, then so is
-                    <span class="math">(r, n - s)</span>.
+                    <span class="math">(r, n − s)</span>.
                 </p>
             </div>
 
@@ -610,12 +610,12 @@ Verify(P, m, (r, s)):
                     <span class="math">u₁ = zs⁻¹</span> and <span class="math">u₂ = rs⁻¹</span>.
                 </p>
                 <p>
-                    For <span class="math">s' = n - s</span>, we have
-                    <span class="math">(s')⁻¹ = (n - s)⁻¹ = -s⁻¹ mod n</span>.
+                    For <span class="math">s′ = n − s</span>, we have
+                    <span class="math">(s′)⁻¹ = (n − s)⁻¹ = −s⁻¹ mod n</span>.
                 </p>
                 <p>
-                    Thus <span class="math">u₁' = -u₁</span> and <span class="math">u₂' = -u₂</span>,
-                    giving <span class="math">u₁'G + u₂'P = -(u₁G + u₂P)</span>.
+                    Thus <span class="math">u₁′ = −u₁</span> and <span class="math">u₂′ = −u₂</span>,
+                    giving <span class="math">u₁′G + u₂′P = −(u₁G + u₂P)</span>.
                 </p>
                 <p>
                     Since negating a point only changes the y-coordinate, the x-coordinate

--- a/chapters/08-schnorr.html
+++ b/chapters/08-schnorr.html
@@ -268,7 +268,7 @@
                     tagged hashes:
                 </p>
                 <p style="text-align: center; font-size: 1.05em;">
-                    <span class="math">H_{tag}(x) = SHA256(SHA256(tag) || SHA256(tag) || x)</span>
+                    <span class="math">H_tag(x) = SHA256(SHA256(tag) || SHA256(tag) || x)</span>
                 </p>
                 <p>
                     The tag is prepended twice (64 bytes total) to align with SHA256's block size,
@@ -453,10 +453,10 @@ Verify(pk, m, sig):
                     <span class="math">R = kG</span> and <span class="math">e = H(r||pk||m)</span>.
                 </p>
                 <p>
-                    Verification computes <span class="math">sG - eP</span>:
+                    Verification computes <span class="math">sG − eP</span>:
                 </p>
                 <p style="text-align: center;">
-                    <span class="math">sG - eP = (k + ed)G - e(dG) = kG + edG - edG = kG = R</span>
+                    <span class="math">sG − eP = (k + ed)G − e(dG) = kG + edG − edG = kG = R</span>
                 </p>
                 <p>
                     Since <span class="math">r = x(R)</span> and <span class="math">R</span> has even
@@ -581,7 +581,7 @@ Verify(pk, m, sig):
                 <p class="definition-title">Definition 8.5 (Rogue Key Attack)</p>
                 <p>
                     In naive aggregation, a malicious party can choose their "public key" as
-                    <span class="math">P_{rogue} = P' - P_{honest}</span> where <span class="math">P'</span>
+                    <span class="math">P_rogue = P′ − P_honest</span> where <span class="math">P'</span>
                     is a key they control. The aggregated key becomes just <span class="math">P'</span>,
                     which the attacker can sign alone.
                 </p>

--- a/chapters/13-blocks.html
+++ b/chapters/13-blocks.html
@@ -285,7 +285,7 @@
                     The <strong>compact target</strong> format encodes a 256-bit target in 4 bytes:
                 </p>
                 <p class="math-block">
-                    target = coefficient × 256^(exponent - 3)
+                    target = coefficient × 256^(exponent − 3)
                 </p>
                 <p>
                     where <code>bits = exponent || coefficient</code> (1 byte + 3 bytes).
@@ -383,21 +383,21 @@ target = 0x00ffff × 256^(29-3)
             <div class="theorem">
                 <p class="theorem-title">Theorem 13.2 (Chain Integrity)</p>
                 <p>
-                    If block <span class="math">B_n</span> contains <code>prev_hash = H(B_{n-1})</code>,
-                    then any modification to <span class="math">B_{n-1}</span> (including its transactions)
-                    invalidates <span class="math">B_n</span> and all subsequent blocks.
+                    If block <span class="math">Bₙ</span> contains <code>prev_hash = H(B[n-1])</code>,
+                    then any modification to <span class="math">Bₙ₋₁</span> (including its transactions)
+                    invalidates <span class="math">Bₙ</span> and all subsequent blocks.
                 </p>
             </div>
 
             <div class="proof">
                 <p class="proof-title">Proof.</p>
                 <p>
-                    Modifying any data in <span class="math">B_{n-1}</span> changes its header (via the
+                    Modifying any data in <span class="math">Bₙ₋₁</span> changes its header (via the
                     Merkle root if transactions change, or directly if header fields change). Assuming
                     <span class="math">H</span> is collision-resistant, this changes
-                    <span class="math">H(B_{n-1})</span> except with negligible probability. Since <span class="math">B_n</span> commits to
+                    <span class="math">H(Bₙ₋₁)</span> except with negligible probability. Since <span class="math">Bₙ</span> commits to
                     the original hash, the link breaks. Repairing requires new proof of work for
-                    <span class="math">B_n</span> and all descendants. □
+                    <span class="math">Bₙ</span> and all descendants. □
                 </p>
             </div>
         </section>

--- a/chapters/14-proof-of-work.html
+++ b/chapters/14-proof-of-work.html
@@ -546,7 +546,7 @@ Daily profit = $3.60 - $3.60 = $0.00</pre>
                     has success probability:
                 </p>
                 <p class="math-block">
-                    P(success) ≈ 1 − Σₖ₌₀^z [λᵏe^(-λ)/k! × (1 − (q/p)^(z-k))]
+                    P(success) ≈ 1 − Σₖ₌₀ᶻ [λᵏe^(−λ)/k! × (1 − (q/p)^(z−k))]
                 </p>
                 <p>
                     where <span class="math">λ = z(q/p)</span> and <span class="math">p = 1 − q</span>.

--- a/chapters/17-spv-theory.html
+++ b/chapters/17-spv-theory.html
@@ -378,7 +378,7 @@
                 </p>
                 <ol>
                     <li>Create a valid-looking block header (requires solving PoW)</li>
-                    <li>Create <span class="math">k-1</span> additional headers building on it</li>
+                    <li>Create <span class="math">k−1</span> additional headers building on it</li>
                     <li>Present this chain to the SPV client</li>
                 </ol>
                 <p>

--- a/chapters/18-bloom-filters.html
+++ b/chapters/18-bloom-filters.html
@@ -233,7 +233,7 @@
                     approximately:
                 </p>
                 <div class="formula">
-                    p ≈ (1 - e<sup>-kn/m</sup>)<sup>k</sup>
+                    p ≈ (1 − e<sup>−kn/m</sup>)<sup>k</sup>
                 </div>
             </div>
 
@@ -242,16 +242,16 @@
                 <p>
                     After inserting one element, each of the <var>k</var> hash functions sets
                     one bit. The probability that a specific bit is <em>not</em> set by one
-                    hash function is (1 - 1/m). After <var>kn</var> hash operations (from <var>n</var>
+                    hash function is (1 − 1/m). After <var>kn</var> hash operations (from <var>n</var>
                     elements), the probability a specific bit is still 0 is:
                 </p>
                 <p style="text-align: center;">
-                    (1 - 1/m)<sup>kn</sup> ≈ e<sup>-kn/m</sup>
+                    (1 − 1/m)<sup>kn</sup> ≈ e<sup>−kn/m</sup>
                 </p>
                 <p>
                     Thus the probability a specific bit is 1 is approximately (1 - e<sup>-kn/m</sup>).
                     A false positive occurs when all <var>k</var> bits checked for a non-member
-                    happen to be 1, giving probability (1 - e<sup>-kn/m</sup>)<sup>k</sup>.
+                    happen to be 1, giving probability (1 − e<sup>−kn/m</sup>)<sup>k</sup>.
                     Two approximations are hidden here: the <var>k</var> probed bits are treated
                     as independent (they are not), and the random set-bit fraction is replaced
                     by its expectation. The classical formula is in fact a slight
@@ -278,17 +278,17 @@
             <div class="example">
                 <p><strong>Example 18.1</strong> (Filter Sizing)</p>
                 <p>
-                    Suppose an SPV wallet has 100 addresses and wants a 0.1% (10<sup>-3</sup>) false
+                    Suppose an SPV wallet has 100 addresses and wants a 0.1% (10<sup>−3</sup>) false
                     positive rate. We need:
                 </p>
                 <p style="text-align: center;">
-                    (0.6185)<sup>m/100</sup> = 10<sup>-3</sup>
+                    (0.6185)<sup>m/100</sup> = 10<sup>−3</sup>
                 </p>
                 <p>
-                    Taking logarithms: m/100 · ln(0.6185) = ln(10<sup>-3</sup>)
+                    Taking logarithms: m/100 · ln(0.6185) = ln(10<sup>−3</sup>)
                 </p>
                 <p style="text-align: center;">
-                    m = 100 · (-6.908) / (-0.481) ≈ 1,436 bits ≈ 180 bytes
+                    m = 100 · (−6.908) / (−0.481) ≈ 1,436 bits ≈ 180 bytes
                 </p>
                 <p>
                     With k = 0.693 · (1436/100) ≈ 10 hash functions.
@@ -555,7 +555,7 @@
                 <p><strong>Proof sketch.</strong></p>
                 <p>
                     The attacker knows the hash function construction (Algorithm 18.1). For each
-                    candidate address <var>a</var>, they compute h₀(a), h₁(a), ..., h<sub>k-1</sub>(a)
+                    candidate address <var>a</var>, they compute h₀(a), h₁(a), ..., hₖ₋₁(a)
                     and check if all corresponding bits are set. True positives (actual wallet
                     addresses) will always match. False positives occur at rate p, but with
                     millions of blockchain addresses and typical filter sizes, the number of
@@ -625,10 +625,10 @@
                     the intersection of matching addresses has vastly reduced false positive rate:
                 </p>
                 <div class="formula">
-                    p<sub>intersection</sub> ≈ p₁ · p₂
+                    p_intersection ≈ p₁ · p₂
                 </div>
                 <p>
-                    After just 3 filter versions with p = 0.001, the false positive rate drops to 10<sup>-9</sup>.
+                    After just 3 filter versions with p = 0.001, the false positive rate drops to 10<sup>−9</sup>.
                 </p>
             </div>
 

--- a/chapters/19-compact-filters.html
+++ b/chapters/19-compact-filters.html
@@ -257,7 +257,7 @@
                 </p>
                 <ul>
                     <li><strong>Quotient:</strong> q = n >> P (right shift by P bits)</li>
-                    <li><strong>Remainder:</strong> r = n & ((1 << P) - 1) (low P bits)</li>
+                    <li><strong>Remainder:</strong> <code>r = n &amp; ((1 &lt;&lt; P) - 1)</code> (low P bits)</li>
                     <li><strong>Encoding:</strong> [q ones] [0] [P-bit remainder]</li>
                 </ul>
             </div>
@@ -267,13 +267,13 @@
                 <p>Encode n = 25 with P = 4 (M = 16):</p>
                 <ul>
                     <li>q = 25 >> 4 = 1</li>
-                    <li>r = 25 & 15 = 9 = 1001<sub>2</sub></li>
+                    <li><code>r = 25 &amp; 15 = 9</code> = 1001₂</li>
                     <li>Encoding: <span class="golomb-bits">1</span><span class="golomb-bits">0</span><span class="golomb-bits">1001</span> = "101001"</li>
                 </ul>
                 <p>Encode n = 7 with P = 4:</p>
                 <ul>
                     <li>q = 7 >> 4 = 0</li>
-                    <li>r = 7 & 15 = 7 = 0111<sub>2</sub></li>
+                    <li><code>r = 7 &amp; 15 = 7</code> = 0111₂</li>
                     <li>Encoding: <span class="golomb-bits">0</span><span class="golomb-bits">0111</span> = "00111"</li>
                 </ul>
             </div>
@@ -653,7 +653,7 @@
                     The filter header for block N is:
                 </p>
                 <div class="formula">
-                    filter_header<sub>N</sub> = SHA256d(SHA256d(filter<sub>N</sub>) || filter_header<sub>N-1</sub>)
+                    filter_header<sub>N</sub> = SHA256d(SHA256d(filter<sub>N</sub>) || filter_header<sub>N−1</sub>)
                 </div>
                 <p>
                     Where SHA256d(x) = SHA256(SHA256(x)) (the HASH256 function of Chapter 6), filter<sub>N</sub> is the raw filter bytes, and filter_header<sub>-1</sub> = 0x00...00 (32 zero bytes).
@@ -823,7 +823,7 @@
                     of at least one false positive is:
                 </p>
                 <div class="formula">
-                    P(false positive) = 1 - (1 - 1/F)<sup>Q</sup> ≈ Q/F
+                    P(false positive) = 1 − (1 − 1/F)<sup>Q</sup> ≈ Q/F
                 </div>
                 <p>
                     With F = 784931, a wallet with 100 addresses has approximately 1/7849

--- a/chapters/25-debunking-myths.html
+++ b/chapters/25-debunking-myths.html
@@ -417,13 +417,13 @@
                     As of 2024:
                 </p>
                 <ul>
-                    <li><strong>Collision resistance:</strong> 2<sup>128</sup> operations (birthday bound); no attacks on full SHA-256 significantly better than this</li>
-                    <li><strong>Preimage resistance:</strong> 2<sup>256</sup> operations; no attacks better than brute force</li>
-                    <li><strong>Second preimage:</strong> 2<sup>256</sup> operations; no practical attacks</li>
+                    <li><strong>Collision resistance:</strong> 2¹²⁸ operations (birthday bound); no attacks on full SHA-256 significantly better than this</li>
+                    <li><strong>Preimage resistance:</strong> 2²⁵⁶ operations; no attacks better than brute force</li>
+                    <li><strong>Second preimage:</strong> 2²⁵⁶ operations; no practical attacks</li>
                 </ul>
                 <p>
                     Even if SHA-256 were weakened to 128-bit security, this provides
-                    2<sup>128</sup> operations—still computationally infeasible.
+                    2¹²⁸ operations—still computationally infeasible.
                 </p>
             </div>
 

--- a/chapters/26-fork-theory.html
+++ b/chapters/26-fork-theory.html
@@ -46,7 +46,7 @@
                     parent block, creating divergent chain histories. Let B<sub>p</sub> be a block
                     and B<sub>1</sub>, B<sub>2</sub> be distinct blocks such that:
                 </p>
-                <p style="text-align: center; font-family: 'Times New Roman', serif;">
+                <p class="math-block">
                     prev_hash(B<sub>1</sub>) = prev_hash(B<sub>2</sub>) = hash(B<sub>p</sub>)
                 </p>
                 <p>
@@ -117,7 +117,7 @@
                     chain tip. For natural forks, this occurs when one branch accumulates strictly
                     more work:
                 </p>
-                <p style="text-align: center; font-family: 'Times New Roman', serif;">
+                <p class="math-block">
                     W(chain<sub>1</sub>) > W(chain<sub>2</sub>) ⟹ nodes adopt chain<sub>1</sub>
                 </p>
                 <p>
@@ -140,8 +140,8 @@
                     Let λ be the block arrival rate (blocks per second) and δ be the network
                     propagation delay. The probability of a natural fork is approximately:
                 </p>
-                <p style="text-align: center; font-family: 'Times New Roman', serif;">
-                    P(fork) ≈ 1 - e<sup>-λδ</sup> ≈ λδ for small λδ
+                <p class="math-block">
+                    P(fork) ≈ 1 − e<sup>−λδ</sup> ≈ λδ for small λδ
                 </p>
             </div>
 
@@ -152,8 +152,8 @@
                     completes. The inter-arrival time follows an exponential distribution with
                     rate λ. The probability that another block arrives within time δ is:
                 </p>
-                <p style="text-align: center; font-family: 'Times New Roman', serif;">
-                    P(T ≤ δ) = 1 - e<sup>-λδ</sup>
+                <p class="math-block">
+                    P(T ≤ δ) = 1 − e<sup>−λδ</sup>
                 </p>
                 <p>
                     For Bitcoin, λ ≈ 1/600 blocks/second and δ ≈ 1-10 seconds, giving
@@ -333,7 +333,7 @@
                     and v<sub>B</sub>(n-k) be the value of holding coins on chain A (with k adopters)
                     and chain B (with n-k adopters) respectively. The payoff exhibits network effects:
                 </p>
-                <p style="text-align: center; font-family: 'Times New Roman', serif;">
+                <p class="math-block">
                     v<sub>A</sub>(k) = f(k) · m<sub>A</sub>
                 </p>
                 <p>
@@ -513,7 +513,7 @@
                     A <strong>fork choice rule</strong> is a function that selects the "best"
                     chain from a set of valid chains:
                 </p>
-                <p style="text-align: center; font-family: 'Times New Roman', serif;">
+                <p class="math-block">
                     FCR: 𝒫(Chains) → Chain
                 </p>
             </div>
@@ -523,7 +523,7 @@
                 <p>
                     Bitcoin's fork choice rule selects the chain with most cumulative work:
                 </p>
-                <p style="text-align: center; font-family: 'Times New Roman', serif;">
+                <p class="math-block">
                     FCR<sub>Nakamoto</sub>(C) = argmax<sub>c∈C</sub> Σ<sub>b∈c</sub> work(b)
                 </p>
                 <p>
@@ -588,7 +588,7 @@
                     Accounting also for blocks the attacker mines during the confirmation
                     period (Theorem 14.4), the probability of a successful double-spend is:
                 </p>
-                <p style="text-align: center; font-family: 'Times New Roman', serif;">
+                <p class="math-block">
                     P(double-spend) = 1 − Σ<sub>m=0</sub><sup>k</sup> [λ<sup>m</sup>e<sup>−λ</sup>/m! × (1 − (q/p)<sup>k−m</sup>)],&nbsp;&nbsp;λ = k(q/p)
                 </p>
                 <p>

--- a/chapters/27-historical-forks.html
+++ b/chapters/27-historical-forks.html
@@ -750,8 +750,8 @@ if (timeSince6Blocks > 12 hours):
                     Empirically, Bitcoin forks exhibit value decay relative to BTC following
                     a pattern consistent with:
                 </p>
-                <p style="text-align: center; font-family: 'Times New Roman', serif;">
-                    V<sub>fork</sub>(t) / V<sub>BTC</sub>(t) ∝ e<sup>-λt</sup>
+                <p class="math-block">
+                    V<sub>fork</sub>(t) / V<sub>BTC</sub>(t) ∝ e<sup>−λt</sup>
                 </p>
                 <p>
                     where λ varies by fork (BCH: ~0.4/year, BTG: ~0.7/year).

--- a/chapters/28-segwit-deep-dive.html
+++ b/chapters/28-segwit-deep-dive.html
@@ -254,7 +254,7 @@ Since R'.x = R.x (negation preserves x), both pass.</pre>
                 <p>
                     For SegWit transactions, the txid is computed excluding witness data:
                 </p>
-                <p style="text-align: center; font-family: 'Times New Roman', serif;">
+                <p class="math-block">
                     txid = SHA256d(version || inputs || outputs || locktime)
                 </p>
                 <p>
@@ -359,13 +359,13 @@ where:
                 <p>
                     <strong>Block weight</strong> is calculated as:
                 </p>
-                <p style="text-align: center; font-family: 'Times New Roman', serif;">
+                <p class="math-block">
                     weight = 3 × base_size + total_size
                 </p>
                 <p>
                     Equivalently:
                 </p>
-                <p style="text-align: center; font-family: 'Times New Roman', serif;">
+                <p class="math-block">
                     weight = base_size × 4 + witness_size × 1
                 </p>
                 <p>
@@ -378,7 +378,7 @@ where:
                 <p>
                     <strong>Virtual bytes</strong> (vbytes) convert weight to a size metric:
                 </p>
-                <p style="text-align: center; font-family: 'Times New Roman', serif;">
+                <p class="math-block">
                     vbytes = ⌈weight / 4⌉
                 </p>
                 <p>
@@ -496,7 +496,7 @@ where:
                     The <strong>witness root</strong> is a Merkle root computed from wtxids
                     (witness transaction IDs), which include witness data:
                 </p>
-                <p style="text-align: center; font-family: 'Times New Roman', serif;">
+                <p class="math-block">
                     wtxid = SHA256d(serialized tx with witness)
                 </p>
                 <p>
@@ -724,7 +724,7 @@ SHA256d(
                 </p>
                 <pre style="background: #f5f5f5; padding: 1rem; font-family: monospace; font-size: 0.85rem;">
 scriptPubKey: OP_HASH160 &lt;hash&gt; OP_EQUAL
-redeemScript: OP_0 <20-byte-key-hash>
+redeemScript: OP_0 &lt;20-byte-key-hash&gt;
 witness:      &lt;sig&gt; &lt;pubkey&gt;</pre>
                 <p>
                     Address format: starts with '3' (vs 'bc1' for native).

--- a/chapters/29-taproot-architecture.html
+++ b/chapters/29-taproot-architecture.html
@@ -69,7 +69,7 @@
                 <p>
                     If the signature is valid:
                 </p>
-                <p style="text-align: center; font-family: 'Times New Roman', serif;">
+                <p class="math-block">
                     s·G = (k + e·d)·G = k·G + e·d·G = R + e·P ✓
                 </p>
             </div>
@@ -142,7 +142,7 @@
                     Given n signatures (R<sub>i</sub>, s<sub>i</sub>) on messages m<sub>i</sub>
                     with public keys P<sub>i</sub>, batch verify by checking:
                 </p>
-                <p style="text-align: center; font-family: 'Times New Roman', serif;">
+                <p class="math-block">
                     (Σ a<sub>i</sub>·s<sub>i</sub>)·G = Σ a<sub>i</sub>·R<sub>i</sub> + Σ a<sub>i</sub>·e<sub>i</sub>·P<sub>i</sub>
                 </p>
                 <p>
@@ -174,13 +174,13 @@
                     A <strong>tweaked public key</strong> Q is computed from internal key P
                     and tweak t:
                 </p>
-                <p style="text-align: center; font-family: 'Times New Roman', serif;">
+                <p class="math-block">
                     Q = P + t·G
                 </p>
                 <p>
                     The corresponding tweaked private key (if P = d·G):
                 </p>
-                <p style="text-align: center; font-family: 'Times New Roman', serif;">
+                <p class="math-block">
                     q = d + t (mod n)
                 </p>
             </div>
@@ -190,7 +190,7 @@
                 <p>
                     For Taproot, the tweak encodes the script tree:
                 </p>
-                <p style="text-align: center; font-family: 'Times New Roman', serif;">
+                <p class="math-block">
                     t = H<sub>TapTweak</sub>(P || script_root)
                 </p>
                 <p>

--- a/chapters/30-covenants.html
+++ b/chapters/30-covenants.html
@@ -579,7 +579,7 @@ Stack: [1 if valid]</pre>
                     A <strong>recursive covenant</strong> can enforce that outputs must
                     themselves be encumbered by the same (or similar) covenant:
                 </p>
-                <p style="text-align: center; font-family: 'Times New Roman', serif;">
+                <p class="math-block">
                     spend(covenant) → outputs must have covenant
                 </p>
                 <p>

--- a/chapters/35-consensus-cleanup.html
+++ b/chapters/35-consensus-cleanup.html
@@ -175,7 +175,7 @@ where:
                     <li><strong>Phase 2:</strong> Set the <em>first</em> block of the next period
                         (block[2016]) to a timestamp far in the <em>past</em></li>
                     <li>The difficulty formula sees a large
-                        <span class="math">actual_time</span> (future minus past), causing
+                        <code>actual_time</code> (future minus past), causing
                         difficulty to decrease (subject to the 4× clamp per period)</li>
                     <li>Repeat: each period reduces difficulty by up to 4×</li>
                     <li>After ~16 periods, difficulty approaches zero</li>

--- a/chapters/36-security-threats.html
+++ b/chapters/36-security-threats.html
@@ -136,7 +136,7 @@
                     the number of confirmations. The exact probability of a successful
                     double-spend (Nakamoto, 2008) is:
                 </p>
-                <p style="text-align: center; font-family: 'Times New Roman', serif;">
+                <p class="math-block">
                     P(success) = 1 if q ≥ 0.5<br>
                     P(success) = 1 − Σ<sub>m=0</sub><sup>k</sup>
                     [λ<sup>m</sup>e<sup>−λ</sup>/m! · (1 − (q/p)<sup>k−m</sup>)]
@@ -247,7 +247,7 @@
                 <ul>
                     <li>P(1-block reorg) ≈ δ/T ≈ 0.5-1%</li>
                     <li>P(2-block reorg) ≈ (δ/T)² ≈ 0.01%</li>
-                    <li>P(k-block reorg) ≈ (δ/T)<sup>k</sup> (approximately)</li>
+                    <li>P(k-block reorg) ≈ (δ/T)ᵏ (approximately)</li>
                 </ul>
                 <p>
                     Deep reorgs under honest mining are astronomically unlikely.
@@ -276,8 +276,8 @@
                 <p>
                     Selfish mining is profitable when attacker hashrate q satisfies:
                 </p>
-                <p style="text-align: center; font-family: 'Times New Roman', serif;">
-                    q > (1 - γ) / (3 - 2γ)
+                <p class="math-block">
+                    q > (1 − γ) / (3 − 2γ)
                 </p>
                 <p>
                     where γ is the fraction of honest miners who mine on attacker's block

--- a/chapters/37-defense-mechanisms.html
+++ b/chapters/37-defense-mechanisms.html
@@ -51,7 +51,7 @@
                     <li>More confirmations = exponentially lower reversal probability</li>
                     <li>Against an attacker with hashrate q &lt; 50%, the reversal probability is
                     given by Nakamoto's formula (Theorem 36.1); it decays roughly geometrically
-                    in k, but the naive catch-up bound (q/(1-q))<sup>k</sup> understates it
+                    in k, but the naive catch-up bound (q/(1−q))<sup>k</sup> understates it
                     (q = 10%, k = 6: about 0.02%, not 0.0002%)</li>
                     <li>6 confirmations (~1 hour): Standard for large transactions</li>
                     <li>1 confirmation (~10 min): Often sufficient for small amounts</li>
@@ -333,7 +333,7 @@ nMinimumChainWork = 0x0000000000000000000000000000000000000000
                 <p>
                     Bitcoin's security is funded by:
                 </p>
-                <p style="text-align: center; font-family: 'Times New Roman', serif;">
+                <p class="math-block">
                     Security Budget = Block Subsidy + Transaction Fees
                 </p>
                 <p>

--- a/chapters/39-quantum-resistance.html
+++ b/chapters/39-quantum-resistance.html
@@ -119,7 +119,7 @@ Common Quantum Gates:
 │   |10⟩ → |11⟩, |11⟩ → |10⟩
 │
 └── Phase Gates: Rotate quantum state
-    Rz(θ)|ψ⟩ = e^(-iθ/2)|ψ⟩
+    Rz(θ)|ψ⟩ = e^(−iθ/2)|ψ⟩
 </pre>
             </div>
         </section>
@@ -585,7 +585,7 @@ Proposed P2QRH (Quantum Resistant Hash):
 └── Backwards compatible soft fork
 
 Implementation:
-witness_v2 = OP_2 <32-byte PQ key hash>
+witness_v2 = OP_2 &lt;32-byte PQ key hash&gt;
 spending = &lt;PQ signature&gt; &lt;PQ public key&gt;
 </pre>
             </div>

--- a/style.css
+++ b/style.css
@@ -384,6 +384,25 @@ footer {
     margin: 0 auto;
 }
 
+/* Display mathematics */
+.math-block {
+    text-align: center;
+    font-family: 'Times New Roman', 'STIX Two Math', serif;
+    font-style: italic;
+    margin: 1.2rem 0;
+}
+
+.formula {
+    text-align: center;
+    font-family: 'Times New Roman', 'STIX Two Math', serif;
+    font-style: italic;
+    margin: 1.2rem 0;
+}
+
+.math-block code, .formula code {
+    font-style: normal;
+}
+
 /* Late-volume chapter layout (Ch 37-40 skeleton) */
 .volume-title, .part-title {
     font-variant: small-caps;


### PR DESCRIPTION
## Summary
From a three-agent formula-formatting audit of all 41 chapters:

**Root cause fixed**: `.math-block` — the book's display-math idiom since Ch 9, used 100+ times — had no CSS rule, so every display formula rendered as plain left-aligned body text. Same for the `.formula` class used in Ch 18-25. Both now styled (centered Times serif italic, matching the Ch 1-8 inline-styled display math).

**Rendering bugs**: LaTeX brace remnants that displayed literally (`(y²)^{(p+1)/4}`, `𝔽_{101}`, `H_{tag}`, `P_{rogue}`, `B_{n-1}`); Ch 14's Nakamoto formula mixed hyphen-minus, true minus, and an ASCII caret in one display (now matches Ch 17's canonical form); two more digit-initial unescaped placeholders.

**Consistency**: ~40 hyphen-minus→true-minus corrections inside math across 14 chapters; Ch 4's worked example now uses the same · as its formulas; sup-tag powers unified with their Unicode neighbors (Ch 18/25/36); Ch 19's bitwise expressions moved into code tags with proper escaping; 23 draft-era inline Times New Roman display blocks in Ch 26-37 converted to the now-styled math-block class.

Remaining (tracked separately): wrapping bare prose math in Ch 18-40 in math spans — those chapters predate the `<span class="math">` convention entirely; that conversion is larger mechanical work.

Fixes #123