### PR TITLE
Wrap prose math in math spans across Ch 18-40

### DIFF
--- a/chapters/18-bloom-filters.html
+++ b/chapters/18-bloom-filters.html
@@ -111,18 +111,18 @@
             <div class="definition">
                 <p><strong>Definition 18.1</strong> (Bloom Filter)</p>
                 <p>
-                    A <em>Bloom filter</em> for a set <var>S</var> consists of:
+                    A <em>Bloom filter</em> for a set <span class="math">S</span> consists of:
                 </p>
                 <ol>
-                    <li>A bit array <var>B</var> of <var>m</var> bits, initially all zeros</li>
-                    <li>A family of <var>k</var> independent hash functions <var>h₀, h₁, ..., hₖ₋₁</var>, each mapping elements to {0, 1, ..., m−1}</li>
+                    <li>A bit array <span class="math">B</span> of <span class="math">m</span> bits, initially all zeros</li>
+                    <li>A family of <span class="math">k</span> independent hash functions <span class="math">h₀, h₁, ..., hₖ₋₁</span>, each mapping elements to <span class="math">{0, 1, ..., m−1}</span></li>
                 </ol>
                 <p>
-                    To <em>add</em> element <var>x</var>: set <var>B[hᵢ(x)] = 1</var> for all <var>i ∈ {1, ..., k}</var>.
+                    To <em>add</em> element <span class="math">x</span>: set <span class="math">B[hᵢ(x)] = 1</span> for all <span class="math">i ∈ {1, ..., k}</span>.
                 </p>
                 <p>
-                    To <em>query</em> element <var>x</var>: return "possibly in set" if <var>B[hᵢ(x)] = 1</var>
-                    for all <var>i</var>; return "definitely not in set" otherwise.
+                    To <em>query</em> element <span class="math">x</span>: return "possibly in set" if <span class="math">B[hᵢ(x)] = 1</span>
+                    for all <span class="math">i</span>; return "definitely not in set" otherwise.
                 </p>
             </div>
 
@@ -228,31 +228,31 @@
             <div class="theorem">
                 <p><strong>Theorem 18.1</strong> (False Positive Rate)</p>
                 <p>
-                    For a Bloom filter with <var>m</var> bits and <var>k</var> hash functions,
-                    after inserting <var>n</var> elements, the probability of a false positive is
+                    For a Bloom filter with <span class="math">m</span> bits and <span class="math">k</span> hash functions,
+                    after inserting <span class="math">n</span> elements, the probability of a false positive is
                     approximately:
                 </p>
                 <div class="formula">
-                    p ≈ (1 − e<sup>−kn/m</sup>)<sup>k</sup>
+                    p ≈ (1 − e<sup>−kn/m</sup>)ᵏ
                 </div>
             </div>
 
             <div class="proof">
                 <p><strong>Proof.</strong></p>
                 <p>
-                    After inserting one element, each of the <var>k</var> hash functions sets
+                    After inserting one element, each of the <span class="math">k</span> hash functions sets
                     one bit. The probability that a specific bit is <em>not</em> set by one
-                    hash function is (1 − 1/m). After <var>kn</var> hash operations (from <var>n</var>
+                    hash function is <span class="math">(1 − 1/m)</span>. After <span class="math">kn</span> hash operations (from <span class="math">n</span>
                     elements), the probability a specific bit is still 0 is:
                 </p>
-                <p style="text-align: center;">
+                <p class="math-block">
                     (1 − 1/m)<sup>kn</sup> ≈ e<sup>−kn/m</sup>
                 </p>
                 <p>
-                    Thus the probability a specific bit is 1 is approximately (1 - e<sup>-kn/m</sup>).
-                    A false positive occurs when all <var>k</var> bits checked for a non-member
-                    happen to be 1, giving probability (1 − e<sup>−kn/m</sup>)<sup>k</sup>.
-                    Two approximations are hidden here: the <var>k</var> probed bits are treated
+                    Thus the probability a specific bit is 1 is approximately <span class="math">(1 − e<sup>−kn/m</sup>)</span>.
+                    A false positive occurs when all <span class="math">k</span> bits checked for a non-member
+                    happen to be 1, giving probability <span class="math">(1 − e<sup>−kn/m</sup>)ᵏ</span>.
+                    Two approximations are hidden here: the <span class="math">k</span> probed bits are treated
                     as independent (they are not), and the random set-bit fraction is replaced
                     by its expectation. The classical formula is in fact a slight
                     <em>under</em>estimate of the true rate (Bose et al., 2008)&mdash;about 30%
@@ -264,34 +264,34 @@
             <div class="corollary">
                 <p><strong>Corollary 18.1</strong> (Optimal Number of Hash Functions)</p>
                 <p>
-                    For fixed <var>m</var> and <var>n</var>, the false positive rate is minimized when:
+                    For fixed <span class="math">m</span> and <span class="math">n</span>, the false positive rate is minimized when:
                 </p>
                 <div class="formula">
                     k = (m/n) · ln(2) ≈ 0.693 · (m/n)
                 </div>
                 <p>
-                    With this optimal <var>k</var>, the false positive rate is approximately
-                    (0.6185)<sup>m/n</sup>.
+                    With this optimal <span class="math">k</span>, the false positive rate is approximately
+                    <span class="math">(0.6185)<sup>m/n</sup></span>.
                 </p>
             </div>
 
             <div class="example">
                 <p><strong>Example 18.1</strong> (Filter Sizing)</p>
                 <p>
-                    Suppose an SPV wallet has 100 addresses and wants a 0.1% (10<sup>−3</sup>) false
+                    Suppose an SPV wallet has 100 addresses and wants a 0.1% (<span class="math">10⁻³</span>) false
                     positive rate. We need:
                 </p>
-                <p style="text-align: center;">
-                    (0.6185)<sup>m/100</sup> = 10<sup>−3</sup>
+                <p class="math-block">
+                    (0.6185)<sup>m/100</sup> = 10⁻³
                 </p>
                 <p>
-                    Taking logarithms: m/100 · ln(0.6185) = ln(10<sup>−3</sup>)
+                    Taking logarithms: <span class="math">m/100 · ln(0.6185) = ln(10⁻³)</span>
                 </p>
-                <p style="text-align: center;">
+                <p class="math-block">
                     m = 100 · (−6.908) / (−0.481) ≈ 1,436 bits ≈ 180 bytes
                 </p>
                 <p>
-                    With k = 0.693 · (1436/100) ≈ 10 hash functions.
+                    With <span class="math">k = 0.693 · (1436/100) ≈ 10</span> hash functions.
                 </p>
             </div>
         </section>
@@ -388,7 +388,7 @@
     seed = (i * 0xFBA4C795 + nTweak) mod 2³²
     return MurmurHash3(seed, data) mod (filter_size * 8)</code></pre>
                 <p>
-                    where <var>i</var> ranges from 0 to nHashFuncs - 1, and the constant
+                    where <span class="math">i</span> ranges from 0 to nHashFuncs − 1, and the constant
                     0xFBA4C795 is chosen to provide good distribution.
                 </p>
             </div>
@@ -544,7 +544,7 @@
             <div class="theorem">
                 <p><strong>Theorem 18.2</strong> (Filter Analysis Attack)</p>
                 <p>
-                    Given a Bloom filter with parameters (<var>m</var>, <var>k</var>, <var>nTweak</var>),
+                    Given a Bloom filter with parameters (<span class="math">m</span>, <span class="math">k</span>, <code>nTweak</code>),
                     an attacker can test arbitrary addresses against the filter locally. By testing
                     all addresses that have ever appeared on the blockchain, the attacker recovers
                     the wallet's address set with high probability.
@@ -555,9 +555,9 @@
                 <p><strong>Proof sketch.</strong></p>
                 <p>
                     The attacker knows the hash function construction (Algorithm 18.1). For each
-                    candidate address <var>a</var>, they compute h₀(a), h₁(a), ..., hₖ₋₁(a)
+                    candidate address <span class="math">a</span>, they compute <span class="math">h₀(a), h₁(a), ..., hₖ₋₁(a)</span>
                     and check if all corresponding bits are set. True positives (actual wallet
-                    addresses) will always match. False positives occur at rate p, but with
+                    addresses) will always match. False positives occur at rate <span class="math">p</span>, but with
                     millions of blockchain addresses and typical filter sizes, the number of
                     false positives is small and can often be distinguished through blockchain
                     graph analysis. ∎
@@ -621,14 +621,14 @@
             <div class="theorem">
                 <p><strong>Theorem 18.3</strong> (Intersection Attack)</p>
                 <p>
-                    If a client sends filter versions F₁ and F₂ with different tweaks or sizes,
+                    If a client sends filter versions <span class="math">F₁</span> and <span class="math">F₂</span> with different tweaks or sizes,
                     the intersection of matching addresses has vastly reduced false positive rate:
                 </p>
                 <div class="formula">
-                    p_intersection ≈ p₁ · p₂
+                    p<sub>intersection</sub> ≈ p₁ · p₂
                 </div>
                 <p>
-                    After just 3 filter versions with p = 0.001, the false positive rate drops to 10<sup>−9</sup>.
+                    After just 3 filter versions with <span class="math">p = 0.001</span>, the false positive rate drops to <span class="math">10⁻⁹</span>.
                 </p>
             </div>
 
@@ -985,7 +985,7 @@
                     invite DoS attacks. BIP-37 violated this by requiring:
                 </p>
                 <ul>
-                    <li>O(1) client request → O(block_size) server work</li>
+                    <li><span class="math">O(1)</span> client request → <span class="math">O(block_size)</span> server work</li>
                     <li>No proof-of-work or stake from clients</li>
                     <li>Stateful server resources (stored filters) per connection</li>
                 </ul>
@@ -1038,7 +1038,7 @@
                 <p><strong>Exercise 18.2</strong></p>
                 <p>
                     Prove that the intersection of two independent Bloom filters (different
-                    tweaks) for the same set has false positive rate p₁ · p₂.
+                    tweaks) for the same set has false positive rate <span class="math">p₁ · p₂</span>.
                 </p>
             </div>
 

--- a/chapters/19-compact-filters.html
+++ b/chapters/19-compact-filters.html
@@ -74,7 +74,7 @@
             <h4>Privacy Advantage</h4>
             <p>
                 <strong>The server learns nothing about client interests.</strong> A client that
-                downloads the filter for block N is indistinguishable from any other client downloading
+                downloads the filter for block <span class="math">N</span> is indistinguishable from any other client downloading
                 that filter. When the client requests the full block, the server learns only that
                 "something in this block is interesting"—not which transactions, addresses, or
                 scripts.
@@ -198,8 +198,8 @@
                     cannot distinguish between:
                 </p>
                 <ol>
-                    <li>A client interested in address A</li>
-                    <li>A client interested in address B</li>
+                    <li>A client interested in address <span class="math">A</span></li>
+                    <li>A client interested in address <span class="math">B</span></li>
                     <li>A client with no specific interest, just syncing</li>
                 </ol>
                 <p>
@@ -236,44 +236,44 @@
             <div class="definition">
                 <p><strong>Definition 19.1</strong> (Golomb Coding)</p>
                 <p>
-                    Given a positive integer <var>n</var> and parameter <var>M</var>, Golomb
-                    coding represents <var>n</var> as:
+                    Given a positive integer <span class="math">n</span> and parameter <span class="math">M</span>, Golomb
+                    coding represents <span class="math">n</span> as:
                 </p>
                 <ul>
-                    <li><strong>Quotient:</strong> q = ⌊n / M⌋, encoded in unary (q ones followed by a zero)</li>
-                    <li><strong>Remainder:</strong> r = n mod M, encoded in binary</li>
+                    <li><strong>Quotient:</strong> <span class="math">q = ⌊n / M⌋</span>, encoded in unary (<span class="math">q</span> ones followed by a zero)</li>
+                    <li><strong>Remainder:</strong> <span class="math">r = n mod M</span>, encoded in binary</li>
                 </ul>
             </div>
 
             <div class="definition">
                 <p><strong>Definition 19.2</strong> (Golomb-Rice Coding)</p>
                 <p>
