### PR TITLE
Fix Ch 26-40 proof-referee findings

### DIFF
--- a/chapters/26-fork-theory.html
+++ b/chapters/26-fork-theory.html
@@ -238,7 +238,7 @@
                 <ul>
                     <li><strong>Soft fork:</strong> R<sub>new</sub> ⊂ R<sub>old</sub> (new rules are stricter)</li>
                     <li><strong>Hard fork:</strong> R<sub>old</sub> ⊂ R<sub>new</sub> (new rules are looser)</li>
-                    <li><strong>Bilateral fork:</strong> R<sub>old</sub> ∩ R<sub>new</sub> = ∅ (each rule set rejects the other's blocks)</li>
+                    <li><strong>Bilateral fork:</strong> no block <em>extending the fork point</em> is valid under both rule sets (each side rejects the other's new blocks; the shared pre-fork history is of course valid under both)</li>
                 </ul>
                 <p>
                     In practice, "hard forks" generally satisfy the weaker condition
@@ -285,7 +285,7 @@
                     new rules R<sub>new</sub>, then:
                 </p>
                 <ol>
-                    <li>The longest chain follows R<sub>new</sub> rules with high probability</li>
+                    <li>The most-work chain eventually follows R<sub>new</sub> rules (with probability 1)</li>
                     <li>Nodes following R<sub>old</sub> remain on this chain (since R<sub>new</sub> ⊂ R<sub>old</sub>)</li>
                     <li>No permanent chain split occurs</li>
                 </ol>
@@ -296,10 +296,12 @@
                 <p>
                     Blocks valid under R<sub>new</sub> are valid under R<sub>old</sub> by definition.
                     Thus, the chain built by the majority (enforcing R<sub>new</sub>) is accepted
-                    by all nodes. Any competing chain violating R<sub>new</sub> will have less cumulative
-                    work in expectation (built by minority hash power) and be rejected by upgraded
-                    nodes. Old nodes might temporarily follow the invalid chain during propagation
-                    delays, but will converge once they see the valid chain with more work. □
+                    by all nodes. A chain violating R<sub>new</sub> can only be extended by the minority
+                    (fraction 1 − f &lt; 0.5). The work race between the two chains is a biased
+                    random walk: by the gambler's-ruin argument of Theorem 14.4, the enforcing
+                    majority's chain takes and keeps the cumulative-work lead with probability 1.
+                    Old nodes might temporarily follow an invalid chain (as in the 2015 BIP-66
+                    incident), but converge once the valid chain has more work. □
                 </p>
             </div>
 
@@ -806,8 +808,8 @@
                 <p class="exercise-title">Exercise 26.1</p>
                 <p>
                     Prove that if hash power is distributed such that no miner has more than
-                    1/n of the total, the expected time to natural fork resolution is bounded
-                    by 2·T<sub>block</sub> with high probability. What assumptions are needed?
+                    1/n of the total, the expected time to natural fork resolution satisfies
+                    E[T] ≤ 2·T<sub>block</sub>. What assumptions are needed?
                 </p>
             </div>
 

--- a/chapters/28-segwit-deep-dive.html
+++ b/chapters/28-segwit-deep-dive.html
@@ -250,16 +250,18 @@ Since R'.x = R.x (negation preserves x), both pass.</pre>
             </figure>
 
             <div class="theorem">
-                <p class="theorem-title">Theorem 28.2 (SegWit Malleability Fix)</p>
+                <p class="theorem-title">Theorem 28.1 (SegWit Malleability Fix)</p>
                 <p>
-                    For SegWit transactions, the txid is computed excluding witness data:
+                    For transactions whose inputs all spend witness programs, the txid is
+                    computed excluding witness data:
                 </p>
                 <p class="math-block">
                     txid = SHA256d(version || inputs || outputs || locktime)
                 </p>
                 <p>
-                    Since signatures are in the witness (not included), third-party
-                    malleability is impossible. The transaction creator can still
+                    Since all signatures are in the witness (not included), third-party
+                    malleability is impossible. (A transaction with even one legacy input
+                    keeps that input's malleable scriptSig inside the txid.) The transaction creator can still
                     change their own signatures, but this is by design.
                 </p>
             </div>
@@ -331,18 +333,20 @@ where:
             </figure>
 
             <div class="theorem">
-                <p class="theorem-title">Theorem 28.3 (Script Versioning Benefit)</p>
+                <p class="theorem-title">Theorem 28.2 (Script Versioning Benefit)</p>
                 <p>
                     Witness versions enable future soft forks:
                 </p>
                 <ol>
                     <li>Old nodes see "OP_n &lt;data&gt;" as anyone-can-spend (but don't relay)</li>
                     <li>New nodes interpret based on version number</li>
-                    <li>No consensus rules need changing for new versions</li>
+                    <li>New versions can be given semantics by a <em>tightening</em> soft
+                        fork without breaking old nodes&mdash;an activation is still required
+                        (Taproot activated witness v1 via Speedy Trial), but never a hard fork</li>
                 </ol>
                 <p>
-                    Versions 2-16 are reserved for future upgrades without requiring
-                    new soft fork activation mechanisms.
+                    Versions 2-16 are reserved for future upgrades that remain
+                    backwards-compatible with existing nodes.
                 </p>
             </div>
         </section>
@@ -580,7 +584,7 @@ commitment = SHA256(SHA256(witness_root || witness_nonce))
             </p>
 
             <div class="theorem">
-                <p class="theorem-title">Theorem 28.5 (SegWit as Soft Fork)</p>
+                <p class="theorem-title">Theorem 28.3 (SegWit as Soft Fork)</p>
                 <p>
                     SegWit outputs (OP_0 &lt;data&gt;) are valid under old rules because:
                 </p>
@@ -835,7 +839,7 @@ witness:      &lt;sig&gt; &lt;pubkey&gt;</pre>
             </p>
 
             <div class="theorem">
-                <p class="theorem-title">Theorem 28.7 (Lightning Network Prerequisite)</p>
+                <p class="theorem-title">Theorem 28.4 (Lightning Network Prerequisite)</p>
                 <p>
                     Lightning Network channels require non-malleable transaction IDs because:
                 </p>
@@ -843,7 +847,7 @@ witness:      &lt;sig&gt; &lt;pubkey&gt;</pre>
                     <li>Funding transaction creates 2-of-2 multisig output</li>
                     <li>Commitment transactions spend this output (reference funding txid)</li>
                     <li>If funding txid could be malleated, commitments become invalid</li>
-                    <li>Both parties would lose funds locked in channel</li>
+                    <li>Funds locked in the channel become hostage to the counterparty's cooperation</li>
                 </ol>
                 <p>
                     SegWit's fixed txid makes channels safe to open before funding confirms.

--- a/chapters/29-taproot-architecture.html
+++ b/chapters/29-taproot-architecture.html
@@ -137,7 +137,7 @@
             <h3>29.1.2 Batch Verification</h3>
 
             <div class="theorem">
-                <p class="theorem-title">Theorem 29.2 (Schnorr Batch Verification)</p>
+                <p class="theorem-title">Theorem 29.1 (Schnorr Batch Verification)</p>
                 <p>
                     Given n signatures (R<sub>i</sub>, s<sub>i</sub>) on messages m<sub>i</sub>
                     with public keys P<sub>i</sub>, batch verify by checking:
@@ -241,7 +241,7 @@
             </figure>
 
             <div class="theorem">
-                <p class="theorem-title">Theorem 29.3 (Taproot Spending Paths)</p>
+                <p class="theorem-title">Theorem 29.2 (Taproot Spending Paths)</p>
                 <p>
                     A Taproot output (OP_1 &lt;Q&gt;) can be spent two ways:
                 </p>
@@ -334,14 +334,14 @@ where:
             </div>
 
             <div class="theorem">
-                <p class="theorem-title">Theorem 29.4 (MAST Privacy)</p>
+                <p class="theorem-title">Theorem 29.3 (MAST Privacy)</p>
                 <p>
                     When spending via script path:
                 </p>
                 <ul>
                     <li>Only the executed script is revealed</li>
                     <li>Other scripts remain hidden (only hashes in proof)</li>
-                    <li>Number of alternative scripts is hidden (proof length varies)</li>
+                    <li>The exact number of alternative scripts is hidden, though the Merkle path length reveals the revealed leaf's depth (a lower bound on tree size)</li>
                 </ul>
                 <p>
                     When spending via key path:
@@ -489,7 +489,7 @@ Stack after:  [n] (or [n+1] if valid)
                 <p><strong>Round 2:</strong></p>
                 <ol>
                     <li>Compute R = Σ R<sub>i,1</sub> + b·Σ R<sub>i,2</sub> where b = H(agg_nonces || agg_key || msg)</li>
-                    <li>Each signer computes partial: s<sub>i</sub> = k<sub>i,1</sub> + b·k<sub>i,2</sub> + e·a<sub>i</sub>·d<sub>i</sub></li>
+                    <li>Each signer computes partial: s<sub>i</sub> = k<sub>i,1</sub> + b·k<sub>i,2</sub> + e·a<sub>i</sub>·d<sub>i</sub>, where e = H(R || P || m) is the challenge of Definition 29.1</li>
                     <li>Aggregate: s = Σ s<sub>i</sub></li>
                     <li>Final signature: (R, s)</li>
                 </ol>
@@ -531,7 +531,7 @@ Stack after:  [n] (or [n+1] if valid)
             </figure>
 
             <div class="theorem">
-                <p class="theorem-title">Theorem 29.6 (MuSig2 Privacy)</p>
+                <p class="theorem-title">Theorem 29.4 (MuSig2 Privacy)</p>
                 <p>
                     A MuSig2 aggregate key and signature are computationally indistinguishable
                     from a single-party key and signature. An observer cannot determine:
@@ -565,7 +565,7 @@ Stack after:  [n] (or [n+1] if valid)
             </div>
 
             <div class="theorem">
-                <p class="theorem-title">Theorem 29.7 (Adaptor Atomicity)</p>
+                <p class="theorem-title">Theorem 29.5 (Adaptor Atomicity)</p>
                 <p>
                     Adaptor signatures enable atomic swaps without hash preimages:
                 </p>

--- a/chapters/31-sidechains.html
+++ b/chapters/31-sidechains.html
@@ -98,11 +98,12 @@
             </figure>
 
             <div class="theorem">
-                <p class="theorem-title">Theorem 31.1 (Peg Security Tradeoff)</p>
+                <p class="theorem-title">Proposition 31.1 (Peg Security Tradeoff)</p>
                 <p>
                     Without changes to Bitcoin's consensus rules, a trustless two-way peg is
-                    impossible. Bitcoin cannot verify sidechain state, so peg-outs require
-                    either:
+                    impossible: Bitcoin Script has no opcode that can verify sidechain
+                    consensus, so some extrinsic trust (or a new opcode) must authorize
+                    peg-outs. The options are:
                 </p>
                 <ul>
                     <li>Trusted custodians (federation)</li>

--- a/chapters/34-drivechains.html
+++ b/chapters/34-drivechains.html
@@ -146,7 +146,11 @@ Withdrawal process:
                 </p>
                 <ol>
                     <li>Create a fraudulent withdrawal bundle</li>
-                    <li>Accumulate 13,150 ACKs within the 26,300-block (~6-month) window (a bare-majority coalition takes ~6 months; ~3 months requires near-unanimous ACKing)</li>
+                    <li>Accumulate 13,150 ACKs within the 26,300-block (~6-month) window. With other
+                        miners abstaining, a bare majority takes ~6 months and ~3 months requires
+                        near-unanimous ACKing; if defending miners actively NACK (the score moves
+                        +1/0/−1 per block), the coalition needs about 75% of blocks to reach the
+                        threshold inside the window at all</li>
                     <li>Maintain >50% hashrate commitment throughout</li>
                 </ol>
                 <p>

--- a/chapters/35-consensus-cleanup.html
+++ b/chapters/35-consensus-cleanup.html
@@ -170,15 +170,16 @@ where:
                     manipulation each retarget period:
                 </p>
                 <ol>
-                    <li><strong>Phase 1:</strong> Set the <em>last</em> block of the current
-                        period (block[2015]) to a timestamp far in the <em>future</em></li>
+                    <li><strong>Phase 1:</strong> Hold the period's timestamps far in the
+                        <em>past</em>, then set the <em>last</em> block (block[2015]) as late
+                        as the rules allow (~2 hours past real time)</li>
                     <li><strong>Phase 2:</strong> Set the <em>first</em> block of the next period
-                        (block[2016]) to a timestamp far in the <em>past</em></li>
+                        (block[2016]) back to the held-back past time</li>
                     <li>The difficulty formula sees a large
                         <code>actual_time</code> (future minus past), causing
                         difficulty to decrease (subject to the 4× clamp per period)</li>
                     <li>Repeat: each period reduces difficulty by up to 4×</li>
-                    <li>After ~16 periods, difficulty approaches zero</li>
+                    <li>After ~24 periods (log₄ of current difficulty ≈ 10¹⁴), difficulty approaches the minimum</li>
                 </ol>
                 <p>
                     Theoretical outcome: Mine all remaining Bitcoin in weeks.

--- a/chapters/37-defense-mechanisms.html
+++ b/chapters/37-defense-mechanisms.html
@@ -350,7 +350,7 @@ nMinimumChainWork = 0x0000000000000000000000000000000000000000
                     <li>Attacker must match honest hashrate + some margin</li>
                     <li>Attacker pays for hardware, electricity, opportunity cost</li>
                     <li>Honest miners are paid (block rewards)</li>
-                    <li>Attacker revenue limited to double-spend value</li>
+                    <li>Attacker gains are self-limiting: the double-spend value plus any block rewards earned, whose value tends to collapse if the attack undermines confidence</li>
                 </ul>
             </div>
 

--- a/chapters/39-quantum-resistance.html
+++ b/chapters/39-quantum-resistance.html
@@ -119,7 +119,7 @@ Common Quantum Gates:
 │   |10⟩ → |11⟩, |11⟩ → |10⟩
 │
 └── Phase Gates: Rotate quantum state
-    Rz(θ)|ψ⟩ = e^(−iθ/2)|ψ⟩
+    Rz(θ): |0⟩ → e^(−iθ/2)|0⟩,  |1⟩ → e^(+iθ/2)|1⟩
 </pre>
             </div>
         </section>
@@ -537,7 +537,7 @@ Lamport Signatures (simpler):
                 <tbody>
                     <tr>
                         <td>ML-DSA</td>
-                        <td>~65x larger</td>
+                        <td>~65x larger signatures (~25x at transaction level)</td>
                         <td>High (NIST standard)</td>
                         <td>Soft fork possible</td>
                     </tr>

--- a/chapters/40-monetary-future.html
+++ b/chapters/40-monetary-future.html
@@ -183,9 +183,9 @@ Stage 5: Laggards (2030+?)
         <section id="nation-state-game-theory">
             <h2>Nation-State Game Theory</h2>
 
-            <h3>The Prisoner's Dilemma</h3>
+            <h3>A Coordination Game</h3>
 
-            <p>Nations face a strategic dilemma regarding Bitcoin:</p>
+            <p>Nations face a coordination problem regarding Bitcoin&mdash;a stag hunt with multiple equilibria rather than a prisoner's dilemma (compare the Schelling-point analysis of Example 26.2):</p>
 
             <div class="code-block">
 <pre>
@@ -208,11 +208,11 @@ If ALL nations adopt Bitcoin:
 ├── Late adopters pay premium
 └── No nation can stop it
 
-Dominant Strategy Analysis:
+Hedging / First-Mover Logic (no dominant strategy exists):
 ├── If neighbors might adopt → consider adopting
 ├── If BTC might succeed → early adoption advantageous
 ├── Waiting has opportunity cost
-└── Game theoretically: adoption is rational hedge
+└── A small allocation is a cheap hedge against the adoption equilibrium
 </pre>
             </div>
 
@@ -280,7 +280,7 @@ Market Position:
 ├── 10-40% of gold's market cap of ~$15T ($1.5-6 trillion)
 ├── Held by 5-10% of global population
 ├── In 10-20% of investment portfolios
-└── Price: $50,000-300,000 per BTC
+└── Price: $75,000-300,000 per BTC
 
 Characteristics:
 ├── Store of value, not medium of exchange


### PR DESCRIPTION
## Summary
First-ever proof-validity referee pass over chapters 26-40 (their facts were verified in round 2; their logic had not been):

**HIGH** — Ch 28's Script Versioning theorem claimed new witness versions need "no consensus rule changes" and "no soft fork activation" — false (Taproot was exactly such a soft fork). Restated as the true backwards-compatibility property.

**MEDIUM**
- Ch 26's bilateral-fork condition (R_old ∩ R_new = ∅) was unsatisfiable over unrestricted block sets — every pre-fork block is valid under both rule sets, contradicting the chapter's own BCH discussion. Now quantified over blocks extending the fork point.
- Ch 26's Soft Fork Safety proof replaced its "less work in expectation" non sequitur with the gambler's-ruin / almost-sure-dominance argument (citing Theorem 14.4), and the statement is now eventual rather than "with high probability".
- Ch 28's malleability theorem gains its necessary hypothesis (all inputs SegWit — one legacy input keeps a malleable scriptSig inside the txid).
- Ch 34's "bare majority steals in ~6 months" now states its abstention assumption and the ~75%-of-blocks requirement under active defensive NACKing (BIP-300's +1/0/−1 scoring).
- Ch 40's nation-state "Prisoner's Dilemma" with a "dominant strategy" is actually a coordination game (stag hunt) with multiple equilibria — now consistent with Ch 26's Schelling-point treatment.

**LOW** — Ch 35 timewarp arithmetic (~24 periods) and phase description; Ch 39 Rz gate (was a global phase as written) and ML-DSA ratio labeling; Ch 37 attack-cost asymmetry; Ch 29/28 theorem numbering gaps closed (29.1-29.5, 28.1-28.4); MAST leaf-depth leak noted; MuSig2 challenge defined; Ch 31 impossibility claim now a justified Proposition; Ch 26 exercise statement made coherent.

Verified clean by the same referee: all Nakamoto tables, Ch 28 weight arithmetic, BIP-340/MuSig2/adaptor algebra, selfish-mining threshold, Ch 38 economic models.

Fixes #125