-                    <em>Golomb-Rice coding</em> is Golomb coding where M = 2<sup>P</sup> for
-                    some parameter P. This simplifies the encoding since the remainder is
-                    exactly P bits.
+                    <em>Golomb-Rice coding</em> is Golomb coding where <span class="math">M = 2<sup>P</sup></span> for
+                    some parameter <span class="math">P</span>. This simplifies the encoding since the remainder is
+                    exactly <span class="math">P</span> bits.
                 </p>
                 <p>
-                    For value <var>n</var>:
+                    For value <span class="math">n</span>:
                 </p>
                 <ul>
-                    <li><strong>Quotient:</strong> q = n >> P (right shift by P bits)</li>
-                    <li><strong>Remainder:</strong> <code>r = n &amp; ((1 &lt;&lt; P) - 1)</code> (low P bits)</li>
-                    <li><strong>Encoding:</strong> [q ones] [0] [P-bit remainder]</li>
+                    <li><strong>Quotient:</strong> <span class="math">q = n >> P</span> (right shift by <span class="math">P</span> bits)</li>
+                    <li><strong>Remainder:</strong> <code>r = n &amp; ((1 &lt;&lt; P) - 1)</code> (low <span class="math">P</span> bits)</li>
+                    <li><strong>Encoding:</strong> [<span class="math">q</span> ones] [0] [<span class="math">P</span>-bit remainder]</li>
                 </ul>
             </div>
 
             <div class="example">
-                <p><strong>Example 19.1</strong> (Golomb-Rice Encoding with P=4)</p>
-                <p>Encode n = 25 with P = 4 (M = 16):</p>
+                <p><strong>Example 19.1</strong> (Golomb-Rice Encoding with <span class="math">P=4</span>)</p>
+                <p>Encode <span class="math">n = 25</span> with <span class="math">P = 4</span> (<span class="math">M = 16</span>):</p>
                 <ul>
-                    <li>q = 25 >> 4 = 1</li>
-                    <li><code>r = 25 &amp; 15 = 9</code> = 1001₂</li>
+                    <li><span class="math">q = 25 >> 4 = 1</span></li>
+                    <li><code>r = 25 &amp; 15 = 9</code> = <span class="math">1001₂</span></li>
                     <li>Encoding: <span class="golomb-bits">1</span><span class="golomb-bits">0</span><span class="golomb-bits">1001</span> = "101001"</li>
                 </ul>
-                <p>Encode n = 7 with P = 4:</p>
+                <p>Encode <span class="math">n = 7</span> with <span class="math">P = 4</span>:</p>
                 <ul>
-                    <li>q = 7 >> 4 = 0</li>
-                    <li><code>r = 7 &amp; 15 = 7</code> = 0111₂</li>
+                    <li><span class="math">q = 7 >> 4 = 0</span></li>
+                    <li><code>r = 7 &amp; 15 = 7</code> = <span class="math">0111₂</span></li>
                     <li>Encoding: <span class="golomb-bits">0</span><span class="golomb-bits">0111</span> = "00111"</li>
                 </ul>
             </div>
@@ -283,8 +283,8 @@
             <div class="theorem">
                 <p><strong>Theorem 19.2</strong> (Golomb-Rice Optimality)</p>
                 <p>
-                    For a geometric distribution with parameter p, Golomb coding with
-                    optimal parameter M achieves expected code length within
+                    For a geometric distribution with parameter <span class="math">p</span>, Golomb coding with
+                    optimal parameter <span class="math">M</span> achieves expected code length within
                     at most 1 bit of the entropy bound.
                 </p>
             </div>
@@ -300,14 +300,14 @@
             <div class="definition">
                 <p><strong>Definition 19.3</strong> (Golomb-Coded Set)</p>
                 <p>
-                    A <em>Golomb-Coded Set</em> represents a set S of N elements with target
-                    false positive rate 1/F:
+                    A <em>Golomb-Coded Set</em> represents a set <span class="math">S</span> of <span class="math">N</span> elements with target
+                    false positive rate <span class="math">1/F</span>:
                 </p>
                 <ol>
-                    <li>Hash each element to the range [0, N·F) using a keyed hash function</li>
+                    <li>Hash each element to the range <span class="math">[0, N·F)</span> using a keyed hash function</li>
                     <li>Sort the resulting hash values</li>
                     <li>Compute successive differences (deltas)</li>
-                    <li>Encode deltas using Golomb-Rice with parameter P</li>
+                    <li>Encode deltas using Golomb-Rice with parameter <span class="math">P</span></li>
                 </ol>
             </div>
 
@@ -393,35 +393,35 @@
             <div class="theorem">
                 <p><strong>Theorem 19.3</strong> (GCS Space Efficiency)</p>
                 <p>
-                    A Golomb-Coded Set with N elements and false positive rate 1/F requires
-                    approximately N · (log₂(F) + 2) bits, plus a small constant overhead.
+                    A Golomb-Coded Set with <span class="math">N</span> elements and false positive rate <span class="math">1/F</span> requires
+                    approximately <span class="math">N · (log₂(F) + 2)</span> bits, plus a small constant overhead.
                 </p>
             </div>
 
             <div class="proof">
                 <p><strong>Proof sketch.</strong></p>
                 <p>
-                    Each delta has expected value F (since N elements are spread over range N·F).
-                    Golomb-Rice with P = log₂(F) (so that the divisor M = 2^P ≈ F) encodes
-                    values near F optimally. Each code is a unary quotient (expected
-                    E[q] + 1 ≈ 2 bits when M ≈ F, since E[q] = e^(−M/F)/(1−e^(−M/F)) ≈ 1)
-                    followed by P remainder bits, so the expected length per delta is
-                    approximately P + 2 bits.
-                    With N deltas, total size ≈ N · (log₂(F) + 2) bits. ∎
+                    Each delta has expected value <span class="math">F</span> (since <span class="math">N</span> elements are spread over range <span class="math">N·F</span>).
+                    Golomb-Rice with <span class="math">P = log₂(F)</span> (so that the divisor <span class="math">M = 2<sup>P</sup> ≈ F</span>) encodes
+                    values near <span class="math">F</span> optimally. Each code is a unary quotient (expected
+                    <span class="math">E[q] + 1 ≈ 2</span> bits when <span class="math">M ≈ F</span>, since <span class="math">E[q] = e<sup>−M/F</sup>/(1−e<sup>−M/F</sup>) ≈ 1</span>)
+                    followed by <span class="math">P</span> remainder bits, so the expected length per delta is
+                    approximately <span class="math">P + 2</span> bits.
+                    With <span class="math">N</span> deltas, total size <span class="math">≈ N · (log₂(F) + 2)</span> bits. ∎
                 </p>
             </div>
 
             <div class="example">
                 <p><strong>Example 19.2</strong> (BIP-158 Filter Size)</p>
                 <p>
-                    BIP-158 uses P = 19 (M = 2¹⁹ = 524,288) and false-positive
-                    parameter F = 784,931 (≈ 1.5 × 2¹⁹).
-                    For a block with N = 2000 scriptPubKeys:
+                    BIP-158 uses <span class="math">P = 19</span> (<span class="math">M = 2¹⁹ = 524,288</span>) and false-positive
+                    parameter <span class="math">F = 784,931</span> (<span class="math">≈ 1.5 × 2¹⁹</span>).
+                    For a block with <span class="math">N = 2000</span> scriptPubKeys:
                 </p>
                 <ul>
-                    <li>Filter size ≈ 2000 × (19 + 2) = 42,000 bits ≈ 5,250 bytes</li>
+                    <li>Filter size <span class="math">≈ 2000 × (19 + 2) = 42,000</span> bits ≈ 5,250 bytes</li>
                     <li>Compared to full block: ~1-2 MB</li>
-                    <li>Ratio: ~1/200 to 1/400 for this N; real blocks contain
+                    <li>Ratio: ~1/200 to 1/400 for this <span class="math">N</span>; real blocks contain
                     more filter elements (~5,000&ndash;10,000), giving the
                     ~1/80 ratio quoted elsewhere</li>
                 </ul>
@@ -471,14 +471,14 @@
                     </thead>
                     <tbody>
                         <tr>
-                            <td>P</td>
+                            <td><span class="math">P</span></td>
                             <td>19</td>
-                            <td>Golomb-Rice coding parameter (remainder is P bits)</td>
+                            <td>Golomb-Rice coding parameter (remainder is <span class="math">P</span> bits)</td>
                         </tr>
                         <tr>
-                            <td>F</td>
+                            <td><span class="math">F</span></td>
                             <td>784931</td>
-                            <td>False positive rate parameter (target rate ≈ 1/F)</td>
+                            <td>False positive rate parameter (target rate <span class="math">≈ 1/F</span>)</td>
                         </tr>
                         <tr>
                             <td>Hash function</td>
@@ -578,8 +578,8 @@
                     <li>If no match: continue to next block (no download)</li>
                 </ol>
                 <p>
-                    Expected false positive rate: 1/784931 per scriptPubKey per block.
-                    With 50 addresses: ~50/784931 ≈ 1/15699 per block ≈ one false positive every ~109 days
+                    Expected false positive rate: <span class="math">1/784931</span> per scriptPubKey per block.
+                    With 50 addresses: <span class="math">~50/784931 ≈ 1/15699</span> per block ≈ one false positive every ~109 days
                     (at 144 blocks/day).
                 </p>
             </div>
@@ -650,13 +650,13 @@
             <div class="definition">
                 <p><strong>Definition 19.7</strong> (Filter Header)</p>
                 <p>
-                    The filter header for block N is:
+                    The filter header for block <span class="math">N</span> is:
                 </p>
                 <div class="formula">
                     filter_header<sub>N</sub> = SHA256d(SHA256d(filter<sub>N</sub>) || filter_header<sub>N−1</sub>)
                 </div>
                 <p>
-                    Where SHA256d(x) = SHA256(SHA256(x)) (the HASH256 function of Chapter 6), filter<sub>N</sub> is the raw filter bytes, and filter_header<sub>-1</sub> = 0x00...00 (32 zero bytes).
+                    Where <span class="math">SHA256d(x) = SHA256(SHA256(x))</span> (the HASH256 function of Chapter 6), <span class="math">filter<sub>N</sub></span> is the raw filter bytes, and <span class="math">filter_header<sub>−1</sub> = 0x00...00</span> (32 zero bytes).
                 </p>
             </div>
 
@@ -819,14 +819,14 @@
             <div class="theorem">
                 <p><strong>Theorem 19.4</strong> (BIP-158 False Positive Rate)</p>
                 <p>
-                    For a filter with N elements and a query set of size Q, the probability
+                    For a filter with <span class="math">N</span> elements and a query set of size <span class="math">Q</span>, the probability
                     of at least one false positive is:
                 </p>
                 <div class="formula">
                     P(false positive) = 1 − (1 − 1/F)<sup>Q</sup> ≈ Q/F
                 </div>
                 <p>
-                    With F = 784931, a wallet with 100 addresses has approximately 1/7849
+                    With <span class="math">F = 784931</span>, a wallet with 100 addresses has approximately <span class="math">1/7849</span>
                     chance of false positive per block.
                 </p>
             </div>
@@ -851,8 +851,8 @@
                 </p>
                 <ol>
                     <li>Querying multiple independent peers for filter headers</li>
-                    <li>Verifying all peers return identical filter_header<sub>N</sub></li>
-                    <li>Verifying received filter hashes to filter_header<sub>N</sub></li>
+                    <li>Verifying all peers return identical <span class="math">filter_header<sub>N</sub></span></li>
+                    <li>Verifying received filter hashes to <span class="math">filter_header<sub>N</sub></span></li>
                 </ol>
                 <p>
                     If at least one honest peer is among those queried, the manipulation is
@@ -878,8 +878,8 @@
                 <ul>
                     <li><strong>Filter download:</strong> Zero bits (all clients download same filter)</li>
                     <li><strong>Full block request after match:</strong> the server learns
-                        "the client cares about one of this block's N scriptPubKeys"&mdash;an
-                        anonymity set of size N, so a <em>larger</em> block leaks
+                        "the client cares about one of this block's <span class="math">N</span> scriptPubKeys"&mdash;an
+                        anonymity set of size <span class="math">N</span>, so a <em>larger</em> block leaks
                         <em>less</em> about the client</li>
                 </ul>
             </div>
@@ -1054,7 +1054,7 @@
             <div class="exercise">
                 <p><strong>Exercise 19.3</strong></p>
                 <p>
-                    Prove that if a client queries k independent peers for filter headers and
+                    Prove that if a client queries <span class="math">k</span> independent peers for filter headers and
                     at least one is honest, any filter manipulation is detected with
                     certainty (the client observes conflicting headers).
                 </p>
@@ -1105,7 +1105,7 @@
                     data, achieving filter sizes of ~1/80th of full block size.
                 </li>
                 <li>
-                    The false positive rate of 1/784931 per element provides good privacy
+                    The false positive rate of <span class="math">1/784931</span> per element provides good privacy
                     cover while keeping bandwidth overhead minimal.
                 </li>
                 <li>

--- a/chapters/20-light-clients.html
+++ b/chapters/20-light-clients.html
@@ -824,17 +824,17 @@ Response:
             <div class="definition">
                 <p><strong>Definition 20.8</strong> (Fraud Proof)</p>
                 <p>
-                    Refining Definition 17.5: a <em>fraud proof</em> for a consensus rule <em>R</em> applied to block <em>B</em>
-                    is a data structure <em>P</em> such that:
+                    Refining Definition 17.5: a <em>fraud proof</em> for a consensus rule <span class="math">R</span> applied to block <span class="math">B</span>
+                    is a data structure <span class="math">P</span> such that:
                 </p>
                 <ol>
-                    <li><strong>Completeness:</strong> If <em>B</em> violates <em>R</em>, an honest full node
-                        can construct <em>P</em> from block data.</li>
-                    <li><strong>Soundness:</strong> If <em>B</em> satisfies <em>R</em>, no adversary can
-                        construct a valid <em>P</em>.</li>
-                    <li><strong>Compactness:</strong> |<em>P</em>| is significantly smaller than |<em>B</em>|.</li>
+                    <li><strong>Completeness:</strong> If <span class="math">B</span> violates <span class="math">R</span>, an honest full node
+                        can construct <span class="math">P</span> from block data.</li>
+                    <li><strong>Soundness:</strong> If <span class="math">B</span> satisfies <span class="math">R</span>, no adversary can
+                        construct a valid <span class="math">P</span>.</li>
+                    <li><strong>Compactness:</strong> <span class="math">|P|</span> is significantly smaller than <span class="math">|B|</span>.</li>
                     <li><strong>Verifiability:</strong> A light client holding the header chain can verify
-                        <em>P</em> without additional data.</li>
+                        <span class="math">P</span> without additional data.</li>
                 </ol>
             </div>
 
@@ -1274,8 +1274,8 @@ Response:
                 <p><strong>Exercise 20.8</strong></p>
                 <p>
                     A compact client subscribes to three independent header publishers.
-                    Two publishers report block hash <em>A</em> at height <em>n</em>, while
-                    the third reports a different hash <em>B</em> at the same height.
+                    Two publishers report block hash <span class="math">A</span> at height <span class="math">n</span>, while
+                    the third reports a different hash <span class="math">B</span> at the same height.
                     Describe the possible causes (chain split, eclipse attack on one publisher,
                     stale block) and design a decision procedure for the client.
                 </p>

--- a/chapters/21-node-optimizations.html
+++ b/chapters/21-node-optimizations.html
@@ -263,11 +263,11 @@
             <div class="definition">
                 <p><strong>Definition 21.3</strong> (AssumeValid)</p>
                 <p>
-                    Given a hardcoded block hash H (the "assumevalid" block):
+                    Given a hardcoded block hash <span class="math">H</span> (the "assumevalid" block):
                 </p>
                 <ul>
-                    <li>For blocks that are ancestors of H: skip script validation (signature checks)</li>
-                    <li>For blocks after H: perform full validation including signatures</li>
+                    <li>For blocks that are ancestors of <span class="math">H</span>: skip script validation (signature checks)</li>
+                    <li>For blocks after <span class="math">H</span>: perform full validation including signatures</li>
                     <li>All other checks performed for all blocks: amounts, structure, PoW</li>
                 </ul>
             </div>
@@ -654,7 +654,7 @@ prune=550</code></pre>
                     that supports:
                 </p>
                 <ul>
-                    <li><strong>Membership proofs:</strong> Prove element x is in the set</li>
+                    <li><strong>Membership proofs:</strong> Prove element <span class="math">x</span> is in the set</li>
                     <li><strong>Updates:</strong> Add or remove elements efficiently</li>
                     <li><strong>Binding:</strong> Cannot forge proofs for non-members</li>
                 </ul>
@@ -751,11 +751,11 @@ prune=550</code></pre>
             <div class="definition">
                 <p><strong>Definition 21.7</strong> (Utreexo Forest)</p>
                 <p>
-                    For N UTXOs, Utreexo maintains at most ⌈log₂(N)⌉ Merkle tree roots,
-                    one for each set bit in the binary representation of N.
+                    For <span class="math">N</span> UTXOs, Utreexo maintains at most <span class="math">⌈log₂(N)⌉</span> Merkle tree roots,
+                    one for each set bit in the binary representation of <span class="math">N</span>.
                 </p>
                 <p>
-                    With N = 170 million UTXOs:
+                    With <span class="math">N</span> = 170 million UTXOs:
                 </p>
                 <ul>
                     <li>Maximum roots: ~28</li>
@@ -772,8 +772,8 @@ prune=550</code></pre>
                     the UTXO exists in the accumulator:
                 </p>
                 <ul>
-                    <li>Proof size: O(log N) hashes ≈ 28 × 32 = 896 bytes maximum</li>
-                    <li>Verification: O(log N) hash operations</li>
+                    <li>Proof size: <span class="math">O(log N)</span> hashes ≈ 28 × 32 = 896 bytes maximum</li>
+                    <li>Verification: <span class="math">O(log N)</span> hash operations</li>
                 </ul>
             </div>
 
@@ -943,7 +943,7 @@ prune=550</code></pre>
             <div class="exercise">
                 <p><strong>Exercise 21.3</strong></p>
                 <p>
-                    For a UTXO set of size N, calculate the maximum Utreexo accumulator
+                    For a UTXO set of size <span class="math">N</span>, calculate the maximum Utreexo accumulator
                     size and the average proof size per transaction input.
                 </p>
             </div>

--- a/chapters/22-client-side-validation.html
+++ b/chapters/22-client-side-validation.html
@@ -95,7 +95,7 @@
                 <div class="paradigm-card paradigm-on-chain">
                     <h4>On-Chain Validation</h4>
                     <p><strong>Model:</strong> Publish all data on-chain; every node validates everything</p>
-                    <p><strong>Scaling:</strong> O(n) validation for n transactions</p>
+                    <p><strong>Scaling:</strong> <span class="math">O(n)</span> validation for <span class="math">n</span> transactions</p>
                     <p><strong>Privacy:</strong> All transaction data public</p>
                     <p><strong>Example:</strong> Standard Bitcoin, Ethereum ERC-20</p>
                 </div>
@@ -103,7 +103,7 @@
                 <div class="paradigm-card paradigm-csv">
                     <h4>Client-Side Validation</h4>
                     <p><strong>Model:</strong> Data exchanged privately; blockchain proves non-double-spend</p>
-                    <p><strong>Scaling:</strong> O(1) on-chain, O(history) for recipient</p>
+                    <p><strong>Scaling:</strong> <span class="math">O(1)</span> on-chain, <span class="math">O(history)</span> for recipient</p>
                     <p><strong>Privacy:</strong> Only parties see transaction data</p>
                     <p><strong>Example:</strong> RGB, Taproot Assets</p>
                 </div>
@@ -175,11 +175,11 @@
                 </p>
                 <ul>
                     <li><strong>Single-use:</strong> Can be closed over a message exactly once</li>
-                    <li><strong>Verified:</strong> Anyone can check if a seal was closed over message m</li>
+                    <li><strong>Verified:</strong> Anyone can check if a seal was closed over message <span class="math">m</span></li>
                     <li><strong>Unique:</strong> A seal cannot be closed over two different messages</li>
                 </ul>
                 <p>
-                    Formally, a seal S provides:
+                    Formally, a seal <span class="math">S</span> provides:
                 </p>
                 <ul>
                     <li><code>Close(S, m) → witness</code>: Close seal over message m</li>
@@ -187,7 +187,7 @@
                 </ul>
                 <p>
                     With the property that if <code>Verify(S, m₁, w₁)</code> and <code>Verify(S, m₂, w₂)</code>
-                    both return true, then m₁ = m₂.
+                    both return true, then <span class="math">m₁ = m₂</span>.
                 </p>
             </div>
 
@@ -200,9 +200,9 @@
                 </p>
                 <ul>
                     <li><strong>Seal identifier:</strong> The outpoint (txid:vout)</li>
-                    <li><strong>Close operation:</strong> Spend the UTXO with commitment to m in the spending tx</li>
+                    <li><strong>Close operation:</strong> Spend the UTXO with commitment to <span class="math">m</span> in the spending tx</li>
                     <li><strong>Witness:</strong> The spending transaction</li>
-                    <li><strong>Verification:</strong> Check tx spends the UTXO and contains commitment to m</li>
+                    <li><strong>Verification:</strong> Check tx spends the UTXO and contains commitment to <span class="math">m</span></li>
                 </ul>
                 <p>
                     The seal can only be closed once because a UTXO can only be spent once.
@@ -212,9 +212,9 @@
             <div class="proof">
                 <p><strong>Proof.</strong></p>
                 <p>
-                    Suppose an adversary could close seal (UTXO) over both m₁ and m₂ where m₁ ≠ m₂.
-                    This would require two transactions tx₁ and tx₂ both spending the same UTXO,
-                    with tx₁ committing to m₁ and tx₂ committing to m₂. But Bitcoin consensus
+                    Suppose an adversary could close seal (UTXO) over both <span class="math">m₁</span> and <span class="math">m₂</span> where <span class="math">m₁ ≠ m₂</span>.
+                    This would require two transactions <span class="math">tx₁</span> and <span class="math">tx₂</span> both spending the same UTXO,
+                    with <span class="math">tx₁</span> committing to <span class="math">m₁</span> and <span class="math">tx₂</span> committing to <span class="math">m₂</span>. But Bitcoin consensus
                     ensures only one transaction spending a given UTXO can be included in the
                     blockchain. Therefore, at most one closing can be valid. ∎
                 </p>
@@ -333,14 +333,14 @@
             <div class="definition">
                 <p><strong>Definition 22.4</strong> (Pay-to-Contract)</p>
                 <p>
-                    Given public key P and message m, the tweaked key is:
+                    Given public key <span class="math">P</span> and message <span class="math">m</span>, the tweaked key is:
                 </p>
                 <div class="formula">
                     P' = P + H(P || m) · G
                 </div>
                 <p>
-                    Where H is a hash function and G is the generator. The commitment is
-                    hidden in P' but verifiable given P and m.
+                    Where <span class="math">H</span> is a hash function and <span class="math">G</span> is the generator. The commitment is
+                    hidden in <span class="math">P'</span> but verifiable given <span class="math">P</span> and <span class="math">m</span>.
                 </p>
             </div>
         </section>
@@ -686,11 +686,11 @@
             <div class="theorem">
                 <p><strong>Theorem 22.3</strong> (CSV On-Chain Scaling)</p>
                 <p>
-                    For N client-side validation transfers, the blockchain footprint is:
+                    For <span class="math">N</span> client-side validation transfers, the blockchain footprint is:
                 </p>
                 <ul>
-                    <li><strong>Optimal case:</strong> O(1) — multiple transfers share one anchor tx</li>
-                    <li><strong>Typical case:</strong> O(N) Bitcoin transactions, but each tx is minimal size</li>
+                    <li><strong>Optimal case:</strong> <span class="math">O(1)</span> — multiple transfers share one anchor tx</li>
+                    <li><strong>Typical case:</strong> <span class="math">O(N)</span> Bitcoin transactions, but each tx is minimal size</li>
                     <li><strong>Data stored:</strong> Only commitments (~32 bytes), not state</li>
                 </ul>
                 <p>
@@ -704,7 +704,7 @@
             <div class="theorem">
                 <p><strong>Theorem 22.4</strong> (Validation Scaling)</p>
                 <p>
-                    Receiver validation cost is O(history_length), not O(all_transfers):
+                    Receiver validation cost is <span class="math">O(history_length)</span>, not <span class="math">O(all_transfers)</span>:
                 </p>
                 <ul>
                     <li>Receiver only validates their branch of history</li>

--- a/chapters/23-payment-channels.html
+++ b/chapters/23-payment-channels.html
@@ -129,7 +129,7 @@
                     <li><strong>Off-chain:</strong> Unlimited transactions between parties</li>
                 </ul>
                 <p>
-                    If a channel supports N off-chain payments, throughput multiplies by N/2.
+                    If a channel supports <span class="math">N</span> off-chain payments, throughput multiplies by <span class="math">N/2</span>.
                 </p>
             </div>
         </section>
@@ -484,7 +484,7 @@ OP_ENDIF</code></pre>
                     <li><strong>revocation_pubkey:</strong> Derived from both, known to counterparty after revocation</li>
                 </ul>
                 <p>
-                    To revoke state N, a party reveals the per_commitment_secret for state N.
+                    To revoke state <span class="math">N</span>, a party reveals the per_commitment_secret for state <span class="math">N</span>.
                     This allows the counterparty to compute the revocation private key.
                 </p>
             </div>
@@ -682,7 +682,7 @@ OP_ENDIF</code></pre>
                     A Hash Time-Locked Contract locks funds that can be claimed in two ways:
                 </p>
                 <ul>
-                    <li><strong>Success path:</strong> Recipient provides preimage R where H(R) = hash</li>
+                    <li><strong>Success path:</strong> Recipient provides preimage <span class="math">R</span> where <span class="math">H(R) = hash</span></li>
                     <li><strong>Timeout path:</strong> Sender reclaims after timeout expires</li>
                 </ul>
                 <pre><code>OP_IF

--- a/chapters/24-lightning.html
+++ b/chapters/24-lightning.html
@@ -96,14 +96,14 @@
             <div class="definition">
                 <p><strong>Definition 24.1</strong> (Multi-Hop Payment)</p>
                 <p>
-                    A multi-hop payment from sender S to receiver R through intermediaries I₁, I₂, ..., Iₙ:
+                    A multi-hop payment from sender <span class="math">S</span> to receiver <span class="math">R</span> through intermediaries <span class="math">I₁, I₂, ..., Iₙ</span>:
                 </p>
                 <ol>
-                    <li>R generates secret preimage r and payment_hash H(r)</li>
-                    <li>R sends payment_hash to S (via invoice)</li>
-                    <li>S routes payment through I₁ → I₂ → ... → Iₙ → R</li>
-                    <li>R reveals r to Iₙ to claim payment</li>
-                    <li>r propagates back: Iₙ → ... → I₁ → S</li>
+                    <li><span class="math">R</span> generates secret preimage <span class="math">r</span> and payment_hash <span class="math">H(r)</span></li>
+                    <li><span class="math">R</span> sends payment_hash to <span class="math">S</span> (via invoice)</li>
+                    <li><span class="math">S</span> routes payment through <span class="math">I₁ → I₂ → ... → Iₙ → R</span></li>
+                    <li><span class="math">R</span> reveals <span class="math">r</span> to <span class="math">Iₙ</span> to claim payment</li>
+                    <li><span class="math">r</span> propagates back: <span class="math">Iₙ → ... → I₁ → S</span></li>
                     <li>Each hop atomically settles their HTLC</li>
                 </ol>
             </div>
@@ -212,15 +212,15 @@
             <div class="proof">
                 <p><strong>Proof.</strong></p>
                 <p>
-                    The payment_hash H(r) is identical across all HTLCs. If receiver reveals r
-                    to claim the final HTLC, every intermediate node learns r (from their
+                    The payment_hash <span class="math">H(r)</span> is identical across all HTLCs. If receiver reveals <span class="math">r</span>
+                    to claim the final HTLC, every intermediate node learns <span class="math">r</span> (from their
                     downstream) and can claim their incoming HTLC. Since timeouts decrease
-                    toward the receiver, each node has sufficient time to claim after learning r.
+                    toward the receiver, each node has sufficient time to claim after learning <span class="math">r</span>.
                 </p>
                 <p>
-                    Conversely, if receiver never reveals r, all HTLCs eventually timeout and
+                    Conversely, if receiver never reveals <span class="math">r</span>, all HTLCs eventually timeout and
                     funds return to senders. An intermediate node cannot steal funds because
-                    they cannot claim their outgoing HTLC without r, and cannot keep their
+                    they cannot claim their outgoing HTLC without <span class="math">r</span>, and cannot keep their
                     incoming HTLC without the timeout expiring. ∎
                 </p>
             </div>
@@ -395,7 +395,7 @@
                     A Lightning invoice encodes:
                 </p>
                 <ul>
-                    <li><strong>payment_hash:</strong> H(preimage) to verify payment</li>
+                    <li><strong>payment_hash:</strong> <span class="math">H(preimage)</span> to verify payment</li>
                     <li><strong>amount:</strong> Requested payment (optional)</li>
                     <li><strong>destination:</strong> Receiver's node public key</li>
                     <li><strong>expiry:</strong> Invoice validity period</li>
@@ -453,11 +453,11 @@ lnbc1pvjluezsp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygspp5qqqsyqcyq5
             <div class="definition">
                 <p><strong>Definition 24.7</strong> (Channel Graph)</p>
                 <p>
-                    The Lightning Network graph G = (V, E) where:
+                    The Lightning Network graph <span class="math">G = (V, E)</span> where:
                 </p>
                 <ul>
-                    <li><strong>Vertices V:</strong> Lightning nodes (public keys)</li>
-                    <li><strong>Edges E:</strong> Payment channels</li>
+                    <li><strong>Vertices <span class="math">V</span>:</strong> Lightning nodes (public keys)</li>
+                    <li><strong>Edges <span class="math">E</span>:</strong> Payment channels</li>
                     <li><strong>Edge weights:</strong> Fees, capacity, reliability metrics</li>
                 </ul>
                 <p>
@@ -476,7 +476,7 @@ lnbc1pvjluezsp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygspp5qqqsyqcyq5
                     <li><strong>base_fee:</strong> Fixed fee per forwarded HTLC, in millisatoshis (msat; 1 satoshi = 1,000 msat, Lightning's sub-satoshi accounting unit)</li>
                     <li><strong>fee_rate:</strong> Proportional fee (millionths of amount)</li>
                 </ul>
-                <p>
+                <p class="math-block">
                     Total fee = base_fee + (amount × fee_rate / 1,000,000)
                 </p>
             </div>
@@ -484,11 +484,11 @@ lnbc1pvjluezsp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygspp5qqqsyqcyq5
             <div class="example">
                 <p><strong>Example 24.2</strong> (Fee Calculation)</p>
                 <p>
-                    Channel with base_fee = 1000 msat, fee_rate = 100:
+                    Channel with <span class="math">base_fee = 1000 msat</span>, <span class="math">fee_rate = 100</span>:
                 </p>
                 <ul>
-                    <li>Forward 100,000 sat: fee = 1000 + (100,000,000 × 100 / 1,000,000) = 1000 + 10,000 = 11,000 msat = 11 sat</li>
-                    <li>Forward 1,000 sat: fee = 1000 + (1,000,000 × 100 / 1,000,000) = 1000 + 100 = 1,100 msat ≈ 1 sat</li>
+                    <li>Forward 100,000 sat: <span class="math">fee = 1000 + (100,000,000 × 100 / 1,000,000) = 1000 + 10,000 = 11,000 msat = 11 sat</span></li>
+                    <li>Forward 1,000 sat: <span class="math">fee = 1000 + (1,000,000 × 100 / 1,000,000) = 1000 + 100 = 1,100 msat ≈ 1 sat</span></li>
                 </ul>
             </div>
 
@@ -780,7 +780,7 @@ lnbc1pvjluezsp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygspp5qqqsyqcyq5
                 <p><strong>Exercise 24.1</strong></p>
                 <p>
                     Calculate the minimum total fees to route 0.1 BTC through a 5-hop path
-                    where each node charges base_fee = 1 sat and fee_rate = 1000 (0.1%).
+                    where each node charges <span class="math">base_fee = 1 sat</span> and <span class="math">fee_rate = 1000</span> (0.1%).
                 </p>
             </div>
 

--- a/chapters/25-debunking-myths.html
+++ b/chapters/25-debunking-myths.html
@@ -385,7 +385,7 @@
                 </ul>
                 <p>For mining:</p>
                 <ul>
-                    <li>Grover's provides only √N speedup (not exponential)</li>
+                    <li>Grover's provides only <span class="math">√N</span> speedup (not exponential)</li>
                     <li>Difficulty adjustment compensates automatically</li>
                     <li>Hash function can be upgraded if needed</li>
                 </ul>
@@ -417,13 +417,13 @@
                     As of 2024:
                 </p>
                 <ul>
-                    <li><strong>Collision resistance:</strong> 2¹²⁸ operations (birthday bound); no attacks on full SHA-256 significantly better than this</li>
-                    <li><strong>Preimage resistance:</strong> 2²⁵⁶ operations; no attacks better than brute force</li>
-                    <li><strong>Second preimage:</strong> 2²⁵⁶ operations; no practical attacks</li>
+                    <li><strong>Collision resistance:</strong> <span class="math">2¹²⁸</span> operations (birthday bound); no attacks on full SHA-256 significantly better than this</li>
+                    <li><strong>Preimage resistance:</strong> <span class="math">2²⁵⁶</span> operations; no attacks better than brute force</li>
+                    <li><strong>Second preimage:</strong> <span class="math">2²⁵⁶</span> operations; no practical attacks</li>
                 </ul>
                 <p>
                     Even if SHA-256 were weakened to 128-bit security, this provides
-                    2¹²⁸ operations—still computationally infeasible.
+                    <span class="math">2¹²⁸</span> operations—still computationally infeasible.
                 </p>
             </div>
 

--- a/chapters/26-fork-theory.html
+++ b/chapters/26-fork-theory.html
@@ -43,14 +43,14 @@
                 <p class="definition-title">Definition 26.1 (Blockchain Fork)</p>
                 <p>
                     A <strong>fork</strong> occurs when two or more valid blocks share the same
-                    parent block, creating divergent chain histories. Let B<sub>p</sub> be a block
-                    and B<sub>1</sub>, B<sub>2</sub> be distinct blocks such that:
+                    parent block, creating divergent chain histories. Let <span class="math">B<sub>p</sub></span> be a block
+                    and <span class="math">B<sub>1</sub></span>, <span class="math">B<sub>2</sub></span> be distinct blocks such that:
                 </p>
                 <p class="math-block">
                     prev_hash(B<sub>1</sub>) = prev_hash(B<sub>2</sub>) = hash(B<sub>p</sub>)
                 </p>
                 <p>
-                    Then blocks B<sub>1</sub> and B<sub>2</sub> constitute a fork at height h(B<sub>p</sub>) + 1.
+                    Then blocks <span class="math">B<sub>1</sub></span> and <span class="math">B<sub>2</sub></span> constitute a fork at height <span class="math">h(B<sub>p</sub>) + 1</span>.
                 </p>
             </div>
 
@@ -121,7 +121,7 @@
                     W(chain<sub>1</sub>) > W(chain<sub>2</sub>) ⟹ nodes adopt chain<sub>1</sub>
                 </p>
                 <p>
-                    where W(·) denotes cumulative proof-of-work.
+                    where <span class="math">W(·)</span> denotes cumulative proof-of-work.
                 </p>
             </div>
         </section>
@@ -137,11 +137,11 @@
             <div class="theorem">
                 <p class="theorem-title">Theorem 26.1 (Fork Probability Bound)</p>
                 <p>
-                    Let λ be the block arrival rate (blocks per second) and δ be the network
+                    Let <span class="math">λ</span> be the block arrival rate (blocks per second) and <span class="math">δ</span> be the network
                     propagation delay. The probability of a natural fork is approximately:
                 </p>
                 <p class="math-block">
-                    P(fork) ≈ 1 − e<sup>−λδ</sup> ≈ λδ for small λδ
+                    P(fork) ≈ 1 − e^(−λδ) ≈ λδ for small λδ
                 </p>
             </div>
 
@@ -150,14 +150,14 @@
                 <p>
                     After a block is found, another block might be found before propagation
                     completes. The inter-arrival time follows an exponential distribution with
-                    rate λ. The probability that another block arrives within time δ is:
+                    rate <span class="math">λ</span>. The probability that another block arrives within time <span class="math">δ</span> is:
                 </p>
                 <p class="math-block">
-                    P(T ≤ δ) = 1 − e<sup>−λδ</sup>
+                    P(T ≤ δ) = 1 − e^(−λδ)
                 </p>
                 <p>
-                    For Bitcoin, λ ≈ 1/600 blocks/second and δ ≈ 1-10 seconds, giving
-                    P(fork) ≈ 0.2% - 1.7%. □
+                    For Bitcoin, <span class="math">λ ≈ 1/600</span> blocks/second and <span class="math">δ ≈ 1–10</span> seconds, giving
+                    <span class="math">P(fork) ≈ 0.2%–1.7%</span>. □
                 </p>
             </div>
 
@@ -232,17 +232,17 @@
             <div class="definition">
                 <p class="definition-title">Definition 26.5 (Rule Sets)</p>
                 <p>
-                    Let R<sub>old</sub> and R<sub>new</sub> be sets of blocks considered valid
+                    Let <span class="math">R<sub>old</sub></span> and <span class="math">R<sub>new</sub></span> be sets of blocks considered valid
                     under old and new rules respectively:
                 </p>
                 <ul>
-                    <li><strong>Soft fork:</strong> R<sub>new</sub> ⊂ R<sub>old</sub> (new rules are stricter)</li>
-                    <li><strong>Hard fork:</strong> R<sub>old</sub> ⊂ R<sub>new</sub> (new rules are looser)</li>
+                    <li><strong>Soft fork:</strong> <span class="math">R<sub>new</sub> ⊂ R<sub>old</sub></span> (new rules are stricter)</li>
+                    <li><strong>Hard fork:</strong> <span class="math">R<sub>old</sub> ⊂ R<sub>new</sub></span> (new rules are looser)</li>
                     <li><strong>Bilateral fork:</strong> no block <em>extending the fork point</em> is valid under both rule sets (each side rejects the other's new blocks; the shared pre-fork history is of course valid under both)</li>
                 </ul>
                 <p>
                     In practice, "hard forks" generally satisfy the weaker condition
-                    R<sub>new</sub> ⊄ R<sub>old</sub> and may simultaneously tighten other
+                    <span class="math">R<sub>new</sub> ⊄ R<sub>old</sub></span> and may simultaneously tighten other
                     rules. Strong replay protection (such as Bitcoin Cash's mandatory
                     SIGHASH_FORKID) deliberately converts an expanding hard fork into a
                     bilateral one.
@@ -281,12 +281,12 @@
             <div class="theorem">
                 <p class="theorem-title">Theorem 26.2 (Soft Fork Safety)</p>
                 <p>
-                    If a soft fork activates with fraction f > 0.5 of hash power enforcing
-                    new rules R<sub>new</sub>, then:
+                    If a soft fork activates with fraction <span class="math">f > 0.5</span> of hash power enforcing
+                    new rules <span class="math">R<sub>new</sub></span>, then:
                 </p>
                 <ol>
-                    <li>The most-work chain eventually follows R<sub>new</sub> rules (with probability 1)</li>
-                    <li>Nodes following R<sub>old</sub> remain on this chain (since R<sub>new</sub> ⊂ R<sub>old</sub>)</li>
+                    <li>The most-work chain eventually follows <span class="math">R<sub>new</sub></span> rules (with probability 1)</li>
+                    <li>Nodes following <span class="math">R<sub>old</sub></span> remain on this chain (since <span class="math">R<sub>new</sub> ⊂ R<sub>old</sub></span>)</li>
                     <li>No permanent chain split occurs</li>
                 </ol>
             </div>
@@ -294,10 +294,10 @@
             <div class="proof">
                 <p class="proof-title">Proof.</p>
                 <p>
-                    Blocks valid under R<sub>new</sub> are valid under R<sub>old</sub> by definition.
-                    Thus, the chain built by the majority (enforcing R<sub>new</sub>) is accepted
-                    by all nodes. A chain violating R<sub>new</sub> can only be extended by the minority
-                    (fraction 1 − f &lt; 0.5). The work race between the two chains is a biased
+                    Blocks valid under <span class="math">R<sub>new</sub></span> are valid under <span class="math">R<sub>old</sub></span> by definition.
+                    Thus, the chain built by the majority (enforcing <span class="math">R<sub>new</sub></span>) is accepted
+                    by all nodes. A chain violating <span class="math">R<sub>new</sub></span> can only be extended by the minority
+                    (fraction <span class="math">1 − f &lt; 0.5</span>). The work race between the two chains is a biased
                     random walk: by the gambler's-ruin argument of Theorem 14.4, the enforcing
                     majority's chain takes and keeps the cumulative-work lead with probability 1.
                     Old nodes might temporarily follow an invalid chain (as in the 2015 BIP-66
@@ -311,9 +311,9 @@
                     A hard fork produces a permanent chain split when the new-rules side
                     persistently holds the most-work chain <em>and</em> some hash power keeps
                     extending an old-rules-only chain. Old nodes reject blocks valid only
-                    under R<sub>new</sub> and follow their own chain. If instead old-rules
+                    under <span class="math">R<sub>new</sub></span> and follow their own chain. If instead old-rules
                     miners retain the majority, upgraded nodes (which still accept old-rules
-                    blocks when R<sub>old</sub> ⊂ R<sub>new</sub>) reorg back to the old
+                    blocks when <span class="math">R<sub>old</sub> ⊂ R<sub>new</sub></span>) reorg back to the old
                     chain and the fork simply dies&mdash;which is why expanding hard forks in
                     practice pair with majority hash power, a fork-point checkpoint, or
                     bilateral replay protection.
@@ -331,15 +331,15 @@
             <div class="definition">
                 <p class="definition-title">Definition 26.6 (Fork Adoption Game)</p>
                 <p>
-                    Consider n players who must choose between chains A and B. Let v<sub>A</sub>(k)
-                    and v<sub>B</sub>(n-k) be the value of holding coins on chain A (with k adopters)
-                    and chain B (with n-k adopters) respectively. The payoff exhibits network effects:
+                    Consider <span class="math">n</span> players who must choose between chains A and B. Let <span class="math">v<sub>A</sub>(k)</span>
+                    and <span class="math">v<sub>B</sub>(n−k)</span> be the value of holding coins on chain A (with <span class="math">k</span> adopters)
+                    and chain B (with <span class="math">n−k</span> adopters) respectively. The payoff exhibits network effects:
                 </p>
                 <p class="math-block">
                     v<sub>A</sub>(k) = f(k) · m<sub>A</sub>
                 </p>
                 <p>
-                    where f(k) is an increasing function of adopters and m<sub>A</sub> is the
+                    where <span class="math">f(k)</span> is an increasing function of adopters and <span class="math">m<sub>A</sub></span> is the
                     intrinsic merit of chain A's properties.
                 </p>
             </div>
@@ -529,7 +529,7 @@
                     FCR<sub>Nakamoto</sub>(C) = argmax<sub>c∈C</sub> Σ<sub>b∈c</sub> work(b)
                 </p>
                 <p>
-                    where work(b) = 2<sup>256</sup> / target(b) for block b (approximately; Bitcoin Core uses 2<sup>256</sup> / (target + 1)).
+                    where <span class="math">work(b) = 2²⁵⁶ / target(b)</span> for block <span class="math">b</span> (approximately; Bitcoin Core uses <span class="math">2²⁵⁶ / (target + 1)</span>).
                 </p>
             </div>
 
@@ -540,8 +540,8 @@
                     cumulative work." These differ when difficulty changes:
                 </p>
                 <ul>
-                    <li>Chain A: 10 blocks at difficulty 1 → work = 10</li>
-                    <li>Chain B: 5 blocks at difficulty 3 → work = 15</li>
+                    <li>Chain A: 10 blocks at difficulty 1 → <span class="math">work = 10</span></li>
+                    <li>Chain B: 5 blocks at difficulty 3 → <span class="math">work = 15</span></li>
                 </ul>
                 <p>
                     Chain B wins despite being shorter.
@@ -575,26 +575,26 @@
             <div class="definition">
                 <p class="definition-title">Definition 26.11 (k-Confirmation Security)</p>
                 <p>
-                    A transaction is <strong>k-confirmed</strong> when it is included in a block
-                    with k-1 blocks built on top of it. The probability of reversal decreases
-                    exponentially with k.
+                    A transaction is <strong><span class="math">k</span>-confirmed</strong> when it is included in a block
+                    with <span class="math">k−1</span> blocks built on top of it. The probability of reversal decreases
+                    exponentially with <span class="math">k</span>.
                 </p>
             </div>
 
             <div class="theorem">
                 <p class="theorem-title">Theorem 26.3 (Double-Spend Probability)</p>
                 <p>
-                    Let q be the fraction of hash power controlled by an attacker, p = 1 − q
-                    with q &lt; p, and k be the number of confirmations. The probability that
-                    the attacker, once k blocks behind, ever catches up is (q/p)<sup>k</sup>.
+                    Let <span class="math">q</span> be the fraction of hash power controlled by an attacker, <span class="math">p = 1 − q</span>
+                    with <span class="math">q &lt; p</span>, and <span class="math">k</span> be the number of confirmations. The probability that
+                    the attacker, once <span class="math">k</span> blocks behind, ever catches up is <span class="math">(q/p)ᵏ</span>.
                     Accounting also for blocks the attacker mines during the confirmation
                     period (Theorem 14.4), the probability of a successful double-spend is:
                 </p>
                 <p class="math-block">
-                    P(double-spend) = 1 − Σ<sub>m=0</sub><sup>k</sup> [λ<sup>m</sup>e<sup>−λ</sup>/m! × (1 − (q/p)<sup>k−m</sup>)],&nbsp;&nbsp;λ = k(q/p)
+                    P(double-spend) = 1 − Σₘ₌₀ᵏ [λᵐe^(−λ)/m! × (1 − (q/p)^(k−m))],&nbsp;&nbsp;λ = k(q/p)
                 </p>
                 <p>
-                    For q = 0.1 (10% attacker) and k = 6: P ≈ 0.02%
+                    For <span class="math">q = 0.1</span> (10% attacker) and <span class="math">k = 6</span>: <span class="math">P ≈ 0.02%</span>
                 </p>
             </div>
 
@@ -808,8 +808,8 @@
                 <p class="exercise-title">Exercise 26.1</p>
                 <p>
                     Prove that if hash power is distributed such that no miner has more than
-                    1/n of the total, the expected time to natural fork resolution satisfies
-                    E[T] ≤ 2·T<sub>block</sub>. What assumptions are needed?
+                    <span class="math">1/n</span> of the total, the expected time to natural fork resolution satisfies
+                    <span class="math">E[T] ≤ 2·T<sub>block</sub></span>. What assumptions are needed?
                 </p>
             </div>
 

--- a/chapters/27-historical-forks.html
+++ b/chapters/27-historical-forks.html
@@ -751,10 +751,10 @@ if (timeSince6Blocks > 12 hours):
                     a pattern consistent with:
                 </p>
                 <p class="math-block">
-                    V<sub>fork</sub>(t) / V<sub>BTC</sub>(t) ∝ e<sup>−λt</sup>
+                    V<sub>fork</sub>(t) / V<sub>BTC</sub>(t) ∝ e^(−λt)
                 </p>
                 <p>
-                    where λ varies by fork (BCH: ~0.4/year, BTG: ~0.7/year).
+                    where <span class="math">λ</span> varies by fork (BCH: ~0.4/year, BTG: ~0.7/year).
                 </p>
                 <p>
                     This suggests that network effects compound over time, increasingly

--- a/chapters/28-segwit-deep-dive.html
+++ b/chapters/28-segwit-deep-dive.html
@@ -45,13 +45,13 @@
                 <p>
                     <strong>Transaction malleability</strong> is the ability to modify a
                     transaction's identifier (txid) without invalidating it. A transaction
-                    T' is a <strong>malleated version</strong> of T if:
+                    <span class="math">T'</span> is a <strong>malleated version</strong> of <span class="math">T</span> if:
                 </p>
                 <ul>
-                    <li>T and T' spend the same inputs</li>
-                    <li>T and T' create the same outputs</li>
+                    <li><span class="math">T</span> and <span class="math">T'</span> spend the same inputs</li>
+                    <li><span class="math">T</span> and <span class="math">T'</span> create the same outputs</li>
                     <li>Both are valid according to consensus rules</li>
-                    <li>txid(T) ≠ txid(T')</li>
+                    <li><span class="math">txid(T) ≠ txid(T')</span></li>
                 </ul>
             </div>
 
@@ -62,7 +62,7 @@
                     including signatures. Several malleability vectors existed:
                 </p>
                 <ol>
-                    <li><strong>ECDSA signature malleability:</strong> (r, s) and (r, n-s) are both valid</li>
+                    <li><strong>ECDSA signature malleability:</strong> <span class="math">(r, s)</span> and <span class="math">(r, n−s)</span> are both valid</li>
                     <li><strong>Script push opcodes:</strong> Multiple ways to push same data</li>
                     <li><strong>Extra data in scriptSig:</strong> Additional stack elements</li>
                     <li><strong>SIGHASH_SINGLE bug:</strong> Edge case producing predictable signatures</li>
@@ -110,8 +110,8 @@
             <div class="example">
                 <p class="example-title">Example 28.1 (ECDSA Signature Malleability)</p>
                 <p>
-                    An ECDSA signature is a pair (r, s) where s can be replaced with n - s
-                    (mod n) to produce an equivalent valid signature:
+                    An ECDSA signature is a pair <span class="math">(r, s)</span> where <span class="math">s</span> can be replaced with <span class="math">n − s</span>
+                    <span class="math">(mod n)</span> to produce an equivalent valid signature:
                 </p>
                 <pre style="background: #f5f5f5; padding: 1rem; font-family: monospace; font-size: 0.85rem;">
 Original:  sig = (r, s)       where s < n/2
@@ -122,7 +122,7 @@ With s' = n − s:        R' = (z·s'⁻¹)·G + (r·s'⁻¹)·P = −R
 Since R'.x = R.x (negation preserves x), both pass.</pre>
                 <p>
                     Bitcoin Core's low-S standardness rule (proposed for consensus as
-                    BIP-146, which never activated) requires s ≤ n/2 as relay policy;
+                    BIP-146, which never activated) requires <span class="math">s ≤ n/2</span> as relay policy;
                     SegWit removed signatures from the txid entirely.
                 </p>
             </div>
@@ -153,11 +153,11 @@ Since R'.x = R.x (negation preserves x), both pass.</pre>
                 <p class="definition-title">Definition 28.2 (Witness)</p>
                 <p>
                     The <strong>witness</strong> is a new transaction component containing
-                    signature and script data. For each input i:
+                    signature and script data. For each input <span class="math">i</span>:
                 </p>
                 <ul>
                     <li><strong>Legacy:</strong> Signature in scriptSig</li>
-                    <li><strong>SegWit:</strong> Signature in witness[i], scriptSig empty</li>
+                    <li><strong>SegWit:</strong> Signature in <span class="math">witness[i]</span>, scriptSig empty</li>
                 </ul>
             </div>
 
@@ -386,7 +386,7 @@ where:
                     vbytes = ⌈weight / 4⌉
                 </p>
                 <p>
-                    Maximum block: 4,000,000 / 4 = 1,000,000 vbytes.
+                    Maximum block: <span class="math">4,000,000 / 4 = 1,000,000</span> vbytes.
                 </p>
             </div>
 
@@ -450,7 +450,7 @@ where:
                     </tbody>
                 </table>
                 <p>
-                    vbytes = ⌈441/4⌉ = 111 vbytes (vs 192 actual bytes).
+                    <span class="math">vbytes = ⌈441/4⌉ = 111</span> vbytes (vs 192 actual bytes).
                     (Input/output count varints are omitted for clarity; a complete
                     serialization adds 2 base bytes.)
                 </p>
@@ -504,7 +504,7 @@ where:
                     wtxid = SHA256d(serialized tx with witness)
                 </p>
                 <p>
-                    For the coinbase: wtxid = 0x00...00 (32 zero bytes).
+                    For the coinbase: <span class="math">wtxid = 0x00...00</span> (32 zero bytes).
                 </p>
             </div>
 
@@ -691,7 +691,7 @@ SHA256d(
                     BIP-143 sighash fixes multiple issues:
                 </p>
                 <ol>
-                    <li><strong>O(n²) hashing eliminated:</strong> Pre-computed hashes reused</li>
+                    <li><strong><span class="math">O(n²)</span> hashing eliminated:</strong> Pre-computed hashes reused</li>
                     <li><strong>Amount committed:</strong> Prevents value manipulation attacks</li>
                     <li><strong>Script committed:</strong> Prevents scriptPubKey substitution</li>
                     <li><strong>Consistent algorithm:</strong> Same process for all input types</li>
@@ -702,13 +702,13 @@ SHA256d(
                 <p class="example-title">Example 28.4 (O(n²) Attack Prevention)</p>
                 <p>
                     In legacy sighash, each signature hashes the entire transaction.
-                    A transaction with n inputs requires n signatures, each hashing
-                    O(n) data → O(n²) total hashing.
+                    A transaction with <span class="math">n</span> inputs requires <span class="math">n</span> signatures, each hashing
+                    <span class="math">O(n)</span> data → <span class="math">O(n²)</span> total hashing.
                 </p>
                 <p>
                     An attacker could create transactions with many inputs to DoS nodes.
                     BIP-143 pre-computes hashPrevouts and hashOutputs once, making
-                    the cost O(n).
+                    the cost <span class="math">O(n)</span>.
                 </p>
             </div>
         </section>
@@ -892,8 +892,8 @@ witness:      &lt;sig&gt; &lt;pubkey&gt;</pre>
             <div class="exercise">
                 <p class="exercise-title">Exercise 28.3</p>
                 <p>
-                    Show that the pre-SegWit sighash algorithm has O(n²) complexity for
-                    n inputs. Then show how BIP-143 achieves O(n).
+                    Show that the pre-SegWit sighash algorithm has <span class="math">O(n²)</span> complexity for
+                    <span class="math">n</span> inputs. Then show how BIP-143 achieves <span class="math">O(n)</span>.
                 </p>
             </div>
 

--- a/chapters/29-taproot-architecture.html
+++ b/chapters/29-taproot-architecture.html
@@ -43,24 +43,24 @@
             <div class="definition">
                 <p class="definition-title">Definition 29.1 (BIP-340 Schnorr Signature)</p>
                 <p>
-                    Given private key d, public key P = d·G, and message m:
+                    Given private key <span class="math">d</span>, public key <span class="math">P = d·G</span>, and message <span class="math">m</span>:
                 </p>
                 <ol>
-                    <li>Choose random nonce k, compute R = k·G (negating k if R has an odd y-coordinate)</li>
-                    <li>Compute challenge e = H<sub>BIP340/challenge</sub>(x(R) || x(P) || m), hashing the x-only serializations</li>
-                    <li>Compute s = k + e·d (mod n)</li>
-                    <li>Signature is (x(R), s), serialized as 64 bytes</li>
+                    <li>Choose random nonce <span class="math">k</span>, compute <span class="math">R = k·G</span> (negating <span class="math">k</span> if <span class="math">R</span> has an odd <span class="math">y</span>-coordinate)</li>
+                    <li>Compute challenge <span class="math">e = H<sub>BIP340/challenge</sub>(x(R) || x(P) || m)</span>, hashing the x-only serializations</li>
+                    <li>Compute <span class="math">s = k + e·d (mod n)</span></li>
+                    <li>Signature is <span class="math">(x(R), s)</span>, serialized as 64 bytes</li>
                 </ol>
             </div>
 
             <div class="definition">
                 <p class="definition-title">Definition 29.2 (Schnorr Verification)</p>
                 <p>
-                    To verify signature (R, s) on message m with public key P:
+                    To verify signature <span class="math">(R, s)</span> on message <span class="math">m</span> with public key <span class="math">P</span>:
                 </p>
                 <ol>
-                    <li>Compute e = H<sub>BIP340/challenge</sub>(R || P || m)</li>
-                    <li>Check that s·G = R + e·P</li>
+                    <li>Compute <span class="math">e = H<sub>BIP340/challenge</sub>(R || P || m)</span></li>
+                    <li>Check that <span class="math">s·G = R + e·P</span></li>
                 </ol>
             </div>
 
@@ -118,8 +118,8 @@
                     is stored (32 bytes instead of 33). The y-coordinate is implicitly even:
                 </p>
                 <ul>
-                    <li>If P has odd y, negate it: use -P (which has even y)</li>
-                    <li>Adjust private key accordingly: if P has odd y, use n - d</li>
+                    <li>If <span class="math">P</span> has odd <span class="math">y</span>, negate it: use <span class="math">−P</span> (which has even <span class="math">y</span>)</li>
+                    <li>Adjust private key accordingly: if <span class="math">P</span> has odd <span class="math">y</span>, use <span class="math">n − d</span></li>
                 </ul>
             </div>
 
@@ -139,15 +139,15 @@
             <div class="theorem">
                 <p class="theorem-title">Theorem 29.1 (Schnorr Batch Verification)</p>
                 <p>
-                    Given n signatures (R<sub>i</sub>, s<sub>i</sub>) on messages m<sub>i</sub>
-                    with public keys P<sub>i</sub>, batch verify by checking:
+                    Given <span class="math">n</span> signatures <span class="math">(R<sub>i</sub>, s<sub>i</sub>)</span> on messages <span class="math">m<sub>i</sub></span>
+                    with public keys <span class="math">P<sub>i</sub></span>, batch verify by checking:
                 </p>
                 <p class="math-block">
                     (Σ a<sub>i</sub>·s<sub>i</sub>)·G = Σ a<sub>i</sub>·R<sub>i</sub> + Σ a<sub>i</sub>·e<sub>i</sub>·P<sub>i</sub>
                 </p>
                 <p>
-                    where a<sub>i</sub> are random weights. Cost: O(n) point additions, one
-                    multi-scalar multiplication, vs O(n) full verifications individually.
+                    where <span class="math">a<sub>i</sub></span> are random weights. Cost: <span class="math">O(n)</span> point additions, one
+                    multi-scalar multiplication, vs <span class="math">O(n)</span> full verifications individually.
                 </p>
             </div>
 
@@ -171,14 +171,14 @@
             <div class="definition">
                 <p class="definition-title">Definition 29.4 (Tweak)</p>
                 <p>
-                    A <strong>tweaked public key</strong> Q is computed from internal key P
-                    and tweak t:
+                    A <strong>tweaked public key</strong> <span class="math">Q</span> is computed from internal key <span class="math">P</span>
+                    and tweak <span class="math">t</span>:
                 </p>
                 <p class="math-block">
                     Q = P + t·G
                 </p>
                 <p>
-                    The corresponding tweaked private key (if P = d·G):
+                    The corresponding tweaked private key (if <span class="math">P = d·G</span>):
                 </p>
                 <p class="math-block">
                     q = d + t (mod n)
@@ -194,7 +194,7 @@
                     t = H<sub>TapTweak</sub>(P || script_root)
                 </p>
                 <p>
-                    If no scripts: t = H<sub>TapTweak</sub>(P)
+                    If no scripts: <span class="math">t = H<sub>TapTweak</sub>(P)</span>
                 </p>
             </div>
 
@@ -246,7 +246,7 @@
                     A Taproot output (OP_1 &lt;Q&gt;) can be spent two ways:
                 </p>
                 <ol>
-                    <li><strong>Key path:</strong> Provide signature for Q (single 64-byte witness)</li>
+                    <li><strong>Key path:</strong> Provide signature for <span class="math">Q</span> (single 64-byte witness)</li>
                     <li><strong>Script path:</strong> Reveal script, provide Merkle proof, satisfy script</li>
                 </ol>
             </div>
@@ -266,8 +266,8 @@
                     A <strong>TapTree</strong> is a Merkle tree of scripts:
                 </p>
                 <ul>
-                    <li>Leaves: H<sub>TapLeaf</sub>(leaf_version || script)</li>
-                    <li>Branches: H<sub>TapBranch</sub>(left || right) where left ≤ right lexicographically</li>
+                    <li>Leaves: <span class="math">H<sub>TapLeaf</sub>(leaf_version || script)</span></li>
+                    <li>Branches: <span class="math">H<sub>TapBranch</sub>(left || right)</span> where <span class="math">left ≤ right</span> lexicographically</li>
                     <li>Root: becomes part of the tweak</li>
                 </ul>
             </div>
@@ -425,13 +425,13 @@ Stack after:  [n] (or [n+1] if valid)
                     <tbody>
                         <tr>
                             <td>OP_CHECKMULTISIG</td>
-                            <td>O(n) pubkeys</td>
-                            <td>k sigs + dummy</td>
+                            <td><span class="math">O(n)</span> pubkeys</td>
+                            <td><span class="math">k</span> sigs + dummy</td>
                         </tr>
                         <tr>
                             <td>CHECKSIGADD</td>
-                            <td>O(n) pubkeys</td>
-                            <td>n sigs (empty for non-signers)</td>
+                            <td><span class="math">O(n)</span> pubkeys</td>
+                            <td><span class="math">n</span> sigs (empty for non-signers)</td>
                         </tr>
                         <tr>
                             <td>MuSig + key path</td>
@@ -467,12 +467,12 @@ Stack after:  [n] (or [n+1] if valid)
             <div class="definition">
                 <p class="definition-title">Definition 29.10 (MuSig2 Key Aggregation)</p>
                 <p>
-                    Given n public keys P<sub>1</sub>, ..., P<sub>n</sub>:
+                    Given <span class="math">n</span> public keys <span class="math">P<sub>1</sub>, ..., P<sub>n</sub></span>:
                 </p>
                 <ol>
-                    <li>Compute key aggregation coefficient: a<sub>i</sub> = H<sub>agg</sub>(L || P<sub>i</sub>)</li>
-                    <li>where L = H(P<sub>1</sub> || ... || P<sub>n</sub>)</li>
-                    <li>Aggregate key: P = Σ a<sub>i</sub>·P<sub>i</sub></li>
+                    <li>Compute key aggregation coefficient: <span class="math">a<sub>i</sub> = H<sub>agg</sub>(L || P<sub>i</sub>)</span></li>
+                    <li>where <span class="math">L = H(P<sub>1</sub> || ... || P<sub>n</sub>)</span></li>
+                    <li>Aggregate key: <span class="math">P = Σ a<sub>i</sub>·P<sub>i</sub></span></li>
                 </ol>
             </div>
 
@@ -483,15 +483,15 @@ Stack after:  [n] (or [n+1] if valid)
                 </p>
                 <p><strong>Round 1:</strong></p>
                 <ol>
-                    <li>Each signer generates two nonces: R<sub>i,1</sub>, R<sub>i,2</sub></li>
+                    <li>Each signer generates two nonces: <span class="math">R<sub>i,1</sub></span>, <span class="math">R<sub>i,2</sub></span></li>
                     <li>Broadcast nonces</li>
                 </ol>
                 <p><strong>Round 2:</strong></p>
                 <ol>
-                    <li>Compute R = Σ R<sub>i,1</sub> + b·Σ R<sub>i,2</sub> where b = H(agg_nonces || agg_key || msg)</li>
-                    <li>Each signer computes partial: s<sub>i</sub> = k<sub>i,1</sub> + b·k<sub>i,2</sub> + e·a<sub>i</sub>·d<sub>i</sub>, where e = H(R || P || m) is the challenge of Definition 29.1</li>
-                    <li>Aggregate: s = Σ s<sub>i</sub></li>
-                    <li>Final signature: (R, s)</li>
+                    <li>Compute <span class="math">R = Σ R<sub>i,1</sub> + b·Σ R<sub>i,2</sub></span> where <span class="math">b = H(agg_nonces || agg_key || msg)</span></li>
+                    <li>Each signer computes partial: <span class="math">s<sub>i</sub> = k<sub>i,1</sub> + b·k<sub>i,2</sub> + e·a<sub>i</sub>·d<sub>i</sub></span>, where <span class="math">e = H(R || P || m)</span> is the challenge of Definition 29.1</li>
+                    <li>Aggregate: <span class="math">s = Σ s<sub>i</sub></span></li>
+                    <li>Final signature: <span class="math">(R, s)</span></li>
                 </ol>
             </div>
 
@@ -554,13 +554,13 @@ Stack after:  [n] (or [n+1] if valid)
             <div class="definition">
                 <p class="definition-title">Definition 29.12 (Adaptor Signature)</p>
                 <p>
-                    An <strong>adaptor signature</strong> σ' is a "partial" signature that becomes
-                    valid when combined with a secret scalar t:
+                    An <strong>adaptor signature</strong> <span class="math">σ'</span> is a "partial" signature that becomes
+                    valid when combined with a secret scalar <span class="math">t</span>:
                 </p>
                 <ul>
-                    <li>Adaptor point: T = t·G (public)</li>
-                    <li>Adaptor signature: σ' = (R + T, s')</li>
-                    <li>When t is revealed: σ = (R + T, s' + t) is valid</li>
+                    <li>Adaptor point: <span class="math">T = t·G</span> (public)</li>
+                    <li>Adaptor signature: <span class="math">σ' = (R + T, s')</span></li>
+                    <li>When <span class="math">t</span> is revealed: <span class="math">σ = (R + T, s' + t)</span> is valid</li>
                 </ul>
             </div>
 
@@ -570,10 +570,10 @@ Stack after:  [n] (or [n+1] if valid)
                     Adaptor signatures enable atomic swaps without hash preimages:
                 </p>
                 <ol>
-                    <li>Alice gives Bob adaptor σ' (valid when combined with secret t)</li>
-                    <li>Bob broadcasts transaction with σ = (R + T, s' + t)</li>
-                    <li>Alice learns t from the broadcast signature: t = s - s'</li>
-                    <li>Alice uses t to complete her side of the swap</li>
+                    <li>Alice gives Bob adaptor <span class="math">σ'</span> (valid when combined with secret <span class="math">t</span>)</li>
+                    <li>Bob broadcasts transaction with <span class="math">σ = (R + T, s' + t)</span></li>
+                    <li>Alice learns <span class="math">t</span> from the broadcast signature: <span class="math">t = s − s'</span></li>
+                    <li>Alice uses <span class="math">t</span> to complete her side of the swap</li>
                 </ol>
                 <p>
                     Either both transactions happen, or neither does.
@@ -664,7 +664,7 @@ Stack after:  [n] (or [n+1] if valid)
                 </p>
                 <ul>
                     <li><strong>Lightning:</strong> Cooperative closes are indistinguishable</li>
-                    <li><strong>Multisig:</strong> MuSig makes n-of-n look like 1-of-1</li>
+                    <li><strong>Multisig:</strong> MuSig makes <span class="math">n</span>-of-<span class="math">n</span> look like 1-of-1</li>
                     <li><strong>DLCs:</strong> Discreet log contracts with privacy</li>
                     <li><strong>Vaults:</strong> Complex custody with fallback options</li>
                     <li><strong>Inscriptions:</strong> Data embedding via witness</li>
@@ -681,7 +681,7 @@ Stack after:  [n] (or [n+1] if valid)
                 <p>
                     Prove that Schnorr batch verification is sound: if the batch check passes
                     but one signature is invalid, derive a contradiction (with high probability
-                    over random a<sub>i</sub>).
+                    over random <span class="math">a<sub>i</sub></span>).
                 </p>
             </div>
 

--- a/chapters/30-covenants.html
+++ b/chapters/30-covenants.html
@@ -322,8 +322,8 @@ Stack after:  [x || y]</pre>
                     on-stack sighash construction (the "Schnorr trick"):
                 </p>
                 <ol>
-                    <li>Schnorr signature: (R, s) where s = k + H(R||P||m)·d, with the
-                        nonce fixed to R = G so s is predictable from m</li>
+                    <li>Schnorr signature: <span class="math">(R, s)</span> where <span class="math">s = k + H(R||P||m)·d</span>, with the
+                        nonce fixed to <span class="math">R = G</span> so <span class="math">s</span> is predictable from <span class="math">m</span></li>
                     <li>Script assembles the claimed sighash components from witness data
                         using CAT</li>
                     <li>The assembled signature is passed to CHECKSIG, which only succeeds

--- a/chapters/31-sidechains.html
+++ b/chapters/31-sidechains.html
@@ -55,7 +55,7 @@
                     <li><strong>Peg-out:</strong> Burn on sidechain → unlock BTC on mainchain</li>
                 </ul>
                 <p>
-                    The peg maintains a 1:1 relationship: total sidechain tokens ≤ locked BTC.
+                    The peg maintains a 1:1 relationship: <span class="math">total sidechain tokens ≤ locked BTC</span>.
                 </p>
             </div>
 
@@ -139,9 +139,9 @@
                     For an m-of-n federation:
                 </p>
                 <ul>
-                    <li><strong>Liveness:</strong> Requires m members to process peg-outs</li>
-                    <li><strong>Safety:</strong> Requires n-m+1 honest members to prevent theft</li>
-                    <li><strong>Attack cost:</strong> Must corrupt m members to steal funds</li>
+                    <li><strong>Liveness:</strong> Requires <span class="math">m</span> members to process peg-outs</li>
+                    <li><strong>Safety:</strong> Requires <span class="math">n − m + 1</span> honest members to prevent theft</li>
+                    <li><strong>Attack cost:</strong> Must corrupt <span class="math">m</span> members to steal funds</li>
                 </ul>
             </div>
 

--- a/chapters/32-beyond-lightning.html
+++ b/chapters/32-beyond-lightning.html
@@ -311,7 +311,7 @@
                     and modify internal channels without on-chain transactions:
                 </p>
                 <ol>
-                    <li>N parties create a single on-chain funding output</li>
+                    <li><span class="math">N</span> parties create a single on-chain funding output</li>
                     <li>Off-chain, they create internal Lightning channels</li>
                     <li>Channels can be rebalanced without on-chain txs</li>
                     <li>Only factory open/close needs on-chain presence</li>
@@ -349,12 +349,12 @@
             <div class="remark">
                 <p class="remark-title">Remark 32.4 (Factory Scaling)</p>
                 <p>
-                    For a factory with n participants:
+                    For a factory with <span class="math">n</span> participants:
                 </p>
                 <ul>
-                    <li><strong>On-chain cost:</strong> 1 UTXO (amortized over n users)</li>
-                    <li><strong>Channel creation:</strong> O(n) signatures, no on-chain tx</li>
-                    <li><strong>Complexity:</strong> All n must sign for factory updates</li>
+                    <li><strong>On-chain cost:</strong> 1 UTXO (amortized over <span class="math">n</span> users)</li>
+                    <li><strong>Channel creation:</strong> <span class="math">O(n)</span> signatures, no on-chain tx</li>
+                    <li><strong>Complexity:</strong> All <span class="math">n</span> must sign for factory updates</li>
                 </ul>
             </div>
 

--- a/chapters/34-drivechains.html
+++ b/chapters/34-drivechains.html
@@ -149,9 +149,9 @@ Withdrawal process:
                     <li>Accumulate 13,150 ACKs within the 26,300-block (~6-month) window. With other
                         miners abstaining, a bare majority takes ~6 months and ~3 months requires
                         near-unanimous ACKing; if defending miners actively NACK (the score moves
-                        +1/0/−1 per block), the coalition needs about 75% of blocks to reach the
+                        <span class="math">+1/0/−1</span> per block), the coalition needs about 75% of blocks to reach the
                         threshold inside the window at all</li>
-                    <li>Maintain >50% hashrate commitment throughout</li>
+                    <li>Maintain <span class="math">&gt;50%</span> hashrate commitment throughout</li>
                 </ol>
                 <p>
                     The extended timeframe allows users to detect and respond to theft attempts.
@@ -263,7 +263,7 @@ OP_RETURN &lt;BMM_TAG&gt; &lt;sidechain_id&gt; &lt;block_hash&gt;
                     <li>If successful, steal all sidechain deposits</li>
                 </ol>
                 <p>
-                    Cost: Must maintain >50% hashrate for 3-6 months while the attack is visible.
+                    Cost: Must maintain <span class="math">&gt;50%</span> hashrate for 3-6 months while the attack is visible.
                 </p>
             </div>
 
@@ -279,7 +279,7 @@ OP_RETURN &lt;BMM_TAG&gt; &lt;sidechain_id&gt; &lt;block_hash&gt;
                     <li>3-month visibility allows market/social response</li>
                 </ul>
                 <p>
-                    Counter-argument: miners could steal and exit if theft value > future mining revenue.
+                    Counter-argument: miners could steal and exit if <span class="math">theft value &gt; future mining revenue</span>.
                 </p>
             </div>
 

--- a/chapters/35-consensus-cleanup.html
+++ b/chapters/35-consensus-cleanup.html
@@ -166,7 +166,7 @@ where:
             <div class="theorem">
                 <p class="theorem-title">Theorem 35.1 (Timewarp Exploitation)</p>
                 <p>
-                    With >50% hashrate, an attacker can perform a two-phase timestamp
+                    With <span class="math">&gt;50%</span> hashrate, an attacker can perform a two-phase timestamp
                     manipulation each retarget period:
                 </p>
                 <ol>
@@ -179,7 +179,7 @@ where:
                         <code>actual_time</code> (future minus past), causing
                         difficulty to decrease (subject to the 4× clamp per period)</li>
                     <li>Repeat: each period reduces difficulty by up to 4×</li>
-                    <li>After ~24 periods (log₄ of current difficulty ≈ 10¹⁴), difficulty approaches the minimum</li>
+                    <li>After ~24 periods (<span class="math">log₄ of current difficulty ≈ 10¹⁴</span>), difficulty approaches the minimum</li>
                 </ol>
                 <p>
                     Theoretical outcome: Mine all remaining Bitcoin in weeks.
@@ -377,7 +377,7 @@ Different blocks, same merkle root → attack vector</pre>
             <div class="definition">
                 <p class="definition-title">Definition 35.11 (Quadratic Hashing)</p>
                 <p>
-                    Some operations in legacy Bitcoin have O(n²) complexity:
+                    Some operations in legacy Bitcoin have <span class="math">O(n²)</span> complexity:
                 </p>
                 <ul>
                     <li>Signature hashing for large transactions</li>

--- a/chapters/36-security-threats.html
+++ b/chapters/36-security-threats.html
@@ -132,20 +132,20 @@
             <div class="theorem">
                 <p class="theorem-title">Theorem 36.1 (Attack Success Probability)</p>
                 <p>
-                    Let q be attacker hashrate fraction, p = 1-q honest hashrate, and k
+                    Let <span class="math">q</span> be attacker hashrate fraction,
+                    <span class="math">p = 1 − q</span> honest hashrate, and <span class="math">k</span>
                     the number of confirmations. The exact probability of a successful
                     double-spend (Nakamoto, 2008) is:
                 </p>
                 <p class="math-block">
                     P(success) = 1 if q ≥ 0.5<br>
-                    P(success) = 1 − Σ<sub>m=0</sub><sup>k</sup>
-                    [λ<sup>m</sup>e<sup>−λ</sup>/m! · (1 − (q/p)<sup>k−m</sup>)]
-                    if q &lt; 0.5
+                    P(success) = 1 − Σₘ₌₀ᵏ [λᵐe^(−λ)/m! · (1 − (q/p)^(k−m))] if q &lt; 0.5
                 </p>
                 <p>
-                    where λ = k · (q/p). The simplified approximation (q/p)<sup>k</sup>
+                    where <span class="math">λ = k · (q/p)</span>. The simplified approximation
+                    <span class="math">(q/p)ᵏ</span>
                     underestimates the probability because it ignores the attacker's
-                    Poisson-distributed progress during the k confirmations; the table
+                    Poisson-distributed progress during the <span class="math">k</span> confirmations; the table
                     below uses the exact Poisson formula.
                 </p>
             </div>
@@ -242,12 +242,13 @@
             <div class="theorem">
                 <p class="theorem-title">Proposition 36.2 (Reorg Probability)</p>
                 <p>
-                    Under honest mining with network delay δ and block time T:
+                    Under honest mining with network delay <span class="math">δ</span> and
+                    block time <span class="math">T</span>:
                 </p>
                 <ul>
-                    <li>P(1-block reorg) ≈ δ/T ≈ 0.5-1%</li>
-                    <li>P(2-block reorg) ≈ (δ/T)² ≈ 0.01%</li>
-                    <li>P(k-block reorg) ≈ (δ/T)ᵏ (approximately)</li>
+                    <li><span class="math">P(1-block reorg) ≈ δ/T ≈ 0.5-1%</span></li>
+                    <li><span class="math">P(2-block reorg) ≈ (δ/T)² ≈ 0.01%</span></li>
+                    <li><span class="math">P(k-block reorg) ≈ (δ/T)ᵏ</span> (approximately)</li>
                 </ul>
                 <p>
                     Deep reorgs under honest mining are astronomically unlikely.
@@ -274,14 +275,15 @@
             <div class="theorem">
                 <p class="theorem-title">Theorem 36.3 (Selfish Mining Threshold)</p>
                 <p>
-                    Selfish mining is profitable when attacker hashrate q satisfies:
+                    Selfish mining is profitable when attacker hashrate <span class="math">q</span> satisfies:
                 </p>
                 <p class="math-block">
                     q > (1 − γ) / (3 − 2γ)
                 </p>
                 <p>
-                    where γ is the fraction of honest miners who mine on attacker's block
-                    during a race. With γ = 0: q > 1/3 ≈ 33%. With γ = 1: q > 0 (any hashrate suffices).
+                    where <span class="math">γ</span> is the fraction of honest miners who mine on attacker's block
+                    during a race. With <span class="math">γ = 0</span>: <span class="math">q &gt; 1/3 ≈ 33%</span>.
+                    With <span class="math">γ = 1</span>: <span class="math">q &gt; 0</span> (any hashrate suffices).
                 </p>
             </div>
 
@@ -322,7 +324,7 @@
                     Selfish mining has not been observed on Bitcoin mainnet because:
                 </p>
                 <ul>
-                    <li>Requires sustained >25-33% hashrate</li>
+                    <li>Requires sustained <span class="math">&gt;25-33%</span> hashrate</li>
                     <li>Detectable through orphan rate analysis</li>
                     <li>Risk of losing secret chain to honest miners</li>
                     <li>Damages network, potentially harming attacker's investment</li>
@@ -385,7 +387,7 @@
                 </p>
                 <ul>
                     <li><strong>Soft censorship:</strong> Some miners refuse; tx eventually confirms</li>
-                    <li><strong>Hard censorship:</strong> >50% refuse; tx never confirms normally</li>
+                    <li><strong>Hard censorship:</strong> <span class="math">&gt;50%</span> refuse; tx never confirms normally</li>
                 </ul>
             </div>
 
@@ -476,14 +478,14 @@
                 <p class="exercise-title">Exercise 36.1</p>
                 <p>
                     Calculate the probability of a successful double-spend with 30% hashrate
-                    after 6 confirmations. How many confirmations would reduce this to <0.1%?
+                    after 6 confirmations. How many confirmations would reduce this to <span class="math">&lt;0.1%</span>?
                 </p>
             </div>
 
             <div class="exercise">
                 <p class="exercise-title">Exercise 36.2</p>
                 <p>
-                    Model a selfish mining attack with 35% hashrate and γ=0.5. What is the
+                    Model a selfish mining attack with 35% hashrate and <span class="math">γ = 0.5</span>. What is the
                     expected revenue advantage over honest mining?
                 </p>
             </div>

--- a/chapters/37-defense-mechanisms.html
+++ b/chapters/37-defense-mechanisms.html
@@ -36,8 +36,8 @@
             <div class="definition">
                 <p class="definition-title">Definition 37.1 (Confirmation)</p>
                 <p>
-                    A transaction has <strong>k confirmations</strong> when it is included
-                    in a block with k-1 blocks built on top of it. The first block containing
+                    A transaction has <strong><span class="math">k</span> confirmations</strong> when it is included
+                    in a block with <span class="math">k − 1</span> blocks built on top of it. The first block containing
                     the transaction is confirmation 1.
                 </p>
             </div>
@@ -49,10 +49,10 @@
                 </p>
                 <ul>
                     <li>More confirmations = exponentially lower reversal probability</li>
-                    <li>Against an attacker with hashrate q &lt; 50%, the reversal probability is
+                    <li>Against an attacker with hashrate <span class="math">q &lt; 50%</span>, the reversal probability is
                     given by Nakamoto's formula (Theorem 36.1); it decays roughly geometrically
-                    in k, but the naive catch-up bound (q/(1−q))<sup>k</sup> understates it
-                    (q = 10%, k = 6: about 0.02%, not 0.0002%)</li>
+                    in <span class="math">k</span>, but the naive catch-up bound <span class="math">(q/(1−q))ᵏ</span> understates it
+                    (<span class="math">q = 10%</span>, <span class="math">k = 6</span>: about 0.02%, not 0.0002%)</li>
                     <li>6 confirmations (~1 hour): Standard for large transactions</li>
                     <li>1 confirmation (~10 min): Often sufficient for small amounts</li>
                 </ul>
@@ -463,7 +463,7 @@ nMinimumChainWork = 0x0000000000000000000000000000000000000000
                 <p class="exercise-title">Exercise 37.1</p>
                 <p>
                     A merchant accepts payment of $10,000 with 3 confirmations. Estimate
-                    the minimum hashrate an attacker needs to have >50% chance of successful
+                    the minimum hashrate an attacker needs to have <span class="math">&gt;50%</span> chance of successful
                     double-spend. Is this attack economically rational?
                 </p>
             </div>

--- a/chapters/39-quantum-resistance.html
+++ b/chapters/39-quantum-resistance.html
@@ -291,7 +291,7 @@ Practical Reality:
             <p>Several factors mitigate the Grover threat:</p>
 
             <ol>
-                <li><strong>Quadratic, not exponential:</strong> 2¹²⁸ is still astronomical</li>
+                <li><strong>Quadratic, not exponential:</strong> <span class="math">2¹²⁸</span> is still astronomical</li>
                 <li><strong>Not parallelizable:</strong> Can't gain advantage from multiple quantum computers</li>
                 <li><strong>Difficulty adjustment:</strong> Network adjusts to maintain 10-minute blocks</li>
                 <li><strong>Simple fix:</strong> Double hash output size (SHA-512) restores security</li>
@@ -421,7 +421,7 @@ For Breaking 256-bit ECDSA (Roetteler et al., 2017):
 
             <div class="key-concept">
                 <h3>Mosca's Theorem</h3>
-                <p>If X = time to migrate cryptography, Y = time data must remain secure, and Z = time until quantum threat: <strong>Start migration when X + Y > Z</strong></p>
+                <p>If <span class="math">X</span> = time to migrate cryptography, <span class="math">Y</span> = time data must remain secure, and <span class="math">Z</span> = time until quantum threat: <strong>Start migration when <span class="math">X + Y &gt; Z</span></strong></p>
                 <p>For Bitcoin: Migration may take 5-10 years, coins must be secure forever. If quantum threat is 15-20 years away, migration should start soon.</p>
             </div>
         </section>


### PR DESCRIPTION
## Summary
Chapters 18-40 predated the book's math markup convention: Ch 18-25 used `<var>`/`<sup>`/`<sub>` tags, Ch 26-40 used bare prose text — so the same equation rendered Times italic in Ch 1-17 and upright Georgia later. This converts all of them to house style (~400 expressions across 20 files):

- **Ch 18-21**: every `<var>` tag converted, single-character powers to Unicode, Ch 18's centered display equations moved to `math-block`.
- **Ch 22-25**: bare seal/channel/fee math wrapped; Ch 24's fee formula promoted to a display block.
- **Ch 26-30**: the heaviest set — Ch 29's entire Schnorr/MuSig2/adaptor algebra wrapped (multi-letter subscripts keep `<sub>` inside the span, matching the no-Unicode-glyph fallback); Ch 26's Nakamoto formula now typographically identical to Ch 17's canonical form.
- **Ch 31-40**: thresholds and probability math wrapped; Ch 36's Nakamoto rendition unified (the third and last divergent copy); raw `<`/`>` comparisons escaped (one was a latent parse hazard); Ch 38/40's essay formula-blocks deliberately retained as the accepted Volume V template.

**Verification** (independent of the conversion agents): HTML tag balance on all changed files, zero nested math spans, zero leftover `<var>` tags, and a normalized text-content diff against HEAD confirming every change is markup/glyph-only — no wording, numbers, or formula content touched.

Fixes #129