### PR TITLE
Unify Volume V: convert Ch 38-40 to the numbered math template

### DIFF
--- a/chapters/38-security-budget.html
+++ b/chapters/38-security-budget.html
@@ -4,48 +4,69 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Chapter 38: The Security Budget Problem | Elementary Bitcoin</title>
+    <meta name="description" content="Chapter 38: The Security Budget Problem - The subsidy decline, fee markets, and Bitcoin's long-term security economics">
     <link rel="stylesheet" href="../style.css">
     <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>&#8383;</text></svg>">
 </head>
 <body>
     <nav class="chapter-nav">
-        <a href="37-defense-mechanisms.html" class="prev">&#8592; Chapter 37: Defense Mechanisms</a>
-        <a href="../index.html" class="home">&#8962; Home</a>
-        <a href="39-quantum-resistance.html" class="next">Chapter 39: Quantum Resistance &#8594;</a>
+        <a href="../index.html">Contents</a>
+        <span class="nav-separator">·</span>
+        <span class="volume-indicator">Volume V: The Path to a Sustainable Future</span>
     </nav>
 
-    <article class="chapter">
-        <header class="chapter-header">
-            <p class="volume-title">Volume V: The Path to a Sustainable Future</p>
-            <p class="part-title">Part XV: Long-Term Security</p>
-            <h1>Chapter 38: The Security Budget Problem</h1>
-            <p class="subtitle">Will Bitcoin Remain Secure as the Subsidy Diminishes?</p>
-        </header>
+    <header class="chapter-header">
+        <p class="chapter-number">Chapter 38</p>
+        <h1>The Security Budget Problem</h1>
+        <p class="chapter-subtitle">Will Bitcoin Remain Secure as the Subsidy Diminishes?</p>
+        <p class="chapter-epigraph">
+            "The security of Bitcoin depends on the total hashpower, which depends on miner
+            revenue. As the block subsidy decreases, transaction fees must increase to
+            maintain security&mdash;but will they?"
+            <br>&mdash; The central question of Bitcoin's long-term sustainability
+        </p>
+    </header>
 
-        <blockquote class="chapter-quote">
-            "The security of Bitcoin depends on the total hashpower, which depends on miner revenue. As the block subsidy decreases, transaction fees must increase to maintain security—but will they?"
-            <cite>— The central question of Bitcoin's long-term sustainability</cite>
-        </blockquote>
+    <main class="chapter-content">
+        <section>
+            <p class="chapter-intro">
+                Bitcoin's security model faces a fundamental challenge: the block subsidy
+                that currently funds most mining operations is designed to eventually reach
+                zero. This creates what critics call the "security budget problem"&mdash;will
+                transaction fees alone provide sufficient incentive for miners to secure the
+                network? This chapter examines the mathematics, economics, and game theory
+                of Bitcoin's long-term security budget, analyzing whether the network can
+                sustainably protect trillions of dollars of value with fees alone.
+            </p>
 
-        <section id="introduction">
-            <h2>The Looming Question</h2>
-
-            <p>Bitcoin's security model faces a fundamental challenge: the block subsidy that currently funds most mining operations is designed to eventually reach zero. This creates what critics call the "security budget problem"—will transaction fees alone provide sufficient incentive for miners to secure the network?</p>
-
-            <div class="key-concept">
-                <h3>The Core Tension</h3>
-                <p>Bitcoin's fixed supply (21 million coins) is fundamental to its monetary properties, but this same property means miner revenue from new coins will eventually end. The network must transition from subsidy-funded security to fee-funded security.</p>
+            <div class="remark">
+                <p class="remark-title">Remark 38.1 (The Core Tension)</p>
+                <p>
+                    Bitcoin's fixed supply (21 million coins) is fundamental to its monetary
+                    properties, but this same property means miner revenue from new coins
+                    will eventually end. The network must transition from subsidy-funded
+                    security to fee-funded security.
+                </p>
             </div>
-
-            <p>This chapter examines the mathematics, economics, and game theory of Bitcoin's long-term security budget, analyzing whether the network can sustainably protect trillions of dollars of value with fees alone.</p>
         </section>
 
-        <section id="subsidy-schedule">
-            <h2>The Subsidy Decline</h2>
+        <section>
+            <h2>38.1 The Subsidy Decline</h2>
 
-            <h3>Bitcoin's Emission Schedule</h3>
-
-            <p>Bitcoin's block subsidy halves approximately every four years (210,000 blocks):</p>
+            <div class="definition">
+                <p class="definition-title">Definition 38.1 (Block Subsidy Schedule)</p>
+                <p>
+                    Bitcoin's block subsidy halves approximately every four years
+                    (210,000 blocks). The subsidy at block height <span class="math">h</span> is
+                </p>
+                <p class="math-block">
+                    subsidy(h) = (50 × 10⁸ satoshis) &gt;&gt; ⌊h / 210,000⌋
+                </p>
+                <p>
+                    where <span class="math">&gt;&gt;</span> denotes a right bit shift (each shift is one halving)
+                    and 210,000 blocks ≈ 4 years.
+                </p>
+            </div>
 
             <table class="data-table">
                 <thead>
@@ -117,36 +138,55 @@
                 </tbody>
             </table>
 
-            <h3>The Mathematical Reality</h3>
-
-            <div class="formula-block">
-                <p><strong>Subsidy at height h:</strong></p>
-                <code>subsidy(h) = 50 × 10⁸ satoshis >> floor(h / 210,000)</code>
-                <p><strong>Where:</strong></p>
-                <ul>
-                    <li>>> = right bit shift (halving)</li>
-                    <li>210,000 blocks ≈ 4 years</li>
-                </ul>
+            <div class="theorem">
+                <p class="theorem-title">Proposition 38.1 (Subsidy Termination)</p>
+                <p>
+                    The block subsidy is exactly zero for every block height
+                    <span class="math">h ≥ 6,930,000</span> (around the year 2140).
+                </p>
             </div>
 
-            <p>By 2032, the block subsidy will be just 0.78125 BTC—less than the total fees a single block has sometimes collected during high-demand periods. By 2048, it will be negligible. The transition to a fee-based security model isn't a distant concern; it's already underway.</p>
+            <div class="proof">
+                <p class="proof-title"></p>
+                <p>
+                    The initial subsidy is <span class="math">50 × 10⁸ = 5 × 10⁹</span> satoshis, and
+                    <span class="math">2³² &lt; 5 × 10⁹ &lt; 2³³</span>. A right shift by 32 therefore leaves
+                    <span class="math">⌊5 × 10⁹ / 2³²⌋ = 1</span> satoshi (the final non-zero subsidy era,
+                    beginning at height 32 × 210,000 = 6,720,000), and a right shift by 33
+                    yields 0. Hence subsidy(h) = 0 for all
+                    <span class="math">h ≥ 33 × 210,000 = 6,930,000</span>.
+                    <span class="qed"></span>
+                </p>
+            </div>
+
+            <p>
+                By 2032, the block subsidy will be just 0.78125 BTC&mdash;less than the total
+                fees a single block has sometimes collected during high-demand periods. By
+                2048, it will be negligible. The transition to a fee-based security model
+                isn't a distant concern; it's already underway.
+            </p>
         </section>
 
-        <section id="security-budget-defined">
-            <h2>Defining the Security Budget</h2>
+        <section>
+            <h2>38.2 Defining the Security Budget</h2>
 
-            <h3>What Is the Security Budget?</h3>
-
-            <p>The security budget is the total revenue available to miners, which determines how much they can profitably spend on mining equipment and electricity:</p>
-
-            <div class="formula-block">
-                <p><strong>Security Budget:</strong></p>
-                <code>Security Budget = (Block Subsidy + Transaction Fees) × Blocks per Year</code>
-                <p><strong>Annual calculation:</strong></p>
-                <code>~52,560 blocks × (subsidy + avg_fees) = Annual Miner Revenue</code>
+            <div class="definition">
+                <p class="definition-title">Definition 38.2 (Security Budget)</p>
+                <p>
+                    The <strong>security budget</strong> is the total revenue available to
+                    miners, which determines how much they can profitably spend on mining
+                    equipment and electricity:
+                </p>
+                <p class="math-block">
+                    Security Budget = (Block Subsidy + Transaction Fees) × Blocks per Year
+                </p>
+                <p>
+                    With ~52,560 blocks per year, the annual calculation is
+                </p>
+                <p class="math-block">
+                    ~52,560 blocks × (subsidy + average fees) = Annual Miner Revenue
+                </p>
             </div>
-
-            <h3>Why It Matters</h3>
 
             <p>The security budget determines:</p>
 
@@ -157,89 +197,112 @@
                 <li><strong>Finality Confidence:</strong> How many confirmations users need for security</li>
             </ol>
 
-            <div class="key-concept">
-                <h3>The Cost of Attack Formula</h3>
-                <code>Attack Cost ≈ Security Budget × Attack Duration / 365</code>
-                <p>A network with a $10 billion annual security budget costs approximately $27 million per day to attack at the 51% threshold. If the security budget drops to $1 billion, attacks become 10x cheaper.</p>
+            <div class="remark">
+                <p class="remark-title">Remark 38.2 (Attack Cost Heuristic)</p>
+                <p>
+                    As a first approximation, the cost of a hashrate-majority attack scales
+                    with the security budget:
+                </p>
+                <p class="math-block">
+                    Attack Cost ≈ Security Budget × Attack Duration / 365
+                </p>
+                <p>
+                    A network with a $10 billion annual security budget costs approximately
+                    $27 million per day to attack at the 51% threshold. If the security
+                    budget drops to $1 billion, attacks become 10x cheaper.
+                </p>
             </div>
         </section>
 
-        <section id="historical-fees">
-            <h2>Historical Fee Analysis</h2>
+        <section>
+            <h2>38.3 Historical Fee Analysis</h2>
 
-            <h3>Fee Revenue Over Time</h3>
+            <div class="remark">
+                <p class="remark-title">Remark 38.3 (Historical Fee Revenue)</p>
+                <p>
+                    Transaction fees have historically been a small fraction of miner revenue:
+                </p>
+                <table class="data-table">
+                    <thead>
+                        <tr>
+                            <th>Year</th>
+                            <th>Avg Fee (BTC)</th>
+                            <th>Total Fees (BTC)</th>
+                            <th>Fee % of Revenue</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>2015</td>
+                            <td>0.00018</td>
+                            <td>~8,200</td>
+                            <td>0.6%</td>
+                        </tr>
+                        <tr>
+                            <td>2017</td>
+                            <td>0.00096</td>
+                            <td>~100,000</td>
+                            <td>13%</td>
+                        </tr>
+                        <tr>
+                            <td>2021</td>
+                            <td>0.00022</td>
+                            <td>~21,000</td>
+                            <td>6.0%</td>
+                        </tr>
+                        <tr>
+                            <td>2023 (Ordinals)</td>
+                            <td>0.00015</td>
+                            <td>~23,000</td>
+                            <td>6.5%</td>
+                        </tr>
+                        <tr>
+                            <td>2024 (Runes, halving)</td>
+                            <td>0.00008</td>
+                            <td>~15,000</td>
+                            <td>6.6%</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
 
-            <p>Transaction fees have historically been a small fraction of miner revenue:</p>
+            <div class="remark">
+                <p class="remark-title">Remark 38.4 (Fee Spikes)</p>
+                <p>
+                    Fees have spiked dramatically during periods of high demand:
+                </p>
+                <ul>
+                    <li><strong>December 2017:</strong> $55 average fee during bull market peak</li>
+                    <li><strong>April 2021:</strong> $62 average fee during institutional adoption wave</li>
+                    <li><strong>May 2023:</strong> $31 average fee during BRC-20 inscription mania</li>
+                    <li><strong>April 2024:</strong> $127 peak fee during Runes launch</li>
+                </ul>
+            </div>
 
-            <table class="data-table">
-                <thead>
-                    <tr>
-                        <th>Year</th>
-                        <th>Avg Fee (BTC)</th>
-                        <th>Total Fees (BTC)</th>
-                        <th>Fee % of Revenue</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr>
-                        <td>2015</td>
-                        <td>0.00018</td>
-                        <td>~8,200</td>
-                        <td>0.6%</td>
-                    </tr>
-                    <tr>
-                        <td>2017</td>
-                        <td>0.00096</td>
-                        <td>~100,000</td>
-                        <td>13%</td>
-                    </tr>
-                    <tr>
-                        <td>2021</td>
-                        <td>0.00022</td>
-                        <td>~21,000</td>
-                        <td>6.0%</td>
-                    </tr>
-                    <tr>
-                        <td>2023 (Ordinals)</td>
-                        <td>0.00015</td>
-                        <td>~23,000</td>
-                        <td>6.5%</td>
-                    </tr>
-                    <tr>
-                        <td>2024 (Runes, halving)</td>
-                        <td>0.00008</td>
-                        <td>~15,000</td>
-                        <td>6.6%</td>
-                    </tr>
-                </tbody>
-            </table>
-
-            <h3>Fee Spikes and Their Causes</h3>
-
-            <p>Fees have spiked dramatically during periods of high demand:</p>
-
-            <ul>
-                <li><strong>December 2017:</strong> $55 average fee during bull market peak</li>
-                <li><strong>April 2021:</strong> $62 average fee during institutional adoption wave</li>
-                <li><strong>May 2023:</strong> $31 average fee during BRC-20 inscription mania</li>
-                <li><strong>April 2024:</strong> $127 peak fee during Runes launch</li>
-            </ul>
-
-            <div class="warning-box">
-                <h4>The Volatility Problem</h4>
-                <p>Fee revenue is highly volatile, spiking 100x during demand surges and collapsing during quiet periods. This makes it difficult for miners to plan long-term investments in hardware and infrastructure.</p>
+            <div class="remark">
+                <p class="remark-title">Remark 38.5 (The Volatility Problem)</p>
+                <p>
+                    Fee revenue is highly volatile, spiking 100x during demand surges and
+                    collapsing during quiet periods. This makes it difficult for miners to
+                    plan long-term investments in hardware and infrastructure.
+                </p>
             </div>
         </section>
 
-        <section id="fee-market-dynamics">
-            <h2>Fee Market Dynamics</h2>
+        <section>
+            <h2>38.4 Fee Market Dynamics</h2>
 
-            <h3>How Fees Are Determined</h3>
+            <div class="definition">
+                <p class="definition-title">Definition 38.3 (Fee Market)</p>
+                <p>
+                    Bitcoin's <strong>fee market</strong> is a first-price auction in which
+                    users bid for limited block space. Users set a fee rate (sat/vB), miners
+                    sort transactions by fee rate and include the highest bidders first, and
+                    the market clears at the marginal transaction.
+                </p>
+            </div>
 
-            <p>Bitcoin's fee market is a first-price auction where users bid for limited block space:</p>
-
-            <div class="code-block">
-<pre>
+            <pre>
 Block Space Supply (per block):
 ├── Weight limit: 4,000,000 weight units
 ├── Typical capacity: ~2,500-4,000 transactions
@@ -251,111 +314,141 @@ Fee Determination:
 ├── Highest bidders included first
 └── Market clears at marginal transaction
 </pre>
-            </div>
-
-            <h3>The Blockspace Demand Curve</h3>
 
             <p>Demand for blockspace comes from multiple sources:</p>
 
             <ol>
-                <li><strong>High-value transfers:</strong> Exchanges, institutions, large holders—price insensitive</li>
-                <li><strong>Time-sensitive payments:</strong> Commerce, payroll—moderately price sensitive</li>
-                <li><strong>Consolidation:</strong> UTXO management—price sensitive, can wait</li>
-                <li><strong>Data inscription:</strong> Ordinals, BRC-20—highly variable demand</li>
-                <li><strong>Layer 2 settlements:</strong> Lightning channel opens/closes—batched, price sensitive</li>
+                <li><strong>High-value transfers:</strong> Exchanges, institutions, large holders&mdash;price insensitive</li>
+                <li><strong>Time-sensitive payments:</strong> Commerce, payroll&mdash;moderately price sensitive</li>
+                <li><strong>Consolidation:</strong> UTXO management&mdash;price sensitive, can wait</li>
+                <li><strong>Data inscription:</strong> Ordinals, BRC-20&mdash;highly variable demand</li>
+                <li><strong>Layer 2 settlements:</strong> Lightning channel opens/closes&mdash;batched, price sensitive</li>
             </ol>
 
-            <h3>Will Demand Be Sufficient?</h3>
+            <p>
+                The critical question: as Bitcoin's value increases, will demand for
+                on-chain transactions scale proportionally?
+            </p>
 
-            <p>The critical question: as Bitcoin's value increases, will demand for on-chain transactions scale proportionally?</p>
-
-            <div class="key-concept">
-                <h3>The Scaling Paradox</h3>
-                <p>If Bitcoin succeeds as a global reserve asset, most transactions will occur on Layer 2 solutions. This increases Bitcoin's value but potentially reduces on-chain fee revenue. Success could undermine the security budget.</p>
+            <div class="remark">
+                <p class="remark-title">Remark 38.6 (The Scaling Paradox)</p>
+                <p>
+                    If Bitcoin succeeds as a global reserve asset, most transactions will
+                    occur on Layer 2 solutions. This increases Bitcoin's value but
+                    potentially reduces on-chain fee revenue. Success could undermine the
+                    security budget.
+                </p>
             </div>
         </section>
 
-        <section id="economic-models">
-            <h2>Economic Models and Projections</h2>
+        <section>
+            <h2>38.5 Economic Models and Projections</h2>
 
-            <h3>Model 1: Linear Fee Growth</h3>
-
-            <p>Optimistic assumption: fees grow proportionally with Bitcoin's market cap.</p>
-
-            <div class="formula-block">
-                <p><strong>If Bitcoin reaches $10 trillion market cap:</strong></p>
-                <code>Required security budget: ~1% = $100 billion/year</code>
-                <code>Required fee revenue: ~$274 million/day</code>
-                <code>Required fee per block: ~$1.9 million</code>
-                <code>At 2,500 tx/block: ~$760 per transaction</code>
+            <div class="definition">
+                <p class="definition-title">Definition 38.4 (Model 1: Linear Fee Growth)</p>
+                <p>
+                    The <strong>linear fee growth model</strong> makes the optimistic
+                    assumption that fee revenue grows proportionally with Bitcoin's market
+                    cap, so the security budget remains a fixed percentage of the value
+                    secured.
+                </p>
             </div>
 
-            <p>This model requires average fees of hundreds of dollars—sustainable only if Bitcoin is used exclusively for high-value settlement.</p>
-
-            <h3>Model 2: Constant Dollar Security</h3>
-
-            <p>Conservative assumption: security budget stays constant in dollar terms.</p>
-
-            <div class="formula-block">
-                <p><strong>If security budget stays at ~$15 billion/year:</strong></p>
-                <code>Post-subsidy fee requirement: $41 million/day</code>
-                <code>Required fee per block: ~$285,000</code>
-                <code>At 2,500 tx/block: ~$114 per transaction</code>
+            <div class="example">
+                <p class="example-title">Example 38.1 (Model 1 at a $10 Trillion Market Cap)</p>
+                <p>If Bitcoin reaches a $10 trillion market cap:</p>
+                <p class="math-block">
+                    Required security budget: ~1% = $100 billion/year<br>
+                    Required fee revenue: ~$274 million/day<br>
+                    Required fee per block: ~$1.9 million<br>
+                    At 2,500 tx/block: ~$760 per transaction
+                </p>
+                <p>
+                    This model requires average fees of hundreds of dollars&mdash;sustainable
+                    only if Bitcoin is used exclusively for high-value settlement.
+                </p>
             </div>
 
-            <h3>Model 3: Security Percentage Decline</h3>
+            <div class="definition">
+                <p class="definition-title">Definition 38.5 (Model 2: Constant Dollar Security)</p>
+                <p>
+                    The <strong>constant dollar security model</strong> makes the
+                    conservative assumption that the security budget stays constant in
+                    dollar terms after the subsidy ends.
+                </p>
+            </div>
 
-            <p>Historical observation: security spending as a percentage of market cap has declined:</p>
+            <div class="example">
+                <p class="example-title">Example 38.2 (Model 2 at $15 Billion per Year)</p>
+                <p>If the security budget stays at ~$15 billion/year:</p>
+                <p class="math-block">
+                    Post-subsidy fee requirement: $41 million/day<br>
+                    Required fee per block: ~$285,000<br>
+                    At 2,500 tx/block: ~$114 per transaction
+                </p>
+            </div>
 
-            <table class="data-table">
-                <thead>
-                    <tr>
-                        <th>Year</th>
-                        <th>Market Cap</th>
-                        <th>Security Budget</th>
-                        <th>Security %</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr>
-                        <td>2015</td>
-                        <td>$4B</td>
-                        <td>$350M</td>
-                        <td>8.75%</td>
-                    </tr>
-                    <tr>
-                        <td>2018</td>
-                        <td>$130B (avg)</td>
-                        <td>$5.5B</td>
-                        <td>~4.0%</td>
-                    </tr>
-                    <tr>
-                        <td>2021</td>
-                        <td>$1T</td>
-                        <td>$17B</td>
-                        <td>1.7%</td>
-                    </tr>
-                    <tr>
-                        <td>2024</td>
-                        <td>$1.3T</td>
-                        <td>$15B</td>
-                        <td>1.15%</td>
-                    </tr>
-                </tbody>
-            </table>
+            <div class="definition">
+                <p class="definition-title">Definition 38.6 (Model 3: Security Percentage Decline)</p>
+                <p>
+                    The <strong>security percentage decline model</strong> extrapolates the
+                    historical observation that security spending as a percentage of market
+                    cap has steadily declined.
+                </p>
+            </div>
 
-            <p>If this trend continues, security as a percentage of value secured could fall below 0.5%—potentially inadequate for a global reserve asset.</p>
+            <div class="example">
+                <p class="example-title">Example 38.3 (Historical Security Percentage)</p>
+                <table class="data-table">
+                    <thead>
+                        <tr>
+                            <th>Year</th>
+                            <th>Market Cap</th>
+                            <th>Security Budget</th>
+                            <th>Security %</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>2015</td>
+                            <td>$4B</td>
+                            <td>$350M</td>
+                            <td>8.75%</td>
+                        </tr>
+                        <tr>
+                            <td>2018</td>
+                            <td>$130B (avg)</td>
+                            <td>$5.5B</td>
+                            <td>~4.0%</td>
+                        </tr>
+                        <tr>
+                            <td>2021</td>
+                            <td>$1T</td>
+                            <td>$17B</td>
+                            <td>1.7%</td>
+                        </tr>
+                        <tr>
+                            <td>2024</td>
+                            <td>$1.3T</td>
+                            <td>$15B</td>
+                            <td>1.15%</td>
+                        </tr>
+                    </tbody>
+                </table>
+                <p>
+                    If this trend continues, security as a percentage of value secured
+                    could fall below 0.5%&mdash;potentially inadequate for a global reserve
+                    asset.
+                </p>
+            </div>
         </section>
 
-        <section id="game-theory">
-            <h2>Game Theoretic Considerations</h2>
-
-            <h3>The Miner's Dilemma</h3>
+        <section>
+            <h2>38.6 Game-Theoretic Considerations</h2>
 
             <p>In a low-subsidy environment, miners face new incentive challenges:</p>
 
-            <div class="code-block">
-<pre>
+            <pre>
 Fee-Only Mining Game Theory:
 ├── Fee Sniping
 │   ├── Profitable to re-mine recent blocks
@@ -377,24 +470,30 @@ Fee-Only Mining Game Theory:
     ├── Actually improves fee market health
     └── But indicates something wrong if common
 </pre>
+
+            <div class="remark">
+                <p class="remark-title">Remark 38.7 (Fee-Sniping Condition)</p>
+                <p>
+                    When fees dominate block rewards, re-mining the previous block becomes
+                    attractive. Sniping block <span class="math">n</span> is attractive when
+                </p>
+                <p class="math-block">
+                    Fees(block n) − E[Fees] ≫ expected race-loss cost (∝ subsidy + E[Fees])
+                </p>
+                <p>
+                    The sniper also collects the subsidy on the re-mined block, so the
+                    subsidy enters only through the cost of losing the race. In a mature fee
+                    market with minimal subsidy, blocks with unusually high fees become
+                    attack targets.
+                </p>
             </div>
 
-            <h3>Fee Sniping Attack</h3>
-
-            <p>When fees dominate block rewards, re-mining the previous block becomes attractive:</p>
-
-            <div class="formula-block">
-                <p><strong>Fee Sniping Condition:</strong></p>
-                <code>Sniping attractive when: Fees_block_n − E[Fees] ≫ expected race-loss cost (∝ subsidy + E[Fees])</code>
-                <p>The sniper also collects the subsidy on the re-mined block, so the subsidy enters only through the cost of losing the race. In a mature fee market with minimal subsidy, blocks with unusually high fees become attack targets.</p>
-            </div>
-
-            <h3>Mitigation: Anti-Fee-Sniping Locktime</h3>
-
-            <p>Bitcoin Core includes fee sniping mitigation by default:</p>
-
-            <div class="code-block">
-<pre>
+            <div class="remark">
+                <p class="remark-title">Remark 38.8 (Anti-Fee-Sniping Locktime)</p>
+                <p>
+                    Bitcoin Core includes fee sniping mitigation by default:
+                </p>
+                <pre>
 // Default locktime set to current block height
 // Prevents transaction from being mined in re-org of recent blocks
 nLockTime = chainActive.Height();
@@ -403,15 +502,17 @@ nLockTime = chainActive.Height();
 if (GetRandInt(10) == 0)
     nLockTime = std::max(0, (int)nLockTime - GetRandInt(100));
 </pre>
+                <p>
+                    This makes transactions invalid in any re-org attempting to steal fees
+                    from recent blocks.
+                </p>
             </div>
-
-            <p>This makes transactions invalid in any re-org attempting to steal fees from recent blocks.</p>
         </section>
 
-        <section id="proposed-solutions">
-            <h2>Proposed Solutions</h2>
+        <section>
+            <h2>38.7 Proposed Solutions</h2>
 
-            <h3>Solution 1: Do Nothing (Market Will Provide)</h3>
+            <h3>38.7.1 Do Nothing (Market Will Provide)</h3>
 
             <p>The dominant view among Bitcoin maximalists:</p>
 
@@ -422,34 +523,45 @@ if (GetRandInt(10) == 0)
                 <li>Layer 2 anchor transactions will provide steady base demand</li>
             </ul>
 
-            <div class="info-box">
-                <h4>The "It Will Work Out" Argument</h4>
-                <p>Bitcoin has survived every challenge so far. The fee market, while imperfect, has functioned for more than fifteen years. As Bitcoin becomes more valuable, rational users will pay appropriate fees for the security they require.</p>
+            <div class="remark">
+                <p class="remark-title">Remark 38.9 (The "It Will Work Out" Argument)</p>
+                <p>
+                    Bitcoin has survived every challenge so far. The fee market, while
+                    imperfect, has functioned for more than fifteen years. As Bitcoin
+                    becomes more valuable, rational users will pay appropriate fees for the
+                    security they require.
+                </p>
             </div>
 
-            <h3>Solution 2: Increase Block Size</h3>
+            <h3>38.7.2 Increase Block Size</h3>
 
             <p>Increase transaction throughput to compensate for lower per-transaction fees:</p>
 
-            <div class="formula-block">
-                <code>Total Fees = Fee_per_tx × Transactions_per_block</code>
-                <p>If fee per transaction drops 90%, increase capacity 10x to maintain revenue.</p>
-            </div>
+            <p class="math-block">
+                Total Fees = Fee per transaction × Transactions per block
+            </p>
+
+            <p>If the fee per transaction drops 90%, increase capacity 10x to maintain revenue.</p>
 
             <p><strong>Problems:</strong></p>
             <ul>
                 <li>Reduces node decentralization</li>
                 <li>Contentious (see SegWit2x failure)</li>
-                <li>May not solve problem—fees might drop proportionally</li>
+                <li>May not solve problem&mdash;fees might drop proportionally</li>
             </ul>
 
-            <h3>Solution 3: Tail Emission (Perpetual Inflation)</h3>
+            <h3>38.7.3 Tail Emission (Perpetual Inflation)</h3>
 
             <p>The most controversial proposal: modify Bitcoin to have permanent low-level issuance.</p>
 
-            <div class="warning-box">
-                <h4>The Tail Emission Debate</h4>
-                <p>Monero implements tail emission (0.6 XMR per block forever). Some researchers argue Bitcoin needs similar. This would fundamentally change Bitcoin's monetary properties and is considered a non-starter by most of the community.</p>
+            <div class="remark">
+                <p class="remark-title">Remark 38.10 (The Tail Emission Debate)</p>
+                <p>
+                    Monero implements tail emission (0.6 XMR per block forever). Some
+                    researchers argue Bitcoin needs similar. This would fundamentally change
+                    Bitcoin's monetary properties and is considered a non-starter by most of
+                    the community.
+                </p>
             </div>
 
             <p>Arguments for tail emission:</p>
@@ -464,16 +576,15 @@ if (GetRandInt(10) == 0)
             <ul>
                 <li>Breaks social contract of 21 million cap</li>
                 <li>Sets precedent for further monetary changes</li>
-                <li>Fee market should handle this—if it can't, that's valuable information</li>
+                <li>Fee market should handle this&mdash;if it can't, that's valuable information</li>
                 <li>Would require extremely contentious hard fork</li>
             </ul>
 
-            <h3>Solution 4: Merged Mining</h3>
+            <h3>38.7.4 Merged Mining</h3>
 
             <p>Miners earn revenue from multiple chains simultaneously:</p>
 
-            <div class="code-block">
-<pre>
+            <pre>
 Merged Mining Revenue Model:
 ├── Bitcoin block reward: 3.125 BTC
 ├── Namecoin (merged): NMC block reward (negligible value)
@@ -481,11 +592,10 @@ Merged Mining Revenue Model:
 ├── Potential future chains: additional revenue
 └── Total revenue > Bitcoin alone
 </pre>
-            </div>
 
             <p>This supplements miner revenue without changing Bitcoin's protocol.</p>
 
-            <h3>Solution 5: Fee Smoothing Mechanisms</h3>
+            <h3>38.7.5 Fee Smoothing Mechanisms</h3>
 
             <p>Protocol changes to reduce fee variance:</p>
 
@@ -497,12 +607,11 @@ Merged Mining Revenue Model:
 
             <p>These reduce miner incentive problems but require consensus changes.</p>
 
-            <h3>Solution 6: Layer 2 Dependency</h3>
+            <h3>38.7.6 Layer 2 Dependency</h3>
 
             <p>Embrace that most transactions occur off-chain:</p>
 
-            <div class="code-block">
-<pre>
+            <pre>
 Layer 2 Fee Model:
 ├── Lightning Network
 │   ├── Channel opens/closes: high fees acceptable
@@ -517,80 +626,95 @@ Layer 2 Fee Model:
     ├── Peg-in/peg-out transactions
     └── Independent fee markets on sidechains
 </pre>
-            </div>
 
-            <p>If each Lightning channel represents 10,000 off-chain payments, users can justify $100+ fees for channel management.</p>
+            <p>
+                If each Lightning channel represents 10,000 off-chain payments, users can
+                justify $100+ fees for channel management.
+            </p>
         </section>
 
-        <section id="security-requirements">
-            <h2>How Much Security Is Enough?</h2>
+        <section>
+            <h2>38.8 How Much Security Is Enough?</h2>
 
-            <h3>Defining "Sufficient" Security</h3>
-
-            <p>Security requirements depend on the threat model (defense levels assume the attacker must sustain a multi-week 51% attack to profit):</p>
-
-            <table class="data-table">
-                <thead>
-                    <tr>
-                        <th>Attacker</th>
-                        <th>Budget</th>
-                        <th>Required Defense</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr>
-                        <td>Individual criminal</td>
-                        <td>$1-10M</td>
-                        <td>~$50M/year security budget</td>
-                    </tr>
-                    <tr>
-                        <td>Criminal organization</td>
-                        <td>$10-100M</td>
-                        <td>~$500M/year security budget</td>
-                    </tr>
-                    <tr>
-                        <td>Corporation</td>
-                        <td>$100M-1B</td>
-                        <td>~$5B/year security budget</td>
-                    </tr>
-                    <tr>
-                        <td>Nation state</td>
-                        <td>$1-100B</td>
-                        <td>~$50B+/year security budget</td>
-                    </tr>
-                </tbody>
-            </table>
-
-            <h3>The Nation State Question</h3>
-
-            <p>If Bitcoin becomes a global reserve asset holding $10+ trillion in value, it must resist nation-state attacks. This requires:</p>
-
-            <div class="formula-block">
-                <p><strong>Nation-State Resistance:</strong></p>
-                <code>Attack cost > (Nation GDP × Political will coefficient)</code>
-                <p>For major powers with $20T+ GDP, Bitcoin likely needs $50B+ annual security budget to provide meaningful deterrence.</p>
+            <div class="remark">
+                <p class="remark-title">Remark 38.11 (Threat Models)</p>
+                <p>
+                    Security requirements depend on the threat model (defense levels assume
+                    the attacker must sustain a multi-week 51% attack to profit):
+                </p>
+                <table class="data-table">
+                    <thead>
+                        <tr>
+                            <th>Attacker</th>
+                            <th>Budget</th>
+                            <th>Required Defense</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>Individual criminal</td>
+                            <td>$1-10M</td>
+                            <td>~$50M/year security budget</td>
+                        </tr>
+                        <tr>
+                            <td>Criminal organization</td>
+                            <td>$10-100M</td>
+                            <td>~$500M/year security budget</td>
+                        </tr>
+                        <tr>
+                            <td>Corporation</td>
+                            <td>$100M-1B</td>
+                            <td>~$5B/year security budget</td>
+                        </tr>
+                        <tr>
+                            <td>Nation state</td>
+                            <td>$1-100B</td>
+                            <td>~$50B+/year security budget</td>
+                        </tr>
+                    </tbody>
+                </table>
             </div>
 
-            <h3>Opportunity Cost Defense</h3>
+            <div class="remark">
+                <p class="remark-title">Remark 38.12 (Nation-State Resistance)</p>
+                <p>
+                    If Bitcoin becomes a global reserve asset holding $10+ trillion in
+                    value, it must resist nation-state attacks. This requires:
+                </p>
+                <p class="math-block">
+                    Attack cost &gt; Nation GDP × Political will coefficient
+                </p>
+                <p>
+                    For major powers with $20T+ GDP, Bitcoin likely needs $50B+ annual
+                    security budget to provide meaningful deterrence.
+                </p>
+            </div>
 
-            <p>The cost of attack includes more than just hardware:</p>
-
-            <ul>
-                <li><strong>Hardware acquisition:</strong> Buying/building 51% of hashrate</li>
-                <li><strong>Opportunity cost:</strong> Revenue foregone by attacking instead of mining honestly</li>
-                <li><strong>Retaliation cost:</strong> Network response (PoW change, social coordination)</li>
-                <li><strong>Value destruction:</strong> Attacker's own holdings lose value</li>
-            </ul>
-
-            <p>These multipliers mean effective security may be higher than raw budget suggests.</p>
+            <div class="remark">
+                <p class="remark-title">Remark 38.13 (Opportunity Cost Defense)</p>
+                <p>
+                    The cost of attack includes more than just hardware:
+                </p>
+                <ul>
+                    <li><strong>Hardware acquisition:</strong> Buying/building 51% of hashrate</li>
+                    <li><strong>Opportunity cost:</strong> Revenue foregone by attacking instead of mining honestly</li>
+                    <li><strong>Retaliation cost:</strong> Network response (PoW change, social coordination)</li>
+                    <li><strong>Value destruction:</strong> Attacker's own holdings lose value</li>
+                </ul>
+                <p>
+                    These multipliers mean effective security may be higher than raw budget
+                    suggests.
+                </p>
+            </div>
         </section>
 
-        <section id="ordinals-impact">
-            <h2>Ordinals and the Fee Market</h2>
+        <section>
+            <h2>38.9 Ordinals and the Fee Market</h2>
 
-            <h3>An Unexpected Demand Driver</h3>
-
-            <p>The emergence of Ordinals, BRC-20 tokens, and Runes has dramatically impacted the fee market:</p>
+            <p>
+                The emergence of Ordinals, BRC-20 tokens, and Runes has dramatically
+                impacted the fee market:
+            </p>
 
             <table class="data-table">
                 <thead>
@@ -619,28 +743,28 @@ Layer 2 Fee Model:
                 </tbody>
             </table>
 
-            <h3>Lessons for the Fee Market</h3>
-
-            <div class="key-concept">
-                <h3>Demand Is Unpredictable</h3>
-                <p>No one predicted Ordinals. New use cases can emerge that dramatically increase blockspace demand. The fee market may be more robust than models assuming only monetary transactions.</p>
+            <div class="remark">
+                <p class="remark-title">Remark 38.14 (Demand Is Unpredictable)</p>
+                <p>
+                    No one predicted Ordinals. New use cases can emerge that dramatically
+                    increase blockspace demand. The fee market may be more robust than
+                    models assuming only monetary transactions.
+                </p>
+                <p>Counter-arguments:</p>
+                <ul>
+                    <li>Inscription demand is speculative, not sustainable</li>
+                    <li>May represent temporary fad, not permanent demand</li>
+                    <li>Competes with monetary use cases, potentially pricing them out</li>
+                </ul>
             </div>
-
-            <p>Counter-arguments:</p>
-            <ul>
-                <li>Inscription demand is speculative, not sustainable</li>
-                <li>May represent temporary fad, not permanent demand</li>
-                <li>Competes with monetary use cases, potentially pricing them out</li>
-            </ul>
         </section>
 
-        <section id="timeline">
-            <h2>The Transition Timeline</h2>
+        <section>
+            <h2>38.10 The Transition Timeline</h2>
 
-            <h3>When Does This Become Critical?</h3>
+            <p>When does this become critical?</p>
 
-            <div class="code-block">
-<pre>
+            <pre>
 Security Budget Timeline:
 │
 ├── 2024-2028: Subsidy = 3.125 BTC
@@ -663,26 +787,30 @@ Security Budget Timeline:
     ├── All theoretical concerns become practical
     └── Network has either adapted or hasn't
 </pre>
+
+            <div class="remark">
+                <p class="remark-title">Remark 38.15 (The Graduation Test)</p>
+                <p>
+                    Each halving is a test: can the network maintain security with reduced
+                    subsidy? So far, Bitcoin has passed every test:
+                </p>
+                <ul>
+                    <li><strong>2012:</strong> First halving, hashrate continued growing</li>
+                    <li><strong>2016:</strong> Second halving, hashrate 10x higher than pre-halving</li>
+                    <li><strong>2020:</strong> Third halving, hashrate reached new ATH within months</li>
+                    <li><strong>2024:</strong> Fourth halving, network remains secure</li>
+                </ul>
+                <p>
+                    This track record provides evidence&mdash;but not proof&mdash;that future
+                    halvings will be manageable.
+                </p>
             </div>
-
-            <h3>The Graduation Test</h3>
-
-            <p>Each halving is a test: can the network maintain security with reduced subsidy? So far, Bitcoin has passed every test:</p>
-
-            <ul>
-                <li><strong>2012:</strong> First halving, hashrate continued growing</li>
-                <li><strong>2016:</strong> Second halving, hashrate 10x higher than pre-halving</li>
-                <li><strong>2020:</strong> Third halving, hashrate reached new ATH within months</li>
-                <li><strong>2024:</strong> Fourth halving, network remains secure</li>
-            </ul>
-
-            <p>This track record provides evidence—but not proof—that future halvings will be manageable.</p>
         </section>
 
-        <section id="scenarios">
-            <h2>Future Scenarios</h2>
+        <section>
+            <h2>38.11 Future Scenarios</h2>
 
-            <h3>Scenario 1: Fee Market Success</h3>
+            <h3>38.11.1 Scenario 1: Fee Market Success</h3>
 
             <p>The optimistic path:</p>
             <ul>
@@ -693,7 +821,7 @@ Security Budget Timeline:
                 <li>Security budget maintains nation-state resistance</li>
             </ul>
 
-            <h3>Scenario 2: Gradual Decline</h3>
+            <h3>38.11.2 Scenario 2: Gradual Decline</h3>
 
             <p>The concerning path:</p>
             <ul>
@@ -704,7 +832,7 @@ Security Budget Timeline:
                 <li>Users accept longer confirmation times, higher confirmation requirements</li>
             </ul>
 
-            <h3>Scenario 3: Crisis and Adaptation</h3>
+            <h3>38.11.3 Scenario 3: Crisis and Adaptation</h3>
 
             <p>The transformative path:</p>
             <ul>
@@ -716,10 +844,10 @@ Security Budget Timeline:
             </ul>
         </section>
 
-        <section id="research-directions">
-            <h2>Active Research</h2>
+        <section>
+            <h2>38.12 Active Research</h2>
 
-            <h3>Fee Market Design</h3>
+            <h3>38.12.1 Fee Market Design</h3>
 
             <p>Researchers are studying improved fee mechanisms:</p>
 
@@ -729,7 +857,7 @@ Security Budget Timeline:
                 <li><strong>Batch auctions:</strong> More efficient price discovery</li>
             </ul>
 
-            <h3>Alternative Security Models</h3>
+            <h3>38.12.2 Alternative Security Models</h3>
 
             <ul>
                 <li><strong>Proof of Stake:</strong> Different security economics (not for Bitcoin)</li>
@@ -737,7 +865,7 @@ Security Budget Timeline:
                 <li><strong>Checkpointing:</strong> Social consensus as security layer</li>
             </ul>
 
-            <h3>Layer 2 Economic Integration</h3>
+            <h3>38.12.3 Layer 2 Economic Integration</h3>
 
             <ul>
                 <li>How do Layer 2 fees contribute to Layer 1 security?</li>
@@ -746,33 +874,99 @@ Security Budget Timeline:
             </ul>
         </section>
 
-        <section id="summary">
-            <h2>Summary: An Open Question</h2>
+        <section>
+            <h2>38.13 Summary</h2>
 
-            <div class="key-takeaways">
-                <h3>Key Points</h3>
-                <ul>
-                    <li>Bitcoin's block subsidy will effectively end within 20-30 years</li>
-                    <li>Transaction fees must eventually fund 100% of mining revenue</li>
-                    <li>Historical fee revenue has been volatile and often insufficient</li>
-                    <li>New demand sources (Ordinals) suggest market may be more robust than expected</li>
-                    <li>Game theoretic challenges (fee sniping) emerge in low-subsidy environment</li>
-                    <li>No consensus on whether intervention is needed or what it should be</li>
-                    <li>Each halving provides real-world data on fee market resilience</li>
-                </ul>
+            <ul>
+                <li>Bitcoin's block subsidy will effectively end within 20-30 years</li>
+                <li>Transaction fees must eventually fund 100% of mining revenue</li>
+                <li>Historical fee revenue has been volatile and often insufficient</li>
+                <li>New demand sources (Ordinals) suggest market may be more robust than expected</li>
+                <li>Game theoretic challenges (fee sniping) emerge in low-subsidy environment</li>
+                <li>No consensus on whether intervention is needed or what it should be</li>
+                <li>Each halving provides real-world data on fee market resilience</li>
+            </ul>
+
+            <p>
+                The security budget problem is perhaps Bitcoin's most significant long-term
+                uncertainty. It cannot be solved with clever cryptography&mdash;it requires
+                sustainable economics. The next two decades will determine whether
+                Bitcoin's fee market can support a global settlement layer, or whether
+                more fundamental changes become necessary.
+            </p>
+        </section>
+
+        <section class="exercises">
+            <h2>Exercises</h2>
+
+            <div class="exercise">
+                <p class="exercise-title">Exercise 38.1</p>
+                <p>
+                    After the 2028 halving, the block subsidy will be 1.5625 BTC. Assuming
+                    144 blocks per day, compute the daily issuance in BTC and the annual
+                    issuance in BTC. Check your daily figure against the table in
+                    Section 38.1.
+                </p>
             </div>
 
-            <p>The security budget problem is perhaps Bitcoin's most significant long-term uncertainty. It cannot be solved with clever cryptography—it requires sustainable economics. The next two decades will determine whether Bitcoin's fee market can support a global settlement layer, or whether more fundamental changes become necessary.</p>
+            <div class="exercise">
+                <p class="exercise-title">Exercise 38.2</p>
+                <p>
+                    Using the formula in Definition 38.1, compute the block subsidy in BTC
+                    at height <span class="math">h = 1,050,000</span>. Then use the argument of
+                    Proposition 38.1 to find the first block height at which the subsidy
+                    is exactly zero.
+                </p>
+            </div>
+
+            <div class="exercise">
+                <p class="exercise-title">Exercise 38.3</p>
+                <p>
+                    Using the heuristic of Remark 38.2, compute the approximate cost per
+                    day of a 51% attack against a network with a $10 billion annual
+                    security budget, and against one with a $1 billion annual budget.
+                    Verify the claim that the second attack is 10x cheaper.
+                </p>
+            </div>
+
+            <div class="exercise">
+                <p class="exercise-title">Exercise 38.4</p>
+                <p>
+                    Recompute Example 38.1 (Model 1) for a $20 trillion market cap: find
+                    the required annual security budget at 1%, the required daily fee
+                    revenue, the required fee per block (using 52,560 blocks per year),
+                    and the required fee per transaction at 2,500 transactions per block.
+                </p>
+            </div>
+
+            <div class="exercise">
+                <p class="exercise-title">Exercise 38.5</p>
+                <p>
+                    A Lightning user pays a $100 on-chain fee to open a channel and another
+                    $100 to close it. If the channel carries 10,000 off-chain payments over
+                    its lifetime, what is the amortized on-chain fee per payment?
+                </p>
+            </div>
+
+            <div class="exercise">
+                <p class="exercise-title">Exercise 38.6</p>
+                <p>
+                    Extend Example 38.3: if Bitcoin's market cap grows to $5 trillion while
+                    the security budget stays at $15 billion per year, what is the security
+                    percentage? Compare your answer with the 0.5% level the chapter flags
+                    as potentially inadequate.
+                </p>
+            </div>
         </section>
 
         <nav class="chapter-navigation">
             <a href="37-defense-mechanisms.html" class="prev-chapter">&#8592; Chapter 37: Defense Mechanisms</a>
             <a href="39-quantum-resistance.html" class="next-chapter">Chapter 39: Quantum Resistance &#8594;</a>
         </nav>
-    </article>
+    </main>
 
     <footer>
-        <p>Elementary Bitcoin - Volume V: The Path to a Sustainable Future</p>
+        <p>Elementary Bitcoin · Volume V: The Path to a Sustainable Future (Draft)</p>
     </footer>
 </body>
 </html>

--- a/chapters/39-quantum-resistance.html
+++ b/chapters/39-quantum-resistance.html
@@ -9,49 +9,72 @@
 </head>
 <body>
     <nav class="chapter-nav">
-        <a href="38-security-budget.html" class="prev">&#8592; Chapter 38: The Security Budget Problem</a>
-        <a href="../index.html" class="home">&#8962; Home</a>
-        <a href="40-monetary-future.html" class="next">Chapter 40: Bitcoin's Monetary Future &#8594;</a>
+        <a href="../index.html">Contents</a>
+        <span class="nav-separator">·</span>
+        <span class="volume-indicator">Volume V: The Path to a Sustainable Future</span>
     </nav>
 
-    <article class="chapter">
-        <header class="chapter-header">
-            <p class="volume-title">Volume V: The Path to a Sustainable Future</p>
-            <p class="part-title">Part XV: Long-Term Security</p>
-            <h1>Chapter 39: Quantum Resistance</h1>
-            <p class="subtitle">Preparing Bitcoin for the Post-Quantum Era</p>
-        </header>
-
-        <blockquote class="chapter-quote">
+    <header class="chapter-header">
+        <p class="chapter-number">Chapter 39</p>
+        <h1>Quantum Resistance</h1>
+        <p class="chapter-subtitle">Preparing Bitcoin for the Post-Quantum Era</p>
+        <p class="chapter-epigraph">
             "Anyone who says they understand quantum mechanics does not understand quantum mechanics."
-            <cite>— Richard Feynman (attributed)</cite>
-        </blockquote>
+            <br>&mdash; Richard Feynman (attributed)
+        </p>
+    </header>
 
-        <section id="introduction">
-            <h2>The Quantum Threat</h2>
+    <main class="chapter-content">
+        <section>
+            <p class="chapter-intro">
+                Quantum computers represent a fundamentally different model of computation.
+                While today's quantum machines are far from threatening Bitcoin, the
+                cryptographic assumptions underlying Bitcoin's security will eventually need
+                to be updated. This chapter examines the two quantum algorithms relevant to
+                Bitcoin, surveys the current state of quantum hardware, presents the
+                post-quantum signature schemes standardized by NIST, and analyzes the
+                migration strategies available to the network. Understanding this
+                threat&mdash;and preparing for it&mdash;is essential for Bitcoin's
+                multi-generational future.
+            </p>
+        </section>
 
-            <p>Quantum computers represent a fundamentally different model of computation. While today's quantum machines are far from threatening Bitcoin, the cryptographic assumptions underlying Bitcoin's security will eventually need to be updated. Understanding this threat—and preparing for it—is essential for Bitcoin's multi-generational future.</p>
+        <section>
+            <h2>39.1 The Two Quantum Threats</h2>
 
-            <div class="key-concept">
-                <h3>The Two Quantum Threats</h3>
-                <p>Quantum computers threaten Bitcoin in two distinct ways:</p>
+            <div class="remark">
+                <p class="remark-title">Remark 39.1 (The Two Quantum Threats)</p>
+                <p>
+                    Quantum computers threaten Bitcoin in two distinct ways:
+                </p>
                 <ol>
                     <li><strong>Shor's Algorithm:</strong> Breaks ECDSA signatures (stealing coins)</li>
                     <li><strong>Grover's Algorithm:</strong> Weakens SHA-256 mining (theoretical)</li>
                 </ol>
-                <p>The first threat is severe and requires eventual migration. The second is less concerning and can be addressed by increasing key sizes.</p>
+                <p>
+                    The first threat is severe and requires eventual migration. The second is
+                    less concerning and can be addressed by increasing key sizes.
+                </p>
             </div>
         </section>
 
-        <section id="quantum-basics">
-            <h2>Quantum Computing Fundamentals</h2>
+        <section>
+            <h2>39.2 Quantum Computing Fundamentals</h2>
 
-            <h3>Classical vs. Quantum</h3>
-
-            <p>Classical computers use bits (0 or 1). Quantum computers use qubits, which can exist in superposition—simultaneously 0 and 1 until measured:</p>
-
-            <div class="code-block">
-<pre>
+            <div class="definition">
+                <p class="definition-title">Definition 39.1 (Qubit)</p>
+                <p>
+                    Classical computers use bits (0 or 1). Quantum computers use
+                    <strong>qubits</strong>, which can exist in superposition&mdash;simultaneously
+                    0 and 1 until measured. A qubit's state is
+                </p>
+                <p class="math-block">
+                    α|0⟩ + β|1⟩, &nbsp;&nbsp;with&nbsp;&nbsp; |α|² + |β|² = 1
+                </p>
+                <p>
+                    where the constraint expresses that the measurement probabilities sum to one.
+                </p>
+                <pre>
 Classical Bit:
 ├── State: 0 OR 1
 ├── Operations: AND, OR, NOT, XOR
@@ -66,47 +89,12 @@ Quantum Qubit:
 </pre>
             </div>
 
-            <h3>Why Quantum Matters for Cryptography</h3>
-
-            <p>Certain problems that are hard for classical computers become tractable for quantum computers:</p>
-
-            <table class="data-table">
-                <thead>
-                    <tr>
-                        <th>Problem</th>
-                        <th>Classical Complexity</th>
-                        <th>Quantum Complexity</th>
-                        <th>Impact</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr>
-                        <td>Integer factorization</td>
-                        <td>Sub-exponential</td>
-                        <td>Polynomial (Shor)</td>
-                        <td>Breaks RSA</td>
-                    </tr>
-                    <tr>
-                        <td>Discrete logarithm</td>
-                        <td>Sub-exponential</td>
-                        <td>Polynomial (Shor)</td>
-                        <td>Breaks ECDSA</td>
-                    </tr>
-                    <tr>
-                        <td>Unstructured search</td>
-                        <td>O(N)</td>
-                        <td>O(√N) (Grover)</td>
-                        <td>Halves hash security</td>
-                    </tr>
-                </tbody>
-            </table>
-
-            <h3>Quantum Gates and Circuits</h3>
-
-            <p>Quantum algorithms use specialized operations:</p>
-
-            <div class="code-block">
-<pre>
+            <div class="definition">
+                <p class="definition-title">Definition 39.2 (Quantum Gates)</p>
+                <p>
+                    Quantum algorithms are built from specialized operations on qubits:
+                </p>
+                <pre>
 Common Quantum Gates:
 ├── Hadamard (H): Creates superposition
 │   H|0⟩ = (|0⟩ + |1⟩)/√2
@@ -122,26 +110,65 @@ Common Quantum Gates:
     Rz(θ): |0⟩ → e^(−iθ/2)|0⟩,  |1⟩ → e^(+iθ/2)|1⟩
 </pre>
             </div>
+
+            <div class="remark">
+                <p class="remark-title">Remark 39.2 (Quantum Speedups for Cryptographic Problems)</p>
+                <p>
+                    Certain problems that are hard for classical computers become tractable
+                    for quantum computers:
+                </p>
+                <table class="data-table">
+                    <thead>
+                        <tr>
+                            <th>Problem</th>
+                            <th>Classical Complexity</th>
+                            <th>Quantum Complexity</th>
+                            <th>Impact</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>Integer factorization</td>
+                            <td>Sub-exponential</td>
+                            <td>Polynomial (Shor)</td>
+                            <td>Breaks RSA</td>
+                        </tr>
+                        <tr>
+                            <td>Discrete logarithm</td>
+                            <td>Sub-exponential</td>
+                            <td>Polynomial (Shor)</td>
+                            <td>Breaks ECDSA</td>
+                        </tr>
+                        <tr>
+                            <td>Unstructured search</td>
+                            <td>O(N)</td>
+                            <td>O(√N) (Grover)</td>
+                            <td>Halves hash security</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
         </section>
 
-        <section id="shors-algorithm">
-            <h2>Shor's Algorithm: The ECDSA Threat</h2>
+        <section>
+            <h2>39.3 Shor's Algorithm: The ECDSA Threat</h2>
 
-            <h3>How Shor's Algorithm Works</h3>
-
-            <p>Peter Shor's 1994 algorithm efficiently solves the discrete logarithm problem—the foundation of ECDSA security:</p>
-
-            <div class="formula-block">
-                <p><strong>The Discrete Log Problem:</strong></p>
-                <code>Given public key P = d × G, find private key d</code>
-                <p>Classical: ~2¹²⁸ operations for 256-bit curve</p>
-                <p>Quantum (Shor): ~10¹² gate operations with enough qubits</p>
-            </div>
-
-            <h3>Algorithm Overview</h3>
-
-            <div class="code-block">
-<pre>
+            <div class="definition">
+                <p class="definition-title">Definition 39.3 (Shor's Algorithm)</p>
+                <p>
+                    <strong>Shor's algorithm</strong> (Peter Shor, 1994) efficiently solves the
+                    discrete logarithm problem&mdash;the foundation of ECDSA security:
+                </p>
+                <p class="math-block">
+                    Given public key P = d × G, find private key d
+                </p>
+                <p>
+                    Classically this requires about <span class="math">2¹²⁸</span> operations for
+                    a 256-bit curve. Shor's algorithm reduces it to roughly
+                    <span class="math">10¹²</span> quantum gate operations, given a sufficiently
+                    large quantum computer. The algorithm proceeds in three stages:
+                </p>
+                <pre>
 Shor's Algorithm for Discrete Log:
 
 1. Quantum Phase Estimation
@@ -158,7 +185,15 @@ Shor's Algorithm for Discrete Log:
    ├── The period of f encodes d (since P = dG)
    ├── Compute d from the measured phase
    └── Verify: d × G = P ✓
+</pre>
+            </div>
 
+            <div class="example">
+                <p class="example-title">Example 39.1 (Resource Requirements for 256-bit ECDSA)</p>
+                <p>
+                    Running Shor's algorithm against a 256-bit elliptic curve key requires:
+                </p>
+                <pre>
 Resource Requirements (256-bit ECDSA):
 ├── Qubits needed: ~2,330 logical qubits
 ├── With error correction: ~13,000,000+ physical qubits
@@ -167,58 +202,69 @@ Resource Requirements (256-bit ECDSA):
 </pre>
             </div>
 
-            <h3>Which Coins Are Vulnerable?</h3>
-
-            <p>Not all Bitcoin addresses are equally vulnerable:</p>
-
-            <table class="data-table">
-                <thead>
-                    <tr>
-                        <th>Address Type</th>
-                        <th>Public Key Exposed?</th>
-                        <th>Quantum Vulnerable?</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr>
-                        <td>P2PK (early)</td>
-                        <td>Always (in scriptPubKey)</td>
-                        <td>Yes - immediately</td>
-                    </tr>
-                    <tr>
-                        <td>P2PKH (legacy)</td>
-                        <td>After first spend</td>
-                        <td>Yes - after spending</td>
-                    </tr>
-                    <tr>
-                        <td>P2WPKH (SegWit)</td>
-                        <td>After first spend</td>
-                        <td>Yes - after spending</td>
-                    </tr>
-                    <tr>
-                        <td>P2TR (Taproot)</td>
-                        <td>Always (tweaked key in output)</td>
-                        <td>Yes - immediately</td>
-                    </tr>
-                    <tr>
-                        <td>Fresh addresses</td>
-                        <td>Never (hash only)</td>
-                        <td>Protected until spent</td>
-                    </tr>
-                </tbody>
-            </table>
-
-            <div class="warning-box">
-                <h4>Satoshi's Coins</h4>
-                <p>Approximately 1 million BTC in early P2PK outputs (including Satoshi's presumed coins) have permanently exposed public keys. These are vulnerable to quantum attack regardless of address reuse practices.</p>
+            <div class="definition">
+                <p class="definition-title">Definition 39.4 (Public-Key Exposure by Address Type)</p>
+                <p>
+                    Not all Bitcoin addresses are equally vulnerable to Shor's algorithm.
+                    An output is exposed exactly when its public key (rather than a hash of it)
+                    is visible on-chain:
+                </p>
+                <table class="data-table">
+                    <thead>
+                        <tr>
+                            <th>Address Type</th>
+                            <th>Public Key Exposed?</th>
+                            <th>Quantum Vulnerable?</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>P2PK (early)</td>
+                            <td>Always (in scriptPubKey)</td>
+                            <td>Yes - immediately</td>
+                        </tr>
+                        <tr>
+                            <td>P2PKH (legacy)</td>
+                            <td>After first spend</td>
+                            <td>Yes - after spending</td>
+                        </tr>
+                        <tr>
+                            <td>P2WPKH (SegWit)</td>
+                            <td>After first spend</td>
+                            <td>Yes - after spending</td>
+                        </tr>
+                        <tr>
+                            <td>P2TR (Taproot)</td>
+                            <td>Always (tweaked key in output)</td>
+                            <td>Yes - immediately</td>
+                        </tr>
+                        <tr>
+                            <td>Fresh addresses</td>
+                            <td>Never (hash only)</td>
+                            <td>Protected until spent</td>
+                        </tr>
+                    </tbody>
+                </table>
             </div>
 
-            <h3>The Transaction Race Attack</h3>
+            <div class="remark">
+                <p class="remark-title">Remark 39.3 (Satoshi's Coins)</p>
+                <p>
+                    Approximately 1 million BTC in early P2PK outputs (including Satoshi's
+                    presumed coins) have permanently exposed public keys. These are vulnerable
+                    to quantum attack regardless of address reuse practices.
+                </p>
+            </div>
 
-            <p>Even "protected" addresses face risk during spending:</p>
-
-            <div class="code-block">
-<pre>
+            <div class="definition">
+                <p class="definition-title">Definition 39.5 (Transaction Race Attack)</p>
+                <p>
+                    Even "protected" addresses face risk during spending. In a
+                    <strong>transaction race attack</strong>, a quantum adversary extracts the
+                    public key from a broadcast transaction and races to compute the private
+                    key before the transaction confirms:
+                </p>
+                <pre>
 Transaction Race Attack:
 
 1. Victim broadcasts transaction
@@ -243,27 +289,31 @@ Critical timing:
 </pre>
             </div>
 
-            <p>This attack requires both a cryptographically relevant quantum computer AND one fast enough to compute discrete logs in under 10 minutes.</p>
+            <p>
+                This attack requires both a cryptographically relevant quantum computer AND
+                one fast enough to compute discrete logs in under 10 minutes.
+            </p>
         </section>
 
-        <section id="grovers-algorithm">
-            <h2>Grover's Algorithm: The Mining Threat</h2>
+        <section>
+            <h2>39.4 Grover's Algorithm: The Mining Threat</h2>
 
-            <h3>How Grover's Algorithm Works</h3>
-
-            <p>Lov Grover's 1996 algorithm provides quadratic speedup for unstructured search:</p>
-
-            <div class="formula-block">
-                <p><strong>Classical Search:</strong> O(N) - check every item</p>
-                <p><strong>Quantum Search:</strong> O(√N) - amplitude amplification</p>
-                <p><strong>For SHA-256:</strong></p>
-                <code>Classical: 2²⁵⁶ operations → Quantum: 2¹²⁸ operations</code>
-            </div>
-
-            <h3>Impact on Bitcoin Mining</h3>
-
-            <div class="code-block">
-<pre>
+            <div class="definition">
+                <p class="definition-title">Definition 39.6 (Grover's Algorithm)</p>
+                <p>
+                    <strong>Grover's algorithm</strong> (Lov Grover, 1996) provides quadratic
+                    speedup for unstructured search via amplitude amplification:
+                </p>
+                <p class="math-block">
+                    Classical search: O(N) &nbsp;&nbsp;→&nbsp;&nbsp; Quantum search: O(√N)
+                </p>
+                <p>
+                    For SHA-256 preimage search:
+                </p>
+                <p class="math-block">
+                    Classical: 2²⁵⁶ operations &nbsp;&nbsp;→&nbsp;&nbsp; Quantum: 2¹²⁸ operations
+                </p>
+                <pre>
 Mining with Grover's Algorithm:
 
 Classical Mining:
@@ -286,77 +336,110 @@ Practical Reality:
 </pre>
             </div>
 
-            <h3>Why Grover Is Less Concerning</h3>
+            <div class="theorem">
+                <p class="theorem-title">Proposition 39.1 (Grover Does Not Break Mining)</p>
+                <p>
+                    Grover's algorithm does not give a quantum miner the kind of decisive
+                    advantage that Shor's algorithm gives a quantum signature forger:
+                </p>
+                <ol>
+                    <li><strong>Quadratic, not exponential:</strong> <span class="math">2¹²⁸</span> is still astronomical</li>
+                    <li><strong>Not parallelizable:</strong> Can't gain advantage from multiple quantum computers</li>
+                    <li><strong>Difficulty adjustment:</strong> Network adjusts to maintain 10-minute blocks</li>
+                    <li><strong>Simple fix:</strong> Double hash output size (SHA-512) restores security</li>
+                </ol>
+            </div>
 
-            <p>Several factors mitigate the Grover threat:</p>
+            <div class="proof">
+                <p class="proof-title">Proof.</p>
+                <p>
+                    A Grover search over a space of size <span class="math">N</span> requires
+                    about <span class="math">√N</span> <em>sequential</em> coherent iterations.
+                    Splitting the search space among <span class="math">M</span> quantum
+                    machines gives each machine a space of size <span class="math">N/M</span>,
+                    costing <span class="math">√(N/M) = √N/√M</span> time&mdash;a collective
+                    speedup of only <span class="math">√M</span>, whereas <span class="math">M</span>
+                    classical ASICs achieve a full <span class="math">M×</span> speedup. Since
+                    mining is a throughput race rather than a one-shot break, and the difficulty
+                    adjustment retargets to whatever total search rate the network achieves,
+                    quantum miners merely join the existing hardware arms race rather than
+                    breaking the proof-of-work mechanism. <span class="qed"></span>
+                </p>
+            </div>
 
-            <ol>
-                <li><strong>Quadratic, not exponential:</strong> <span class="math">2¹²⁸</span> is still astronomical</li>
-                <li><strong>Not parallelizable:</strong> Can't gain advantage from multiple quantum computers</li>
-                <li><strong>Difficulty adjustment:</strong> Network adjusts to maintain 10-minute blocks</li>
-                <li><strong>Simple fix:</strong> Double hash output size (SHA-512) restores security</li>
-            </ol>
-
-            <div class="info-box">
-                <h4>Effective Security Levels</h4>
-                <p>Post-quantum, SHA-256 provides 128-bit security (still extremely strong). If needed, migration to SHA-384 or SHA-512 could restore 256-bit security against quantum adversaries.</p>
+            <div class="remark">
+                <p class="remark-title">Remark 39.4 (Effective Security Levels)</p>
+                <p>
+                    Post-quantum, SHA-256 provides 128-bit security (still extremely strong).
+                    If needed, migration to SHA-384 or SHA-512 could restore 256-bit security
+                    against quantum adversaries.
+                </p>
             </div>
         </section>
 
-        <section id="current-state">
-            <h2>Current State of Quantum Computing</h2>
+        <section>
+            <h2>39.5 The Current State of Quantum Computing</h2>
 
-            <h3>2024 Quantum Landscape</h3>
+            <div class="example">
+                <p class="example-title">Example 39.2 (2024 Quantum Landscape)</p>
+                <table class="data-table">
+                    <thead>
+                        <tr>
+                            <th>Company/Lab</th>
+                            <th>Qubits (Physical)</th>
+                            <th>Technology</th>
+                            <th>Error Rate</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>IBM Condor</td>
+                            <td>1,121</td>
+                            <td>Superconducting</td>
+                            <td>~0.1%</td>
+                        </tr>
+                        <tr>
+                            <td>Google Sycamore</td>
+                            <td>53</td>
+                            <td>Superconducting</td>
+                            <td>~0.5%</td>
+                        </tr>
+                        <tr>
+                            <td>IonQ Forte</td>
+                            <td>36</td>
+                            <td>Trapped ion</td>
+                            <td>~0.03%</td>
+                        </tr>
+                        <tr>
+                            <td>Quantinuum H2</td>
+                            <td>56</td>
+                            <td>Trapped ion</td>
+                            <td>~0.1%</td>
+                        </tr>
+                        <tr>
+                            <td>Required for ECDSA</td>
+                            <td>~2,330 logical</td>
+                            <td>Error-corrected</td>
+                            <td>~0.0001%</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
 
-            <table class="data-table">
-                <thead>
-                    <tr>
-                        <th>Company/Lab</th>
-                        <th>Qubits (Physical)</th>
-                        <th>Technology</th>
-                        <th>Error Rate</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr>
-                        <td>IBM Condor</td>
-                        <td>1,121</td>
-                        <td>Superconducting</td>
-                        <td>~0.1%</td>
-                    </tr>
-                    <tr>
-                        <td>Google Sycamore</td>
-                        <td>53</td>
-                        <td>Superconducting</td>
-                        <td>~0.5%</td>
-                    </tr>
-                    <tr>
-                        <td>IonQ Forte</td>
-                        <td>36</td>
-                        <td>Trapped ion</td>
-                        <td>~0.03%</td>
-                    </tr>
-                    <tr>
-                        <td>Quantinuum H2</td>
-                        <td>56</td>
-                        <td>Trapped ion</td>
-                        <td>~0.1%</td>
-                    </tr>
-                    <tr>
-                        <td>Required for ECDSA</td>
-                        <td>~2,330 logical</td>
-                        <td>Error-corrected</td>
-                        <td>~0.0001%</td>
-                    </tr>
-                </tbody>
-            </table>
+            <div class="definition">
+                <p class="definition-title">Definition 39.7 (Logical Qubit)</p>
+                <p>
+                    Current quantum computers are "noisy"&mdash;qubits decohere and operations
+                    have errors. A <strong>logical qubit</strong> is an error-corrected qubit
+                    built from many physical qubits, allowing arbitrarily long computations.
+                    Useful cryptographic attacks require fault-tolerant quantum computers built
+                    from logical qubits.
+                </p>
+            </div>
 
-            <h3>The Error Correction Challenge</h3>
-
-            <p>Current quantum computers are "noisy"—qubits decohere and operations have errors. Useful cryptographic attacks require fault-tolerant quantum computers with error correction:</p>
-
-            <div class="code-block">
-<pre>
+            <div class="example">
+                <p class="example-title">Example 39.3 (Error-Correction Overhead)</p>
+                <pre>
 Logical Qubit Construction:
 
 Physical qubits available: ~1,000
@@ -378,109 +461,132 @@ For Breaking 256-bit ECDSA (Roetteler et al., 2017):
 </pre>
             </div>
 
-            <h3>Timeline Estimates</h3>
+            <div class="remark">
+                <p class="remark-title">Remark 39.5 (Timeline Estimates)</p>
+                <p>
+                    Expert predictions for cryptographically relevant quantum computers vary widely:
+                </p>
+                <table class="data-table">
+                    <thead>
+                        <tr>
+                            <th>Source</th>
+                            <th>Year</th>
+                            <th>Prediction</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>NIST (2016)</td>
+                            <td>2030</td>
+                            <td>"Unlikely before 2030"</td>
+                        </tr>
+                        <tr>
+                            <td>Google (2019)</td>
+                            <td>2029</td>
+                            <td>"Million-qubit machine possible"</td>
+                        </tr>
+                        <tr>
+                            <td>IBM Roadmap (2023)</td>
+                            <td>2033</td>
+                            <td>"100,000 physical qubits"</td>
+                        </tr>
+                        <tr>
+                            <td>Mosca Theorem</td>
+                            <td>Variable</td>
+                            <td>"Migrate before threat arrives"</td>
+                        </tr>
+                        <tr>
+                            <td>Skeptics</td>
+                            <td>2050+</td>
+                            <td>"Fundamental barriers remain"</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
 
-            <p>Expert predictions vary widely:</p>
+            <div class="definition">
+                <p class="definition-title">Definition 39.8 (Mosca's Inequality)</p>
+                <p>
+                    Let <span class="math">X</span> = time to migrate cryptography,
+                    <span class="math">Y</span> = time data must remain secure, and
+                    <span class="math">Z</span> = time until the quantum threat arrives.
+                    Migration must begin now whenever
+                </p>
+                <p class="math-block">
+                    X + Y &gt; Z
+                </p>
+            </div>
 
-            <table class="data-table">
-                <thead>
-                    <tr>
-                        <th>Source</th>
-                        <th>Year</th>
-                        <th>Prediction</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr>
-                        <td>NIST (2016)</td>
-                        <td>2030</td>
-                        <td>"Unlikely before 2030"</td>
-                    </tr>
-                    <tr>
-                        <td>Google (2019)</td>
-                        <td>2029</td>
-                        <td>"Million-qubit machine possible"</td>
-                    </tr>
-                    <tr>
-                        <td>IBM Roadmap (2023)</td>
-                        <td>2033</td>
-                        <td>"100,000 physical qubits"</td>
-                    </tr>
-                    <tr>
-                        <td>Mosca Theorem</td>
-                        <td>Variable</td>
-                        <td>"Migrate before threat arrives"</td>
-                    </tr>
-                    <tr>
-                        <td>Skeptics</td>
-                        <td>2050+</td>
-                        <td>"Fundamental barriers remain"</td>
-                    </tr>
-                </tbody>
-            </table>
-
-            <div class="key-concept">
-                <h3>Mosca's Theorem</h3>
-                <p>If <span class="math">X</span> = time to migrate cryptography, <span class="math">Y</span> = time data must remain secure, and <span class="math">Z</span> = time until quantum threat: <strong>Start migration when <span class="math">X + Y &gt; Z</span></strong></p>
-                <p>For Bitcoin: Migration may take 5-10 years, coins must be secure forever. If quantum threat is 15-20 years away, migration should start soon.</p>
+            <div class="remark">
+                <p class="remark-title">Remark 39.6 (Mosca's Inequality Applied to Bitcoin)</p>
+                <p>
+                    For Bitcoin: migration may take 5-10 years, and coins must be secure
+                    forever (so <span class="math">Y</span> is effectively unbounded for stored
+                    value). If the quantum threat is 15-20 years away, migration should
+                    start soon.
+                </p>
             </div>
         </section>
 
-        <section id="post-quantum">
-            <h2>Post-Quantum Cryptography</h2>
+        <section>
+            <h2>39.6 Post-Quantum Cryptography</h2>
 
-            <h3>NIST Post-Quantum Standards</h3>
+            <div class="definition">
+                <p class="definition-title">Definition 39.9 (NIST Post-Quantum Standards)</p>
+                <p>
+                    In 2024, NIST finalized the first post-quantum cryptographic standards:
+                </p>
+                <table class="data-table">
+                    <thead>
+                        <tr>
+                            <th>Algorithm</th>
+                            <th>Type</th>
+                            <th>Use Case</th>
+                            <th>Key Size</th>
+                            <th>Signature Size</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>ML-KEM (Kyber)</td>
+                            <td>Lattice</td>
+                            <td>Key encapsulation</td>
+                            <td>~1.5 KB</td>
+                            <td>N/A</td>
+                        </tr>
+                        <tr>
+                            <td>ML-DSA (Dilithium)</td>
+                            <td>Lattice</td>
+                            <td>Signatures</td>
+                            <td>~2.5 KB</td>
+                            <td>~4.6 KB</td>
+                        </tr>
+                        <tr>
+                            <td>SLH-DSA (SPHINCS+)</td>
+                            <td>Hash-based</td>
+                            <td>Signatures</td>
+                            <td>~64 bytes</td>
+                            <td>~8-50 KB</td>
+                        </tr>
+                        <tr>
+                            <td>ECDSA (current)</td>
+                            <td>Elliptic curve</td>
+                            <td>Signatures</td>
+                            <td>33 bytes</td>
+                            <td>~72 bytes</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
 
-            <p>In 2024, NIST finalized the first post-quantum cryptographic standards:</p>
-
-            <table class="data-table">
-                <thead>
-                    <tr>
-                        <th>Algorithm</th>
-                        <th>Type</th>
-                        <th>Use Case</th>
-                        <th>Key Size</th>
-                        <th>Signature Size</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr>
-                        <td>ML-KEM (Kyber)</td>
-                        <td>Lattice</td>
-                        <td>Key encapsulation</td>
-                        <td>~1.5 KB</td>
-                        <td>N/A</td>
-                    </tr>
-                    <tr>
-                        <td>ML-DSA (Dilithium)</td>
-                        <td>Lattice</td>
-                        <td>Signatures</td>
-                        <td>~2.5 KB</td>
-                        <td>~4.6 KB</td>
-                    </tr>
-                    <tr>
-                        <td>SLH-DSA (SPHINCS+)</td>
-                        <td>Hash-based</td>
-                        <td>Signatures</td>
-                        <td>~64 bytes</td>
-                        <td>~8-50 KB</td>
-                    </tr>
-                    <tr>
-                        <td>ECDSA (current)</td>
-                        <td>Elliptic curve</td>
-                        <td>Signatures</td>
-                        <td>33 bytes</td>
-                        <td>~72 bytes</td>
-                    </tr>
-                </tbody>
-            </table>
-
-            <h3>Lattice-Based Cryptography</h3>
-
-            <p>Most promising for Bitcoin—based on the hardness of lattice problems:</p>
-
-            <div class="code-block">
-<pre>
+            <div class="definition">
+                <p class="definition-title">Definition 39.10 (Lattice-Based Signatures)</p>
+                <p>
+                    <strong>Lattice-based cryptography</strong> rests on the hardness of
+                    lattice problems, for which no efficient quantum algorithm is known.
+                    It is the most promising family for Bitcoin:
+                </p>
+                <pre>
 Lattice Problem (simplified):
 
 Given: Basis vectors of a high-dimensional lattice
@@ -497,12 +603,14 @@ ML-DSA (Dilithium) for Bitcoin:
 </pre>
             </div>
 
-            <h3>Hash-Based Signatures</h3>
-
-            <p>Most conservative option—security relies only on hash function security:</p>
-
-            <div class="code-block">
-<pre>
+            <div class="definition">
+                <p class="definition-title">Definition 39.11 (Hash-Based Signatures)</p>
+                <p>
+                    <strong>Hash-based signatures</strong> are the most conservative
+                    option&mdash;their security relies only on the security of the underlying
+                    hash function:
+                </p>
+                <pre>
 SPHINCS+ (SLH-DSA):
 ├── Based on: Merkle trees + hash chains
 ├── Security assumption: Hash function (SHA-256, SHAKE)
@@ -523,55 +631,57 @@ Lamport Signatures (simpler):
 </pre>
             </div>
 
-            <h3>Comparing Options for Bitcoin</h3>
-
-            <table class="data-table">
-                <thead>
-                    <tr>
-                        <th>Scheme</th>
-                        <th>Transaction Size Impact</th>
-                        <th>Security Confidence</th>
-                        <th>Compatibility</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr>
-                        <td>ML-DSA</td>
-                        <td>~65x larger signatures (~25x at transaction level)</td>
-                        <td>High (NIST standard)</td>
-                        <td>Soft fork possible</td>
-                    </tr>
-                    <tr>
-                        <td>SPHINCS+</td>
-                        <td>~100-700x larger</td>
-                        <td>Very high (hash only)</td>
-                        <td>Soft fork possible</td>
-                    </tr>
-                    <tr>
-                        <td>Lamport (committed)</td>
-                        <td>~100x larger</td>
-                        <td>Very high</td>
-                        <td>Usable today</td>
-                    </tr>
-                    <tr>
-                        <td>STARK signatures</td>
-                        <td>~50-100x larger</td>
-                        <td>High (hash + ZK)</td>
-                        <td>Needs research</td>
-                    </tr>
-                </tbody>
-            </table>
+            <div class="example">
+                <p class="example-title">Example 39.4 (Comparing Post-Quantum Options for Bitcoin)</p>
+                <table class="data-table">
+                    <thead>
+                        <tr>
+                            <th>Scheme</th>
+                            <th>Transaction Size Impact</th>
+                            <th>Security Confidence</th>
+                            <th>Compatibility</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>ML-DSA</td>
+                            <td>~65x larger signatures (~25x at transaction level)</td>
+                            <td>High (NIST standard)</td>
+                            <td>Soft fork possible</td>
+                        </tr>
+                        <tr>
+                            <td>SPHINCS+</td>
+                            <td>~100-700x larger</td>
+                            <td>Very high (hash only)</td>
+                            <td>Soft fork possible</td>
+                        </tr>
+                        <tr>
+                            <td>Lamport (committed)</td>
+                            <td>~100x larger</td>
+                            <td>Very high</td>
+                            <td>Usable today</td>
+                        </tr>
+                        <tr>
+                            <td>STARK signatures</td>
+                            <td>~50-100x larger</td>
+                            <td>High (hash + ZK)</td>
+                            <td>Needs research</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
         </section>
 
-        <section id="migration-strategies">
-            <h2>Bitcoin Migration Strategies</h2>
+        <section>
+            <h2>39.7 Bitcoin Migration Strategies</h2>
 
-            <h3>Strategy 1: Soft Fork New Address Types</h3>
-
-            <p>Add post-quantum signature schemes as new SegWit versions:</p>
-
-            <div class="code-block">
-<pre>
+            <div class="definition">
+                <p class="definition-title">Definition 39.12 (Post-Quantum SegWit, P2QRH)</p>
+                <p>
+                    The first migration strategy adds post-quantum signature schemes as new
+                    SegWit versions via a soft fork:
+                </p>
+                <pre>
 Post-Quantum SegWit:
 
 Version 0: P2WPKH, P2WSH (current)
@@ -590,12 +700,14 @@ spending = &lt;PQ signature&gt; &lt;PQ public key&gt;
 </pre>
             </div>
 
-            <h3>Strategy 2: Commit-Delay-Reveal</h3>
-
-            <p>Protect against transaction race attacks:</p>
-
-            <div class="code-block">
-<pre>
+            <div class="definition">
+                <p class="definition-title">Definition 39.13 (Commit-Delay-Reveal)</p>
+                <p>
+                    The second strategy protects against transaction race attacks by separating
+                    the commitment to spend from the reveal of the (quantum-vulnerable)
+                    public key:
+                </p>
+                <pre>
 Commit-Delay-Reveal Protocol:
 
 1. Commit Phase
@@ -621,12 +733,13 @@ Benefits:
 </pre>
             </div>
 
-            <h3>Strategy 3: Hybrid Signatures</h3>
-
-            <p>Combine classical and post-quantum signatures:</p>
-
-            <div class="code-block">
-<pre>
+            <div class="definition">
+                <p class="definition-title">Definition 39.14 (Hybrid Signatures)</p>
+                <p>
+                    The third strategy combines classical and post-quantum signatures, so the
+                    construction is secure as long as <em>either</em> scheme remains secure:
+                </p>
+                <pre>
 Hybrid Signature Scheme:
 
 signature = {
@@ -646,12 +759,11 @@ Security:
 </pre>
             </div>
 
-            <h3>Strategy 4: Emergency Hard Fork</h3>
-
-            <p>Last resort if quantum threat materializes suddenly:</p>
-
-            <div class="warning-box">
-                <h4>Emergency Migration Scenario</h4>
+            <div class="remark">
+                <p class="remark-title">Remark 39.7 (Emergency Hard Fork)</p>
+                <p>
+                    The last resort, if the quantum threat materializes suddenly:
+                </p>
                 <ol>
                     <li>Quantum attack demonstrated or imminent</li>
                     <li>Freeze all ECDSA-based transactions</li>
@@ -659,28 +771,34 @@ Security:
                     <li>Hard fork to PQ-only signatures</li>
                     <li>Coins without valid PQ proof may be frozen/burned</li>
                 </ol>
-                <p>This is extremely disruptive and should be avoided through proactive migration.</p>
+                <p>
+                    This is extremely disruptive and should be avoided through proactive migration.
+                </p>
             </div>
         </section>
 
-        <section id="scalability-concerns">
-            <h2>Scalability Implications</h2>
+        <section>
+            <h2>39.8 Scalability Implications</h2>
 
-            <h3>Transaction Size Explosion</h3>
-
-            <p>Post-quantum signatures are much larger than ECDSA:</p>
-
-            <div class="formula-block">
-                <p><strong>Current ECDSA transaction:</strong> ~250 bytes typical</p>
-                <p><strong>ML-DSA transaction:</strong> ~5,000-7,000 bytes</p>
-                <p><strong>SPHINCS+ transaction:</strong> ~10,000-50,000 bytes</p>
-                <p><strong>Capacity impact:</strong> 5-100x fewer transactions per block</p>
+            <div class="example">
+                <p class="example-title">Example 39.5 (Transaction Size Explosion)</p>
+                <p>
+                    Post-quantum signatures are much larger than ECDSA:
+                </p>
+                <ul>
+                    <li><strong>Current ECDSA transaction:</strong> ~250 bytes typical</li>
+                    <li><strong>ML-DSA transaction:</strong> ~5,000-7,000 bytes</li>
+                    <li><strong>SPHINCS+ transaction:</strong> ~10,000-50,000 bytes</li>
+                    <li><strong>Capacity impact:</strong> 5-100x fewer transactions per block</li>
+                </ul>
             </div>
 
-            <h3>Mitigation Approaches</h3>
-
-            <div class="code-block">
-<pre>
+            <div class="remark">
+                <p class="remark-title">Remark 39.8 (Mitigation Approaches)</p>
+                <p>
+                    Several approaches can offset the cost of larger signatures:
+                </p>
+                <pre>
 Dealing with Larger Signatures:
 
 1. Signature Aggregation
@@ -711,24 +829,21 @@ Dealing with Larger Signatures:
             </div>
         </section>
 
-        <section id="lost-coins">
-            <h2>The Lost Coins Problem</h2>
+        <section>
+            <h2>39.9 The Lost Coins Problem</h2>
 
-            <h3>Coins That Cannot Migrate</h3>
-
-            <p>Some Bitcoin cannot be moved to quantum-resistant addresses:</p>
-
-            <ul>
-                <li><strong>Lost keys:</strong> ~3-4 million BTC estimated lost forever</li>
-                <li><strong>Satoshi's coins:</strong> ~1 million BTC unmoved since 2009-2010</li>
-                <li><strong>Dead holders:</strong> No heir has keys</li>
-                <li><strong>Forgotten wallets:</strong> Keys exist but owners unaware/unable</li>
-            </ul>
-
-            <h3>The Quantum "Inheritance" Problem</h3>
-
-            <div class="code-block">
-<pre>
+            <div class="remark">
+                <p class="remark-title">Remark 39.9 (Coins That Cannot Migrate)</p>
+                <p>
+                    Some Bitcoin cannot be moved to quantum-resistant addresses:
+                </p>
+                <ul>
+                    <li><strong>Lost keys:</strong> ~3-4 million BTC estimated lost forever</li>
+                    <li><strong>Satoshi's coins:</strong> ~1 million BTC unmoved since 2009-2010</li>
+                    <li><strong>Dead holders:</strong> No heir has keys</li>
+                    <li><strong>Forgotten wallets:</strong> Keys exist but owners unaware/unable</li>
+                </ul>
+                <pre>
 Quantum Threat to Unmoved Coins:
 
 P2PK outputs (exposed public keys):
@@ -754,30 +869,36 @@ Controversial Question:
 </pre>
             </div>
 
-            <div class="info-box">
-                <h4>The Ethical Dimension</h4>
-                <p>If quantum computers can claim Satoshi's coins, ~1 million BTC returns to circulation. Is this theft? Inheritance? A feature? The community has no consensus on how to handle this eventuality.</p>
+            <div class="remark">
+                <p class="remark-title">Remark 39.10 (The Ethical Dimension)</p>
+                <p>
+                    If quantum computers can claim Satoshi's coins, ~1 million BTC returns to
+                    circulation. Is this theft? Inheritance? A feature? The community has no
+                    consensus on how to handle this eventuality.
+                </p>
             </div>
         </section>
 
-        <section id="preparation">
-            <h2>Preparing Today</h2>
+        <section>
+            <h2>39.10 Preparing Today</h2>
 
-            <h3>Best Practices for Users</h3>
+            <div class="remark">
+                <p class="remark-title">Remark 39.11 (Best Practices for Users)</p>
+                <ol>
+                    <li><strong>Never reuse addresses:</strong> Fresh addresses hide public keys</li>
+                    <li><strong>Prefer P2WPKH over P2TR:</strong> P2TR exposes the tweaked public key in the output; P2WPKH hides the key behind a hash until spending</li>
+                    <li><strong>Monitor quantum progress:</strong> Be ready to migrate when solutions deploy</li>
+                    <li><strong>Support PQ research:</strong> Encourage wallet/protocol development</li>
+                </ol>
+            </div>
 
-            <ol>
-                <li><strong>Never reuse addresses:</strong> Fresh addresses hide public keys</li>
-                <li><strong>Prefer P2WPKH over P2TR:</strong> P2TR exposes the tweaked public key in the output; P2WPKH hides the key behind a hash until spending</li>
-                <li><strong>Monitor quantum progress:</strong> Be ready to migrate when solutions deploy</li>
-                <li><strong>Support PQ research:</strong> Encourage wallet/protocol development</li>
-            </ol>
-
-            <h3>Commit Now, Reveal Later</h3>
-
-            <p>Users can protect themselves today using P2SH commitments:</p>
-
-            <div class="code-block">
-<pre>
+            <div class="definition">
+                <p class="definition-title">Definition 39.15 (Committed Lamport Fallback)</p>
+                <p>
+                    Users can protect themselves today by committing to a hash-based
+                    signature inside a P2SH script&mdash;a "commit now, reveal later" defense:
+                </p>
+                <pre>
 DIY Quantum Protection (Advanced):
 
 1. Generate Lamport keypair offline
@@ -796,21 +917,18 @@ Note: Complex, not user-friendly
 </pre>
             </div>
 
-            <h3>For Developers</h3>
+            <p>
+                For developers, preparation means: researching post-quantum signature
+                integration, implementing hybrid signature schemes, preparing wallet upgrade
+                paths, and testing on signet/testnet.
+            </p>
 
-            <ul>
-                <li>Research post-quantum signature integration</li>
-                <li>Implement hybrid signature schemes</li>
-                <li>Prepare wallet upgrade paths</li>
-                <li>Test on signet/testnet</li>
-            </ul>
-        </section>
-
-        <section id="timeline-action">
-            <h2>Action Timeline</h2>
-
-            <div class="code-block">
-<pre>
+            <div class="remark">
+                <p class="remark-title">Remark 39.12 (Action Timeline)</p>
+                <p>
+                    A recommended preparation timeline:
+                </p>
+                <pre>
 Recommended Preparation Timeline:
 
 2024-2026: Research Phase
@@ -845,40 +963,119 @@ Recommended Preparation Timeline:
 </pre>
             </div>
 
-            <div class="key-concept">
-                <h3>The 20-Year Window</h3>
-                <p>Most estimates give Bitcoin 15-25 years before quantum computers threaten ECDSA. This seems like ample time, but cryptographic migrations are slow. The Y2K problem was identified in the 1960s—and we still barely made it.</p>
+            <div class="remark">
+                <p class="remark-title">Remark 39.13 (The 20-Year Window)</p>
+                <p>
+                    Most estimates give Bitcoin 15-25 years before quantum computers threaten
+                    ECDSA. This seems like ample time, but cryptographic migrations are slow.
+                    The Y2K problem was identified in the 1960s&mdash;and we still barely made it.
+                </p>
             </div>
         </section>
 
-        <section id="summary">
-            <h2>Summary: A Manageable Challenge</h2>
+        <section>
+            <h2>39.11 Summary</h2>
 
-            <div class="key-takeaways">
-                <h3>Key Points</h3>
-                <ul>
-                    <li><strong>Shor's algorithm</strong> will eventually break ECDSA—migration is inevitable</li>
-                    <li><strong>Grover's algorithm</strong> halves hash security—doubling key size fixes it</li>
-                    <li><strong>Timeline:</strong> Likely 15-25 years, but uncertain</li>
-                    <li><strong>NIST standards</strong> (ML-DSA, SPHINCS+) provide ready alternatives</li>
-                    <li><strong>Signatures will be larger</strong>—5-100x current size</li>
-                    <li><strong>Soft fork migration</strong> is possible and least disruptive</li>
-                    <li><strong>Users should avoid address reuse</strong> as basic protection</li>
-                    <li><strong>Research and planning should begin now</strong>—migration takes years</li>
-                </ul>
+            <ul>
+                <li><strong>Shor's algorithm</strong> will eventually break ECDSA&mdash;migration is inevitable</li>
+                <li><strong>Grover's algorithm</strong> halves hash security&mdash;doubling key size fixes it</li>
+                <li><strong>Timeline:</strong> Likely 15-25 years, but uncertain</li>
+                <li><strong>NIST standards</strong> (ML-DSA, SPHINCS+) provide ready alternatives</li>
+                <li><strong>Signatures will be larger</strong>&mdash;5-100x current size</li>
+                <li><strong>Soft fork migration</strong> is possible and least disruptive</li>
+                <li><strong>Users should avoid address reuse</strong> as basic protection</li>
+                <li><strong>Research and planning should begin now</strong>&mdash;migration takes years</li>
+            </ul>
+
+            <p>
+                The quantum threat to Bitcoin is real but not imminent. With proper
+                preparation, Bitcoin can transition to quantum-resistant cryptography
+                smoothly. The challenge is significant but surmountable&mdash;far easier than
+                the social coordination required to change monetary policy would be.
+            </p>
+        </section>
+
+        <section class="exercises">
+            <h2>Exercises</h2>
+
+            <div class="exercise">
+                <p class="exercise-title">Exercise 39.1</p>
+                <p>
+                    A Lamport signature scheme for 256-bit messages uses two random 256-bit
+                    preimages per message bit. Compute the sizes of the private key, the
+                    public key (one 256-bit hash per preimage), and a signature (one revealed
+                    preimage per message bit). Verify that the signature size matches the
+                    8 KB figure quoted in Definition 39.11.
+                </p>
             </div>
 
-            <p>The quantum threat to Bitcoin is real but not imminent. With proper preparation, Bitcoin can transition to quantum-resistant cryptography smoothly. The challenge is significant but surmountable—far easier than the social coordination required to change monetary policy would be.</p>
+            <div class="exercise">
+                <p class="exercise-title">Exercise 39.2</p>
+                <p>
+                    Consider a 1-input, 2-output transaction whose non-signature "skeleton"
+                    is 150 bytes. Using the ML-DSA-87 parameters from Definition 39.10
+                    (public key 2,592 bytes, signature 4,627 bytes) and ECDSA
+                    (33-byte key, 72-byte signature), compute both total transaction sizes
+                    and their ratio. Compare your result with the "~25x at transaction level"
+                    and "~5,000-7,000 bytes" figures in Examples 39.4 and 39.5.
+                </p>
+            </div>
+
+            <div class="exercise">
+                <p class="exercise-title">Exercise 39.3</p>
+                <p>
+                    Apply Mosca's inequality (Definition 39.8) with migration time
+                    <span class="math">X = 7</span> years and required security lifetime
+                    <span class="math">Y = 10</span> years. Is migration already overdue if
+                    the quantum threat arrives in <span class="math">Z = 18</span> years?
+                    What if <span class="math">Z = 15</span> years? By how many years?
+                </p>
+            </div>
+
+            <div class="exercise">
+                <p class="exercise-title">Exercise 39.4</p>
+                <p>
+                    Suppose finding a valid block requires <span class="math">2⁸⁰</span> expected
+                    hash evaluations. How many Grover iterations does a single quantum computer
+                    need? If the search space is split across <span class="math">2¹⁰</span> quantum
+                    machines, how many iterations does each machine need, and how does this
+                    compare with the per-machine workload of <span class="math">2¹⁰</span> classical
+                    ASICs? Explain how this supports Proposition 39.1.
+                </p>
+            </div>
+
+            <div class="exercise">
+                <p class="exercise-title">Exercise 39.5</p>
+                <p>
+                    Grover's algorithm reduces SHA-256 preimage search to
+                    <span class="math">2¹²⁸</span> sequential iterations (Definition 39.6).
+                    If a fault-tolerant quantum computer performs <span class="math">10⁹</span>
+                    Grover iterations per second, how many years would the full search take?
+                    What does this say about Remark 39.4's claim that 128-bit post-quantum
+                    security is "still extremely strong"?
+                </p>
+            </div>
+
+            <div class="exercise">
+                <p class="exercise-title">Exercise 39.6</p>
+                <p>
+                    Using Example 39.3, compute the total physical qubit count needed to break
+                    256-bit ECDSA at error-correction overheads of 1,000 and 10,000 physical
+                    qubits per logical qubit (2,330 logical qubits required). By what factor
+                    does each figure exceed IBM Condor's 1,121 physical qubits
+                    (Example 39.2)?
+                </p>
+            </div>
         </section>
 
         <nav class="chapter-navigation">
             <a href="38-security-budget.html" class="prev-chapter">&#8592; Chapter 38: The Security Budget Problem</a>
             <a href="40-monetary-future.html" class="next-chapter">Chapter 40: Bitcoin's Monetary Future &#8594;</a>
         </nav>
-    </article>
+    </main>
 
     <footer>
-        <p>Elementary Bitcoin - Volume V: The Path to a Sustainable Future</p>
+        <p>Elementary Bitcoin · Volume V: The Path to a Sustainable Future (Draft)</p>
     </footer>
 </body>
 </html>

--- a/chapters/40-monetary-future.html
+++ b/chapters/40-monetary-future.html
@@ -9,782 +9,779 @@
 </head>
 <body>
     <nav class="chapter-nav">
-        <a href="39-quantum-resistance.html" class="prev">&#8592; Chapter 39: Quantum Resistance</a>
-        <a href="../index.html" class="home">&#8962; Home</a>
-        <a href="../index.html" class="next">Return to Index &#8594;</a>
+        <a href="../index.html">Contents</a>
+        <span class="nav-separator">·</span>
+        <span class="volume-indicator">Volume V: The Path to a Sustainable Future</span>
     </nav>
 
-    <article class="chapter">
-        <header class="chapter-header">
-            <p class="volume-title">Volume V: The Path to a Sustainable Future</p>
-            <p class="part-title">Part XVI: The Road Ahead</p>
-            <h1>Chapter 40: Bitcoin's Monetary Future</h1>
-            <p class="subtitle">From Digital Curiosity to Global Reserve Asset</p>
-        </header>
+    <header class="chapter-header">
+        <p class="chapter-number">Chapter 40</p>
+        <h1 class="chapter-title">Bitcoin's Monetary Future</h1>
+        <p class="chapter-subtitle">From Digital Curiosity to Global Reserve Asset</p>
+        <p class="chapter-epigraph">
+            "It might make sense just to get some in case it catches on. If enough people
+            think the same way, that becomes a self-fulfilling prophecy."
+            <br>&mdash; Satoshi Nakamoto, January 17, 2009
+        </p>
+    </header>
 
-        <blockquote class="chapter-quote">
-            "It might make sense just to get some in case it catches on. If enough people think the same way, that becomes a self-fulfilling prophecy."
-            <cite>— Satoshi Nakamoto, January 17, 2009</cite>
-        </blockquote>
+    <main class="chapter-content">
+        <section>
+            <p class="chapter-intro">
+                More than fifteen years after its creation, Bitcoin has exceeded nearly every
+                early expectation&mdash;yet its ultimate role in the global monetary system remains
+                undefined. Is Bitcoin digital gold? A global settlement layer? An alternative
+                reserve currency? The base money of a new financial system? This final chapter
+                examines Bitcoin's potential futures: the scenarios, the obstacles, the game
+                theory of adoption, and the implications if Bitcoin achieves its maximum
+                potential. Bitcoin is not just a new payment technology&mdash;it is a potential
+                transformation of money itself. The outcomes range from irrelevance to the most
+                significant monetary change since the end of the gold standard. Much of this
+                chapter is necessarily speculative; speculative claims are confined to clearly
+                labeled scenario definitions and remarks, never stated as theorems.
+            </p>
+        </section>
 
-        <section id="introduction">
-            <h2>The Unfinished Revolution</h2>
+        <section>
+            <h2>40.1 The Evolution of Money</h2>
 
-            <p>More than fifteen years after its creation, Bitcoin has exceeded nearly every early expectation—yet its ultimate role in the global monetary system remains undefined. Is Bitcoin digital gold? A global settlement layer? An alternative reserve currency? The base money of a new financial system?</p>
+            <div class="definition">
+                <p class="definition-title">Definition 40.1 (Monetary Eras)</p>
+                <p>
+                    The history of money divides into four broad eras, each characterized by
+                    distinct monetary properties:
+                </p>
+                <ol>
+                    <li><strong>Commodity money</strong> (ancient &ndash; 1971): shells, cattle, salt,
+                    and metals; the gold standard peaked from 1870&ndash;1914, followed by the
+                    Bretton Woods system (1944&ndash;1971). Properties: scarce, durable, divisible,
+                    portable.</li>
+                    <li><strong>Fiat currency</strong> (1971 &ndash; present): the Nixon shock ended
+                    gold convertibility, replaced by central bank management and floating
+                    exchange rates. Properties: elastic supply, political control.</li>
+                    <li><strong>Digital fiat</strong> (1990s &ndash; present): electronic banking,
+                    credit cards, ACH, SWIFT, and central bank digital currencies (CBDCs).
+                    Properties: convenient, surveilled, controllable.</li>
+                    <li><strong>Bitcoin</strong> (2009 &ndash; future?): programmable scarcity,
+                    decentralized issuance, permissionless access. Properties: fixed supply,
+                    censorship-resistant, borderless.</li>
+                </ol>
+            </div>
 
-            <p>This final chapter explores Bitcoin's potential futures: the scenarios, the obstacles, the game theory of adoption, and the profound implications for human civilization if Bitcoin achieves its maximum potential.</p>
-
-            <div class="key-concept">
-                <h3>The Stakes</h3>
-                <p>Bitcoin isn't just a new payment technology—it's a potential transformation of money itself. The outcomes range from irrelevance to the most significant monetary change since the end of the gold standard. Understanding these possibilities is essential for navigating the decades ahead.</p>
+            <div class="example">
+                <p class="example-title">Example 40.1 (Monetary Problems and Bitcoin's Responses)</p>
+                <p>
+                    Bitcoin addresses fundamental issues with existing monetary systems:
+                </p>
+                <table class="data-table">
+                    <thead>
+                        <tr>
+                            <th>Problem</th>
+                            <th>Fiat Status Quo</th>
+                            <th>Bitcoin Solution</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>Inflation</td>
+                            <td>2-10%+ annual debasement</td>
+                            <td>Fixed 21M supply cap</td>
+                        </tr>
+                        <tr>
+                            <td>Censorship</td>
+                            <td>Accounts frozen, transactions blocked</td>
+                            <td>Permissionless transactions</td>
+                        </tr>
+                        <tr>
+                            <td>Seizure</td>
+                            <td>Assets confiscated by decree</td>
+                            <td>Self-custody with cryptography</td>
+                        </tr>
+                        <tr>
+                            <td>Border control</td>
+                            <td>Capital controls, reporting requirements</td>
+                            <td>Borderless by design</td>
+                        </tr>
+                        <tr>
+                            <td>Counterparty risk</td>
+                            <td>Bank failures, bail-ins</td>
+                            <td>Bearer asset, no intermediary</td>
+                        </tr>
+                        <tr>
+                            <td>Settlement speed</td>
+                            <td>Days for international transfers</td>
+                            <td>~1 hour (6 confirmations) vs days for wires</td>
+                        </tr>
+                    </tbody>
+                </table>
             </div>
         </section>
 
-        <section id="monetary-evolution">
-            <h2>The Evolution of Money</h2>
+        <section>
+            <h2>40.2 Stages of Adoption</h2>
 
-            <h3>Historical Progression</h3>
-
-            <p>Money has evolved through distinct phases:</p>
-
-            <div class="code-block">
-<pre>
-Monetary Evolution:
-
-1. Commodity Money (ancient - 1971)
-   ├── Shells, cattle, salt, metals
-   ├── Gold standard peak (1870-1914)
-   ├── Bretton Woods (1944-1971)
-   └── Properties: Scarce, durable, divisible, portable
-
-2. Fiat Currency (1971 - present)
-   ├── Nixon shock ends gold convertibility
-   ├── Central bank management
-   ├── Floating exchange rates
-   └── Properties: Elastic supply, political control
-
-3. Digital Fiat (1990s - present)
-   ├── Electronic banking
-   ├── Credit cards, ACH, SWIFT
-   ├── Central bank digital currencies (CBDCs)
-   └── Properties: Convenient, surveilled, controllable
-
-4. Bitcoin (2009 - future?)
-   ├── Programmable scarcity
-   ├── Decentralized issuance
-   ├── Permissionless access
-   └── Properties: Fixed supply, censorship-resistant, borderless
-</pre>
+            <div class="definition">
+                <p class="definition-title">Definition 40.2 (Adoption S-Curve)</p>
+                <p>
+                    The <strong>adoption S-curve</strong> is the standard model of technology
+                    diffusion: adoption grows slowly among innovators, accelerates through early
+                    adopters and the early majority, then saturates among the late majority and
+                    laggards. Applied to Bitcoin, the model partitions adopters into five stages
+                    by period, user base, and price regime.
+                </p>
             </div>
 
-            <h3>What Problem Does Bitcoin Solve?</h3>
-
-            <p>Bitcoin addresses fundamental issues with existing monetary systems:</p>
-
-            <table class="data-table">
-                <thead>
-                    <tr>
-                        <th>Problem</th>
-                        <th>Fiat Status Quo</th>
-                        <th>Bitcoin Solution</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr>
-                        <td>Inflation</td>
-                        <td>2-10%+ annual debasement</td>
-                        <td>Fixed 21M supply cap</td>
-                    </tr>
-                    <tr>
-                        <td>Censorship</td>
-                        <td>Accounts frozen, transactions blocked</td>
-                        <td>Permissionless transactions</td>
-                    </tr>
-                    <tr>
-                        <td>Seizure</td>
-                        <td>Assets confiscated by decree</td>
-                        <td>Self-custody with cryptography</td>
-                    </tr>
-                    <tr>
-                        <td>Border control</td>
-                        <td>Capital controls, reporting requirements</td>
-                        <td>Borderless by design</td>
-                    </tr>
-                    <tr>
-                        <td>Counterparty risk</td>
-                        <td>Bank failures, bail-ins</td>
-                        <td>Bearer asset, no intermediary</td>
-                    </tr>
-                    <tr>
-                        <td>Settlement speed</td>
-                        <td>Days for international transfers</td>
-                        <td>~1 hour (6 confirmations) vs days for wires</td>
-                    </tr>
-                </tbody>
-            </table>
-        </section>
-
-        <section id="adoption-stages">
-            <h2>Stages of Adoption</h2>
-
-            <h3>The S-Curve Model</h3>
-
-            <p>Technology adoption typically follows an S-curve pattern:</p>
-
-            <div class="code-block">
-<pre>
-Bitcoin Adoption Stages:
-
-Stage 1: Innovators (2009-2012)
-├── Cypherpunks, cryptographers
-├── Ideological early adopters
-├── Price: $0 → $12
-└── Users: Thousands
-
-Stage 2: Early Adopters (2012-2017)
-├── Tech-savvy investors
-├── First exchanges, services
-├── Price: $12 → $1,000
-└── Users: Millions
-
-Stage 3: Early Majority (2017-2024)
-├── Retail speculation
-├── Institutional exploration
-├── Price: $1,000 → $70,000+
-└── Users: Tens of millions
-
-Stage 4: Late Majority (2024-2030?)
-├── Corporate treasury adoption
-├── Nation-state reserves
-├── ETFs, pension funds
-└── Users: Hundreds of millions
-
-Stage 5: Laggards (2030+?)
-├── Universal acceptance
-├── Unit of account
-├── Reserve currency
-└── Users: Billions
-</pre>
+            <div class="example">
+                <p class="example-title">Example 40.2 (Bitcoin's Adoption Stages)</p>
+                <table class="data-table">
+                    <thead>
+                        <tr>
+                            <th>Stage</th>
+                            <th>Period</th>
+                            <th>Adopters</th>
+                            <th>Price</th>
+                            <th>Users</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>1. Innovators</td>
+                            <td>2009-2012</td>
+                            <td>Cypherpunks, cryptographers, ideological early adopters</td>
+                            <td>$0 &rarr; $12</td>
+                            <td>Thousands</td>
+                        </tr>
+                        <tr>
+                            <td>2. Early Adopters</td>
+                            <td>2012-2017</td>
+                            <td>Tech-savvy investors; first exchanges and services</td>
+                            <td>$12 &rarr; $1,000</td>
+                            <td>Millions</td>
+                        </tr>
+                        <tr>
+                            <td>3. Early Majority</td>
+                            <td>2017-2024</td>
+                            <td>Retail speculation, institutional exploration</td>
+                            <td>$1,000 &rarr; $70,000+</td>
+                            <td>Tens of millions</td>
+                        </tr>
+                        <tr>
+                            <td>4. Late Majority</td>
+                            <td>2024-2030?</td>
+                            <td>Corporate treasuries, nation-state reserves, ETFs, pension funds</td>
+                            <td>&mdash;</td>
+                            <td>Hundreds of millions</td>
+                        </tr>
+                        <tr>
+                            <td>5. Laggards</td>
+                            <td>2030+?</td>
+                            <td>Universal acceptance, unit of account, reserve currency</td>
+                            <td>&mdash;</td>
+                            <td>Billions</td>
+                        </tr>
+                    </tbody>
+                </table>
             </div>
 
-            <h3>Current Position</h3>
-
-            <p>As of the mid-2020s, Bitcoin appears to be transitioning from Early Majority to Late Majority:</p>
-
-            <ul>
-                <li><strong>Spot ETFs approved:</strong> Institutional access simplified</li>
-                <li><strong>Corporate holdings:</strong> MicroStrategy, Tesla, others</li>
-                <li><strong>Nation-state adoption:</strong> El Salvador (legal tender 2021&ndash;2025, now voluntary)</li>
-                <li><strong>Market cap:</strong> ~$2 trillion (top 10 global assets)</li>
-                <li><strong>Network effects:</strong> Self-reinforcing adoption dynamics</li>
-            </ul>
-        </section>
-
-        <section id="nation-state-game-theory">
-            <h2>Nation-State Game Theory</h2>
-
-            <h3>A Coordination Game</h3>
-
-            <p>Nations face a coordination problem regarding Bitcoin&mdash;a stag hunt with multiple equilibria rather than a prisoner's dilemma (compare the Schelling-point analysis of Example 26.2):</p>
-
-            <div class="code-block">
-<pre>
-Nation-State Bitcoin Game:
-
-If ALL nations reject Bitcoin:
-├── Status quo maintained
-├── Dollar hegemony continues
-└── No nation gains/loses from BTC
-
-If SOME nations adopt while others reject:
-├── Adopters gain if BTC succeeds
-├── Adopters lose if BTC fails
-├── Rejecters lose if BTC succeeds
-└── First-mover advantage significant
-
-If ALL nations adopt Bitcoin:
-├── New monetary order
-├── Early adopters benefit most
-├── Late adopters pay premium
-└── No nation can stop it
-
-Hedging / First-Mover Logic (no dominant strategy exists):
-├── If neighbors might adopt → consider adopting
-├── If BTC might succeed → early adoption advantageous
-├── Waiting has opportunity cost
-└── A small allocation is a cheap hedge against the adoption equilibrium
-</pre>
-            </div>
-
-            <h3>Strategic Reserve Asset</h3>
-
-            <p>The case for Bitcoin in sovereign reserves:</p>
-
-            <table class="data-table">
-                <thead>
-                    <tr>
-                        <th>Consideration</th>
-                        <th>For Bitcoin</th>
-                        <th>Against Bitcoin</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr>
-                        <td>Sanction resistance</td>
-                        <td>Cannot be frozen by adversaries</td>
-                        <td>May invite sanctions for holding</td>
-                    </tr>
-                    <tr>
-                        <td>Diversification</td>
-                        <td>Non-correlated with traditional assets</td>
-                        <td>Highly volatile</td>
-                    </tr>
-                    <tr>
-                        <td>Settlement</td>
-                        <td>Direct, no intermediary risk</td>
-                        <td>Limited throughput</td>
-                    </tr>
-                    <tr>
-                        <td>Scarcity</td>
-                        <td>Cannot be inflated</td>
-                        <td>Cannot be expanded in crisis</td>
-                    </tr>
-                    <tr>
-                        <td>Sovereignty</td>
-                        <td>No issuer to impose conditions</td>
-                        <td>Rules cannot be changed if needed</td>
-                    </tr>
-                </tbody>
-            </table>
-
-            <h3>The Tipping Point</h3>
-
-            <div class="key-concept">
-                <h3>When Does FOMO Start?</h3>
-                <p>If one major economy adds Bitcoin to reserves, others face pressure to follow. The first major central bank (Fed, ECB, PBoC, BoJ) to accumulate Bitcoin could trigger a cascade of sovereign adoption—dramatically impacting price and legitimacy.</p>
+            <div class="remark">
+                <p class="remark-title">Remark 40.1 (Current Position)</p>
+                <p>
+                    As of the mid-2020s, Bitcoin appears to be transitioning from Early Majority
+                    to Late Majority:
+                </p>
+                <ul>
+                    <li><strong>Spot ETFs approved:</strong> Institutional access simplified</li>
+                    <li><strong>Corporate holdings:</strong> MicroStrategy, Tesla, others</li>
+                    <li><strong>Nation-state adoption:</strong> El Salvador (legal tender 2021&ndash;2025, now voluntary)</li>
+                    <li><strong>Market cap:</strong> ~$2 trillion (top 10 global assets)</li>
+                    <li><strong>Network effects:</strong> Self-reinforcing adoption dynamics</li>
+                </ul>
             </div>
         </section>
 
-        <section id="scenarios">
-            <h2>Future Scenarios</h2>
+        <section>
+            <h2>40.3 Nation-State Game Theory</h2>
 
-            <h3>Scenario 1: Digital Gold (High Probability)</h3>
-
-            <p>Bitcoin becomes a widely-held store of value alongside gold:</p>
-
-            <div class="code-block">
-<pre>
-Digital Gold Scenario:
-
-Market Position:
-├── 10-40% of gold's market cap of ~$15T ($1.5-6 trillion)
-├── Held by 5-10% of global population
-├── In 10-20% of investment portfolios
-└── Price: $75,000-300,000 per BTC
-
-Characteristics:
-├── Store of value, not medium of exchange
-├── "Digital property" narrative dominates
-├── Coexists with fiat currencies
-├── Limited payment usage (high-value settlement)
-└── Lightning Network for smaller transactions
-
-Implications:
-├── Wealth preservation tool
-├── Portfolio diversification asset
-├── Not disruptive to existing monetary order
-└── Fiat inflation continues, Bitcoin holders protected
-</pre>
+            <div class="definition">
+                <p class="definition-title">Definition 40.3 (Nation-State Adoption Game)</p>
+                <p>
+                    The <strong>nation-state adoption game</strong> models national Bitcoin policy
+                    as a coordination game&mdash;a stag hunt with multiple equilibria rather than a
+                    prisoner's dilemma (compare the Schelling-point analysis of Example 26.2).
+                    The payoff structure has three regimes:
+                </p>
+                <ul>
+                    <li><strong>All nations reject:</strong> the status quo is maintained, dollar
+                    hegemony continues, and no nation gains or loses from Bitcoin.</li>
+                    <li><strong>Some adopt while others reject:</strong> adopters gain if Bitcoin
+                    succeeds and lose if it fails; rejecters lose if Bitcoin succeeds. The
+                    first-mover advantage is significant.</li>
+                    <li><strong>All nations adopt:</strong> a new monetary order emerges; early
+                    adopters benefit most, late adopters pay a premium, and no nation can stop it.</li>
+                </ul>
             </div>
 
-            <h3>Scenario 2: Global Reserve Asset (Medium Probability)</h3>
-
-            <p>Bitcoin joins or replaces gold in central bank reserves:</p>
-
-            <div class="code-block">
-<pre>
-Reserve Asset Scenario:
-
-Market Position:
-├── Equal to or greater than gold (~$15 trillion)
-├── Held by majority of central banks
-├── Strategic reserve for nations
-└── Price: $700,000-1,500,000 per BTC
-
-Characteristics:
-├── Settlement layer for international trade
-├── Neutral asset for adversarial nations
-├── Backing for fiat currencies (partial)
-├── Reduced dollar hegemony
-└── New Bretton Woods-style arrangements
-
-Implications:
-├── Fundamental shift in monetary order
-├── Reduced US exorbitant privilege
-├── Increased financial sovereignty for small nations
-├── More multipolar monetary system
-</pre>
+            <div class="remark">
+                <p class="remark-title">Remark 40.2 (Hedging Logic)</p>
+                <p>
+                    No dominant strategy exists in the adoption game, so each nation's best
+                    response depends on its beliefs about others:
+                </p>
+                <ul>
+                    <li>If neighbors might adopt &rarr; consider adopting</li>
+                    <li>If Bitcoin might succeed &rarr; early adoption is advantageous</li>
+                    <li>Waiting has opportunity cost</li>
+                    <li>A small allocation is a cheap hedge against the adoption equilibrium</li>
+                </ul>
             </div>
 
-            <h3>Scenario 3: Global Base Money (Low-Medium Probability)</h3>
-
-            <p>Bitcoin becomes the primary global unit of account:</p>
-
-            <div class="code-block">
-<pre>
-Base Money Scenario:
-
-Market Position:
-├── Majority of global monetary base
-├── Universal unit of account
-├── Primary settlement for all trade
-└── Price: Measured in satoshis, not dollars
-
-Characteristics:
-├── Prices quoted in BTC/sats globally
-├── Fiat currencies pegged to Bitcoin
-├── Central banks manage BTC-backed currencies
-├── Layer 2 handles all daily transactions
-└── Layer 1 for final settlement only
-
-Implications:
-├── End of fiat monetary era
-├── Deflationary pressure (falling prices)
-├── Reduced credit expansion capability
-├── Fundamental economic restructuring
-├── Unknown social/political consequences
-</pre>
+            <div class="example">
+                <p class="example-title">Example 40.3 (Strategic Reserve Considerations)</p>
+                <p>
+                    The case for and against Bitcoin in sovereign reserves:
+                </p>
+                <table class="data-table">
+                    <thead>
+                        <tr>
+                            <th>Consideration</th>
+                            <th>For Bitcoin</th>
+                            <th>Against Bitcoin</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>Sanction resistance</td>
+                            <td>Cannot be frozen by adversaries</td>
+                            <td>May invite sanctions for holding</td>
+                        </tr>
+                        <tr>
+                            <td>Diversification</td>
+                            <td>Non-correlated with traditional assets</td>
+                            <td>Highly volatile</td>
+                        </tr>
+                        <tr>
+                            <td>Settlement</td>
+                            <td>Direct, no intermediary risk</td>
+                            <td>Limited throughput</td>
+                        </tr>
+                        <tr>
+                            <td>Scarcity</td>
+                            <td>Cannot be inflated</td>
+                            <td>Cannot be expanded in crisis</td>
+                        </tr>
+                        <tr>
+                            <td>Sovereignty</td>
+                            <td>No issuer to impose conditions</td>
+                            <td>Rules cannot be changed if needed</td>
+                        </tr>
+                    </tbody>
+                </table>
             </div>
 
-            <h3>Scenario 4: Niche/Failure (Low Probability)</h3>
-
-            <p>Bitcoin remains marginal or declines:</p>
-
-            <div class="code-block">
-<pre>
-Failure Scenario:
-
-Possible Causes:
-├── Catastrophic bug/exploit discovered
-├── Quantum computing breaks ECDSA (no migration)
-├── Coordinated global ban (enforced)
-├── Superior technology replaces it
-├── Internal governance failure
-└── Fee market collapse, security degradation
-
-Market Position:
-├── <$100 billion market cap
-├── Limited to ideological users
-├── No mainstream adoption
-└── Viewed as failed experiment
-
-Probability Assessment:
-├── 15+ years of resilience argues against
-├── Network effects provide stability
-├── No superior alternative has emerged
-├── Global ban coordination unlikely
-└── Estimated probability: <10%
-</pre>
+            <div class="remark">
+                <p class="remark-title">Remark 40.3 (The Tipping Point)</p>
+                <p>
+                    If one major economy adds Bitcoin to its reserves, others face pressure to
+                    follow. The first major central bank (Fed, ECB, PBoC, BoJ) to accumulate
+                    Bitcoin could trigger a cascade of sovereign adoption&mdash;dramatically
+                    impacting price and legitimacy.
+                </p>
             </div>
         </section>
 
-        <section id="hyperbitcoinization">
-            <h2>Hyperbitcoinization</h2>
+        <section>
+            <h2>40.4 Future Scenarios</h2>
 
-            <h3>The Concept</h3>
+            <p>
+                Where a scenario states a price range, the arithmetic is the simple identity
+            </p>
+            <p class="math-block">
+                price = market capitalization / circulating supply,
+            </p>
+            <p>
+                evaluated at a round circulating supply of roughly 20 million BTC.
+            </p>
 
-            <p>Hyperbitcoinization describes the theoretical tipping point where Bitcoin becomes the dominant global currency:</p>
-
-            <div class="key-concept">
-                <h3>Definition</h3>
-                <p>"Hyperbitcoinization is the point at which Bitcoin becomes the default value system of the world—not through force, but through voluntary adoption driven by superior monetary properties."</p>
+            <div class="definition">
+                <p class="definition-title">Definition 40.4 (Scenario: Digital Gold)</p>
+                <p>
+                    In the <strong>digital gold scenario</strong> (high probability), Bitcoin
+                    becomes a widely-held store of value alongside gold:
+                </p>
+                <ul>
+                    <li><strong>Market position:</strong> 10-40% of gold's market cap of ~$15T
+                    ($1.5-6 trillion); held by 5-10% of the global population; in 10-20% of
+                    investment portfolios; price $75,000-300,000 per BTC.</li>
+                    <li><strong>Characteristics:</strong> store of value rather than medium of
+                    exchange; the "digital property" narrative dominates; coexistence with fiat
+                    currencies; limited payment usage (high-value settlement), with the Lightning
+                    Network for smaller transactions.</li>
+                    <li><strong>Implications:</strong> wealth preservation tool and portfolio
+                    diversification asset; not disruptive to the existing monetary order; fiat
+                    inflation continues while Bitcoin holders are protected.</li>
+                </ul>
             </div>
 
-            <h3>Potential Triggers</h3>
-
-            <ol>
-                <li><strong>Fiat currency crisis:</strong> Major currency hyperinflation drives adoption</li>
-                <li><strong>Sovereign default cascade:</strong> Trust in government money collapses</li>
-                <li><strong>Weaponized dollar:</strong> Overuse of sanctions drives alternatives</li>
-                <li><strong>Institutional stampede:</strong> FOMO among pension funds, sovereign wealth</li>
-                <li><strong>Technological tipping point:</strong> UX reaches mass-market readiness</li>
-            </ol>
-
-            <h3>How It Might Unfold</h3>
-
-            <div class="code-block">
-<pre>
-Hyperbitcoinization Process:
-
-Phase 1: Speculative Store of Value
-├── Current state
-├── HODLers accumulate
-├── Volatility decreases over time
-└── Institutional adoption grows
-
-Phase 2: Treasury Reserve Asset
-├── Companies hold BTC
-├── Nations add to reserves
-├── Legitimacy established
-└── Infrastructure matures
-
-Phase 3: Medium of Exchange
-├── Lightning adoption scales
-├── Commerce integration
-├── Salary payments begin
-└── Dual pricing (fiat + BTC)
-
-Phase 4: Unit of Account
-├── Prices quoted in sats
-├── Fiat prices derived from BTC
-├── Accounting standards adapt
-└── Mental shift: BTC is "real money"
-
-Phase 5: Base Money Layer
-├── Settlement for all global trade
-├── Fiat currencies as stablecoins on BTC
-├── Central banks as BTC custodians
-└── New monetary order established
-</pre>
+            <div class="example">
+                <p class="example-title">Example 40.4 (Implied Price: Digital Gold)</p>
+                <p>
+                    At 10% of gold's market cap and a ~20 million BTC supply:
+                </p>
+                <p class="math-block">
+                    price = $1.5 trillion / 20,000,000 BTC = $75,000 per BTC.
+                </p>
+                <p>
+                    At 40% of gold's market cap:
+                </p>
+                <p class="math-block">
+                    price = $6 trillion / 20,000,000 BTC = $300,000 per BTC.
+                </p>
             </div>
-        </section>
 
-        <section id="economic-implications">
-            <h2>Economic Implications</h2>
+            <div class="definition">
+                <p class="definition-title">Definition 40.5 (Scenario: Global Reserve Asset)</p>
+                <p>
+                    In the <strong>global reserve asset scenario</strong> (medium probability),
+                    Bitcoin joins or replaces gold in central bank reserves:
+                </p>
+                <ul>
+                    <li><strong>Market position:</strong> market cap equal to or greater than
+                    gold (~$15 trillion); held by a majority of central banks; a strategic
+                    reserve for nations; price $700,000-1,500,000 per BTC.</li>
+                    <li><strong>Characteristics:</strong> settlement layer for international
+                    trade; a neutral asset for adversarial nations; partial backing for fiat
+                    currencies; reduced dollar hegemony; new Bretton Woods-style arrangements.</li>
+                    <li><strong>Implications:</strong> a fundamental shift in the monetary order;
+                    reduced US exorbitant privilege; increased financial sovereignty for small
+                    nations; a more multipolar monetary system.</li>
+                </ul>
+            </div>
 
-            <h3>A Deflationary Standard</h3>
+            <div class="example">
+                <p class="example-title">Example 40.5 (Implied Price: Reserve Asset)</p>
+                <p>
+                    At gold parity and a ~20 million BTC supply:
+                </p>
+                <p class="math-block">
+                    price = $15 trillion / 20,000,000 BTC = $750,000 per BTC,
+                </p>
+                <p>
+                    at the lower end of the scenario's $700,000-1,500,000 range; market caps up
+                    to roughly $30 trillion correspond to the upper end.
+                </p>
+            </div>
 
-            <p>If Bitcoin becomes dominant, its fixed supply creates a naturally deflationary environment:</p>
+            <div class="definition">
+                <p class="definition-title">Definition 40.6 (Scenario: Global Base Money)</p>
+                <p>
+                    In the <strong>global base money scenario</strong> (low-medium probability),
+                    Bitcoin becomes the primary global unit of account:
+                </p>
+                <ul>
+                    <li><strong>Market position:</strong> the majority of the global monetary
+                    base; universal unit of account; primary settlement for all trade; price
+                    measured in satoshis, not dollars.</li>
+                    <li><strong>Characteristics:</strong> prices quoted in BTC/sats globally;
+                    fiat currencies pegged to Bitcoin; central banks manage BTC-backed
+                    currencies; Layer 2 handles all daily transactions; Layer 1 for final
+                    settlement only.</li>
+                    <li><strong>Implications:</strong> end of the fiat monetary era; deflationary
+                    pressure (falling prices); reduced credit expansion capability; fundamental
+                    economic restructuring; unknown social and political consequences.</li>
+                </ul>
+            </div>
 
-            <table class="data-table">
-                <thead>
-                    <tr>
-                        <th>Characteristic</th>
-                        <th>Inflationary Fiat</th>
-                        <th>Bitcoin Standard</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr>
-                        <td>Purchasing power</td>
-                        <td>Decreases over time</td>
-                        <td>Increases over time</td>
-                    </tr>
-                    <tr>
-                        <td>Saving incentive</td>
-                        <td>Discouraged (invest or lose)</td>
-                        <td>Encouraged (value preserved)</td>
-                    </tr>
-                    <tr>
-                        <td>Time preference</td>
-                        <td>High (spend now)</td>
-                        <td>Low (save for future)</td>
-                    </tr>
-                    <tr>
-                        <td>Debt dynamics</td>
-                        <td>Debt inflated away</td>
-                        <td>Debt becomes heavier</td>
-                    </tr>
-                    <tr>
-                        <td>Price signals</td>
-                        <td>Distorted by inflation</td>
-                        <td>Clear, stable measurement</td>
-                    </tr>
-                    <tr>
-                        <td>Capital allocation</td>
-                        <td>Favors debtors</td>
-                        <td>Favors savers</td>
-                    </tr>
-                </tbody>
-            </table>
+            <div class="definition">
+                <p class="definition-title">Definition 40.7 (Scenario: Niche or Failure)</p>
+                <p>
+                    In the <strong>failure scenario</strong> (low probability), Bitcoin remains
+                    marginal or declines. Possible causes:
+                </p>
+                <ul>
+                    <li>Catastrophic bug or exploit discovered</li>
+                    <li>Quantum computing breaks ECDSA (no migration)</li>
+                    <li>Coordinated global ban (enforced)</li>
+                    <li>Superior technology replaces it</li>
+                    <li>Internal governance failure</li>
+                    <li>Fee market collapse, security degradation</li>
+                </ul>
+                <p>
+                    Market position: market cap below $100 billion, limited to ideological users,
+                    no mainstream adoption, viewed as a failed experiment.
+                </p>
+            </div>
 
-            <h3>The Deflation Debate</h3>
-
-            <p>Critics argue deflation is dangerous:</p>
-
-            <ul>
-                <li><strong>Debt deflation spiral:</strong> Falling prices increase real debt burden</li>
-                <li><strong>Delayed consumption:</strong> Why buy today if cheaper tomorrow?</li>
-                <li><strong>Wage stickiness:</strong> Nominal wage cuts are psychologically difficult</li>
-            </ul>
-
-            <p>Proponents counter:</p>
-
-            <ul>
-                <li><strong>Productivity deflation:</strong> Falling prices from efficiency gains are healthy</li>
-                <li><strong>Low time preference:</strong> Encourages sustainable investment</li>
-                <li><strong>Historical examples:</strong> 19th century gold standard saw growth with mild deflation</li>
-                <li><strong>Technology prices:</strong> Computers get cheaper; people still buy them</li>
-            </ul>
-
-            <h3>Credit and Banking</h3>
-
-            <p>A Bitcoin standard would transform banking:</p>
-
-            <div class="code-block">
-<pre>
-Banking Under Bitcoin Standard:
-
-Traditional Fractional Reserve:
-├── Banks create money through lending
-├── Central bank as lender of last resort
-├── Deposit insurance backstops runs
-└── Money supply expands with credit
-
-Bitcoin Native Banking:
-├── Full reserve custody (no money creation)
-├── Credit still possible (term-matched loans)
-├── No lender of last resort for BTC
-├── Bank runs possible if fractional reserve attempted
-└── Higher lending rates, lower leverage
-
-Likely Hybrid:
-├── Bitcoin-backed fiat currencies
-├── Central banks hold BTC reserves
-├── Fractional reserve on fiat layer
-├── Bitcoin as final settlement asset
-└── Similar to gold standard historically
-</pre>
+            <div class="remark">
+                <p class="remark-title">Remark 40.4 (Probability Assessment)</p>
+                <p>
+                    Several considerations argue against the failure scenario: 15+ years of
+                    resilience, network effects that provide stability, the absence of any
+                    superior alternative, and the unlikelihood of coordinated global ban
+                    enforcement. Estimated probability: below 10%.
+                </p>
             </div>
         </section>
 
-        <section id="social-political">
-            <h2>Social and Political Implications</h2>
+        <section>
+            <h2>40.5 Hyperbitcoinization</h2>
 
-            <h3>Separation of Money and State</h3>
-
-            <p>Bitcoin potentially represents a historic separation:</p>
-
-            <div class="key-concept">
-                <h3>The Monetary Reformation</h3>
-                <p>Just as separation of church and state limited religious authority, separation of money and state could limit monetary authority. Governments would lose the ability to print money, fundamentally constraining fiscal policy.</p>
+            <div class="definition">
+                <p class="definition-title">Definition 40.8 (Hyperbitcoinization)</p>
+                <p>
+                    <strong>Hyperbitcoinization</strong> is the point at which Bitcoin becomes
+                    the default value system of the world&mdash;not through force, but through
+                    voluntary adoption driven by superior monetary properties.
+                </p>
             </div>
 
-            <h3>Winners and Losers</h3>
-
-            <table class="data-table">
-                <thead>
-                    <tr>
-                        <th>Group</th>
-                        <th>Bitcoin Advantage</th>
-                        <th>Bitcoin Disadvantage</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr>
-                        <td>Savers</td>
-                        <td>Wealth preserved from inflation</td>
-                        <td>Must learn new technology</td>
-                    </tr>
-                    <tr>
-                        <td>Debtors</td>
-                        <td>Discipline in borrowing</td>
-                        <td>Debt becomes heavier</td>
-                    </tr>
-                    <tr>
-                        <td>Governments</td>
-                        <td>Budget discipline enforced</td>
-                        <td>Lose monetary flexibility</td>
-                    </tr>
-                    <tr>
-                        <td>Banks</td>
-                        <td>Custody business opportunity</td>
-                        <td>Reduced lending profits</td>
-                    </tr>
-                    <tr>
-                        <td>Developing nations</td>
-                        <td>Escape currency manipulation</td>
-                        <td>Lose competitive devaluation</td>
-                    </tr>
-                    <tr>
-                        <td>Early adopters</td>
-                        <td>Significant wealth gain</td>
-                        <td>Social/political backlash</td>
-                    </tr>
-                </tbody>
-            </table>
-
-            <h3>Governance Challenges</h3>
-
-            <p>A Bitcoin-dominated monetary system raises questions:</p>
-
-            <ul>
-                <li><strong>Crisis response:</strong> How do governments stimulate during recessions?</li>
-                <li><strong>War financing:</strong> Can nations fund large-scale conflicts?</li>
-                <li><strong>Wealth inequality:</strong> Early adopters gain disproportionately</li>
-                <li><strong>Democratic control:</strong> Monetary policy becomes protocol rules</li>
-                <li><strong>Transition pain:</strong> Existing debts become harder to repay</li>
-            </ul>
-        </section>
-
-        <section id="challenges">
-            <h2>Challenges to Widespread Adoption</h2>
-
-            <h3>Technical Challenges</h3>
-
-            <ul>
-                <li><strong>Scalability:</strong> Layer 1 limited to ~500K tx/day; Layer 2 still maturing</li>
-                <li><strong>UX:</strong> Key management too complex for average users</li>
-                <li><strong>Quantum computing:</strong> Requires cryptographic migration</li>
-                <li><strong>Security budget:</strong> Long-term sustainability uncertain</li>
-            </ul>
-
-            <h3>Economic Challenges</h3>
-
-            <ul>
-                <li><strong>Volatility:</strong> Unsuitable for pricing until stability achieved</li>
-                <li><strong>Network effects:</strong> Incumbent currencies have strong inertia</li>
-                <li><strong>Transition costs:</strong> Switching from fiat is expensive/disruptive</li>
-                <li><strong>Credit contraction:</strong> Less money creation means less credit</li>
-            </ul>
-
-            <h3>Political Challenges</h3>
-
-            <ul>
-                <li><strong>Regulatory hostility:</strong> Governments may restrict use</li>
-                <li><strong>CBDCs:</strong> Competing government digital currencies</li>
-                <li><strong>Geopolitical:</strong> May trigger international conflict</li>
-                <li><strong>Vested interests:</strong> Current system benefits from status quo</li>
-            </ul>
-
-            <h3>Social Challenges</h3>
-
-            <ul>
-                <li><strong>Education:</strong> Most people don't understand money</li>
-                <li><strong>Trust:</strong> "Magic internet money" perception persists</li>
-                <li><strong>Custody:</strong> "Be your own bank" is burdensome</li>
-                <li><strong>Inequality:</strong> Early adopter wealth creates resentment</li>
-            </ul>
-        </section>
-
-        <section id="coexistence">
-            <h2>The Coexistence Model</h2>
-
-            <h3>Bitcoin Among Monies</h3>
-
-            <p>The most likely near-term outcome is coexistence:</p>
-
-            <div class="code-block">
-<pre>
-Multi-Money Future:
-
-Bitcoin:
-├── Global settlement layer
-├── Store of value / digital gold
-├── Reserve asset for institutions
-└── Censorship-resistant savings
-
-Stablecoins:
-├── Dollar/euro/etc. on blockchain
-├── Daily transactions
-├── Commerce and payments
-└── Regulatory compliance built-in
-
-CBDCs:
-├── Government digital currencies
-├── Programmable, surveillable
-├── Welfare, taxation, control
-└── Competition with private money
-
-Local Fiat:
-├── Traditional currencies persist
-├── Gradually Bitcoin-backed
-├── Legal tender for taxes
-└── Managed float against BTC
-</pre>
+            <div class="remark">
+                <p class="remark-title">Remark 40.5 (Potential Triggers)</p>
+                <ol>
+                    <li><strong>Fiat currency crisis:</strong> Major currency hyperinflation drives adoption</li>
+                    <li><strong>Sovereign default cascade:</strong> Trust in government money collapses</li>
+                    <li><strong>Weaponized dollar:</strong> Overuse of sanctions drives alternatives</li>
+                    <li><strong>Institutional stampede:</strong> FOMO among pension funds, sovereign wealth</li>
+                    <li><strong>Technological tipping point:</strong> UX reaches mass-market readiness</li>
+                </ol>
             </div>
 
-            <h3>The Layer Model</h3>
-
-            <div class="code-block">
-<pre>
-Monetary System Layers:
-
-Layer 1: Bitcoin base layer
-├── Final settlement
-├── Maximum security
-├── Minimum throughput
-└── Reserve asset status
-
-Layer 2: Lightning / State channels
-├── Fast payments
-├── Low fees
-├── BTC-denominated
-└── Self-custodial option
-
-Layer 3: Bitcoin banks / Custodians
-├── Fractional reserve possible
-├── Traditional banking services
-├── Regulated, insured
-└── Trade-off: convenience vs sovereignty
-
-Layer 4: Fiat / Stablecoins
-├── Unit of account for commerce
-├── Backed by BTC reserves
-├── Familiar user experience
-└── Bridge to legacy system
-</pre>
+            <div class="definition">
+                <p class="definition-title">Definition 40.9 (Hyperbitcoinization Phases)</p>
+                <p>
+                    A hypothetical hyperbitcoinization process proceeds in five phases:
+                </p>
+                <ol>
+                    <li><strong>Speculative store of value</strong> (the current state): holders
+                    accumulate, volatility decreases over time, institutional adoption grows.</li>
+                    <li><strong>Treasury reserve asset:</strong> companies hold BTC, nations add
+                    it to reserves, legitimacy is established, infrastructure matures.</li>
+                    <li><strong>Medium of exchange:</strong> Lightning adoption scales, commerce
+                    integrates, salary payments begin, dual pricing (fiat + BTC) appears.</li>
+                    <li><strong>Unit of account:</strong> prices are quoted in sats, fiat prices
+                    are derived from BTC, accounting standards adapt, and the mental shift
+                    completes: BTC is "real money".</li>
+                    <li><strong>Base money layer:</strong> settlement for all global trade; fiat
+                    currencies as stablecoins on BTC; central banks as BTC custodians; a new
+                    monetary order established.</li>
+                </ol>
             </div>
         </section>
 
-        <section id="timeline">
-            <h2>Potential Timeline</h2>
+        <section>
+            <h2>40.6 Economic Implications</h2>
 
-            <div class="code-block">
-<pre>
-Speculative Adoption Timeline:
-
-2024-2027: Institutional Foundation
-├── ETFs accumulate significant holdings
-├── More public companies add treasury BTC
-├── United States establishes Strategic Bitcoin Reserve (2025)
-├── Lightning Network reaches 10M+ users
-└── Price range: $50K-$200K
-
-2027-2032: Mainstream Legitimacy
-├── Multiple sovereign holders
-├── Pension fund allocations common
-├── Bitcoin savings accounts widespread
-├── Unit of account for some niches
-└── Price range: $200K-$1M
-
-2032-2040: Monetary Competition
-├── Bitcoin vs CBDC competition
-├── Some nations adopt BTC standard
-├── Fiat currencies weakened
-├── Layer 2 handles billions of users
-└── Price range: $500K-$5M
-
-2040+: New Monetary Order (if successful)
-├── Bitcoin as global reserve
-├── Fiat currencies pegged to BTC
-├── Price quoted in satoshis
-└── Generational wealth transfer complete
-</pre>
+            <div class="definition">
+                <p class="definition-title">Definition 40.10 (Deflationary Standard)</p>
+                <p>
+                    A <strong>deflationary standard</strong> is a monetary regime whose money
+                    supply is fixed while output grows, so that the general price level falls
+                    and purchasing power rises over time. If Bitcoin becomes dominant, its fixed
+                    supply creates such a regime:
+                </p>
+                <table class="data-table">
+                    <thead>
+                        <tr>
+                            <th>Characteristic</th>
+                            <th>Inflationary Fiat</th>
+                            <th>Bitcoin Standard</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>Purchasing power</td>
+                            <td>Decreases over time</td>
+                            <td>Increases over time</td>
+                        </tr>
+                        <tr>
+                            <td>Saving incentive</td>
+                            <td>Discouraged (invest or lose)</td>
+                            <td>Encouraged (value preserved)</td>
+                        </tr>
+                        <tr>
+                            <td>Time preference</td>
+                            <td>High (spend now)</td>
+                            <td>Low (save for future)</td>
+                        </tr>
+                        <tr>
+                            <td>Debt dynamics</td>
+                            <td>Debt inflated away</td>
+                            <td>Debt becomes heavier</td>
+                        </tr>
+                        <tr>
+                            <td>Price signals</td>
+                            <td>Distorted by inflation</td>
+                            <td>Clear, stable measurement</td>
+                        </tr>
+                        <tr>
+                            <td>Capital allocation</td>
+                            <td>Favors debtors</td>
+                            <td>Favors savers</td>
+                        </tr>
+                    </tbody>
+                </table>
             </div>
 
-            <div class="warning-box">
-                <h4>Uncertainty Acknowledgment</h4>
-                <p>These timelines are highly speculative. Bitcoin could achieve widespread adoption faster—or never achieve it at all. The future is inherently unpredictable, and this should inform investment and planning decisions.</p>
+            <div class="remark">
+                <p class="remark-title">Remark 40.6 (The Deflation Debate)</p>
+                <p>
+                    Critics argue deflation is dangerous:
+                </p>
+                <ul>
+                    <li><strong>Debt deflation spiral:</strong> Falling prices increase real debt burden</li>
+                    <li><strong>Delayed consumption:</strong> Why buy today if cheaper tomorrow?</li>
+                    <li><strong>Wage stickiness:</strong> Nominal wage cuts are psychologically difficult</li>
+                </ul>
+                <p>
+                    Proponents counter:
+                </p>
+                <ul>
+                    <li><strong>Productivity deflation:</strong> Falling prices from efficiency gains are healthy</li>
+                    <li><strong>Low time preference:</strong> Encourages sustainable investment</li>
+                    <li><strong>Historical examples:</strong> 19th century gold standard saw growth with mild deflation</li>
+                    <li><strong>Technology prices:</strong> Computers get cheaper; people still buy them</li>
+                </ul>
+            </div>
+
+            <div class="definition">
+                <p class="definition-title">Definition 40.11 (Banking Models Under a Bitcoin Standard)</p>
+                <p>
+                    Three banking models are relevant to a Bitcoin-dominated system:
+                </p>
+                <ul>
+                    <li><strong>Traditional fractional reserve:</strong> banks create money
+                    through lending; the central bank acts as lender of last resort; deposit
+                    insurance backstops runs; the money supply expands with credit.</li>
+                    <li><strong>Bitcoin-native banking:</strong> full reserve custody (no money
+                    creation); credit remains possible via term-matched loans; no lender of last
+                    resort for BTC; bank runs are possible if fractional reserve is attempted;
+                    higher lending rates and lower leverage.</li>
+                    <li><strong>Likely hybrid:</strong> Bitcoin-backed fiat currencies; central
+                    banks hold BTC reserves; fractional reserve on the fiat layer; Bitcoin as
+                    the final settlement asset&mdash;similar to the historical gold standard.</li>
+                </ul>
             </div>
         </section>
 
-        <section id="conclusion">
-            <h2>Conclusion: The Money of the Future</h2>
+        <section>
+            <h2>40.7 Social and Political Implications</h2>
 
-            <h3>What Bitcoin Represents</h3>
-
-            <p>Beyond technology or investment, Bitcoin represents an idea: that money can be a protocol rather than a privilege, that monetary policy can be algorithmic rather than political, and that individuals can have true financial sovereignty.</p>
-
-            <div class="key-concept">
-                <h3>The Fundamental Innovation</h3>
-                <p>Bitcoin's core innovation isn't blockchain technology—it's the creation of absolute digital scarcity. For the first time in history, we have a digital asset that cannot be copied, counterfeited, or inflated. This property, combined with decentralized consensus, creates a new form of money that could persist for generations.</p>
+            <div class="remark">
+                <p class="remark-title">Remark 40.7 (The Monetary Reformation)</p>
+                <p>
+                    Bitcoin potentially represents a historic separation of money and state.
+                    Just as separation of church and state limited religious authority,
+                    separation of money and state could limit monetary authority. Governments
+                    would lose the ability to print money, fundamentally constraining fiscal
+                    policy.
+                </p>
             </div>
 
-            <h3>The Path Forward</h3>
+            <div class="example">
+                <p class="example-title">Example 40.6 (Winners and Losers)</p>
+                <table class="data-table">
+                    <thead>
+                        <tr>
+                            <th>Group</th>
+                            <th>Bitcoin Advantage</th>
+                            <th>Bitcoin Disadvantage</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>Savers</td>
+                            <td>Wealth preserved from inflation</td>
+                            <td>Must learn new technology</td>
+                        </tr>
+                        <tr>
+                            <td>Debtors</td>
+                            <td>Discipline in borrowing</td>
+                            <td>Debt becomes heavier</td>
+                        </tr>
+                        <tr>
+                            <td>Governments</td>
+                            <td>Budget discipline enforced</td>
+                            <td>Lose monetary flexibility</td>
+                        </tr>
+                        <tr>
+                            <td>Banks</td>
+                            <td>Custody business opportunity</td>
+                            <td>Reduced lending profits</td>
+                        </tr>
+                        <tr>
+                            <td>Developing nations</td>
+                            <td>Escape currency manipulation</td>
+                            <td>Lose competitive devaluation</td>
+                        </tr>
+                        <tr>
+                            <td>Early adopters</td>
+                            <td>Significant wealth gain</td>
+                            <td>Social/political backlash</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
 
-            <p>Bitcoin's future depends on:</p>
+            <div class="remark">
+                <p class="remark-title">Remark 40.8 (Governance Challenges)</p>
+                <p>
+                    A Bitcoin-dominated monetary system raises questions:
+                </p>
+                <ul>
+                    <li><strong>Crisis response:</strong> How do governments stimulate during recessions?</li>
+                    <li><strong>War financing:</strong> Can nations fund large-scale conflicts?</li>
+                    <li><strong>Wealth inequality:</strong> Early adopters gain disproportionately</li>
+                    <li><strong>Democratic control:</strong> Monetary policy becomes protocol rules</li>
+                    <li><strong>Transition pain:</strong> Existing debts become harder to repay</li>
+                </ul>
+            </div>
+        </section>
 
+        <section>
+            <h2>40.8 Obstacles to Widespread Adoption</h2>
+
+            <div class="remark">
+                <p class="remark-title">Remark 40.9 (Technical and Economic Obstacles)</p>
+                <p>
+                    <strong>Technical:</strong>
+                </p>
+                <ul>
+                    <li><strong>Scalability:</strong> Layer 1 limited to ~500K tx/day; Layer 2 still maturing</li>
+                    <li><strong>UX:</strong> Key management too complex for average users</li>
+                    <li><strong>Quantum computing:</strong> Requires cryptographic migration</li>
+                    <li><strong>Security budget:</strong> Long-term sustainability uncertain</li>
+                </ul>
+                <p>
+                    <strong>Economic:</strong>
+                </p>
+                <ul>
+                    <li><strong>Volatility:</strong> Unsuitable for pricing until stability achieved</li>
+                    <li><strong>Network effects:</strong> Incumbent currencies have strong inertia</li>
+                    <li><strong>Transition costs:</strong> Switching from fiat is expensive/disruptive</li>
+                    <li><strong>Credit contraction:</strong> Less money creation means less credit</li>
+                </ul>
+            </div>
+
+            <div class="remark">
+                <p class="remark-title">Remark 40.10 (Political and Social Obstacles)</p>
+                <p>
+                    <strong>Political:</strong>
+                </p>
+                <ul>
+                    <li><strong>Regulatory hostility:</strong> Governments may restrict use</li>
+                    <li><strong>CBDCs:</strong> Competing government digital currencies</li>
+                    <li><strong>Geopolitical:</strong> May trigger international conflict</li>
+                    <li><strong>Vested interests:</strong> Current system benefits from status quo</li>
+                </ul>
+                <p>
+                    <strong>Social:</strong>
+                </p>
+                <ul>
+                    <li><strong>Education:</strong> Most people don't understand money</li>
+                    <li><strong>Trust:</strong> "Magic internet money" perception persists</li>
+                    <li><strong>Custody:</strong> "Be your own bank" is burdensome</li>
+                    <li><strong>Inequality:</strong> Early adopter wealth creates resentment</li>
+                </ul>
+            </div>
+        </section>
+
+        <section>
+            <h2>40.9 The Coexistence Model</h2>
+
+            <div class="definition">
+                <p class="definition-title">Definition 40.12 (Multi-Money Coexistence)</p>
+                <p>
+                    The <strong>coexistence model</strong>&mdash;the most likely near-term
+                    outcome&mdash;assigns complementary roles to several forms of money:
+                </p>
+                <ul>
+                    <li><strong>Bitcoin:</strong> global settlement layer; store of value /
+                    digital gold; reserve asset for institutions; censorship-resistant savings.</li>
+                    <li><strong>Stablecoins:</strong> dollar, euro, and other currencies on
+                    blockchains; daily transactions; commerce and payments; regulatory
+                    compliance built in.</li>
+                    <li><strong>CBDCs:</strong> government digital currencies; programmable and
+                    surveillable; welfare, taxation, control; competition with private money.</li>
+                    <li><strong>Local fiat:</strong> traditional currencies persist, gradually
+                    Bitcoin-backed; legal tender for taxes; managed float against BTC.</li>
+                </ul>
+            </div>
+
+            <div class="definition">
+                <p class="definition-title">Definition 40.13 (The Layer Model)</p>
+                <p>
+                    The <strong>layer model</strong> organizes a future monetary system into
+                    four layers, trading security for convenience as one moves up the stack:
+                </p>
+                <ul>
+                    <li><strong>Layer 1 &mdash; Bitcoin base layer:</strong> final settlement,
+                    maximum security, minimum throughput, reserve asset status.</li>
+                    <li><strong>Layer 2 &mdash; Lightning / state channels:</strong> fast
+                    payments, low fees, BTC-denominated, self-custodial option.</li>
+                    <li><strong>Layer 3 &mdash; Bitcoin banks / custodians:</strong> fractional
+                    reserve possible, traditional banking services, regulated and insured;
+                    trade-off: convenience vs sovereignty.</li>
+                    <li><strong>Layer 4 &mdash; Fiat / stablecoins:</strong> unit of account for
+                    commerce, backed by BTC reserves, familiar user experience, bridge to the
+                    legacy system.</li>
+                </ul>
+            </div>
+        </section>
+
+        <section>
+            <h2>40.10 A Speculative Timeline</h2>
+
+            <div class="remark">
+                <p class="remark-title">Remark 40.11 (Speculative Adoption Timeline)</p>
+                <ul>
+                    <li><strong>2024-2027 &mdash; Institutional foundation:</strong> ETFs
+                    accumulate significant holdings; more public companies add treasury BTC;
+                    the United States establishes a Strategic Bitcoin Reserve (2025); the
+                    Lightning Network reaches 10M+ users. Price range: $50K-$200K.</li>
+                    <li><strong>2027-2032 &mdash; Mainstream legitimacy:</strong> multiple
+                    sovereign holders; pension fund allocations common; Bitcoin savings accounts
+                    widespread; unit of account for some niches. Price range: $200K-$1M.</li>
+                    <li><strong>2032-2040 &mdash; Monetary competition:</strong> Bitcoin vs CBDC
+                    competition; some nations adopt a BTC standard; fiat currencies weakened;
+                    Layer 2 handles billions of users. Price range: $500K-$5M.</li>
+                    <li><strong>2040+ &mdash; New monetary order (if successful):</strong>
+                    Bitcoin as global reserve; fiat currencies pegged to BTC; prices quoted in
+                    satoshis; generational wealth transfer complete.</li>
+                </ul>
+            </div>
+
+            <div class="remark">
+                <p class="remark-title">Remark 40.12 (Uncertainty)</p>
+                <p>
+                    These timelines are highly speculative. Bitcoin could achieve widespread
+                    adoption faster&mdash;or never achieve it at all. The future is inherently
+                    unpredictable, and this should inform investment and planning decisions.
+                </p>
+            </div>
+        </section>
+
+        <section>
+            <h2>40.11 The Money of the Future</h2>
+
+            <p>
+                Beyond technology or investment, Bitcoin represents an idea: that money can be
+                a protocol rather than a privilege, that monetary policy can be algorithmic
+                rather than political, and that individuals can have true financial sovereignty.
+            </p>
+
+            <div class="remark">
+                <p class="remark-title">Remark 40.13 (Absolute Digital Scarcity)</p>
+                <p>
+                    Bitcoin's core innovation isn't blockchain technology&mdash;it's the creation
+                    of absolute digital scarcity. For the first time in history, we have a
+                    digital asset that cannot be copied, counterfeited, or inflated. This
+                    property, combined with decentralized consensus, creates a new form of money
+                    that could persist for generations.
+                </p>
+            </div>
+
+            <p>
+                Bitcoin's future depends on:
+            </p>
             <ol>
                 <li><strong>Technical evolution:</strong> Continued protocol development, Layer 2 maturation</li>
                 <li><strong>Economic resilience:</strong> Surviving market cycles, maintaining security budget</li>
@@ -793,45 +790,121 @@ Speculative Adoption Timeline:
                 <li><strong>Community cohesion:</strong> Maintaining consensus on core principles</li>
             </ol>
 
-            <h3>Final Thoughts</h3>
+            <p>
+                Bitcoin may ultimately succeed or fail. But it has already achieved something
+                remarkable: it has proven that decentralized digital money is possible. Whatever
+                happens to Bitcoin specifically, the genie cannot be put back in the bottle. The
+                idea of programmable, scarce, permissionless money will persist.
+            </p>
 
-            <p>Bitcoin may ultimately succeed or fail. But it has already achieved something remarkable: it has proven that decentralized digital money is possible. Whatever happens to Bitcoin specifically, the genie cannot be put back in the bottle. The idea of programmable, scarce, permissionless money will persist.</p>
+            <p>
+                For those who believe in this vision, the path forward is clear: continue
+                building, continue learning, continue advocating for financial sovereignty.
+                The monetary system of tomorrow will be shaped by the choices made today.
+            </p>
 
-            <p>For those who believe in this vision, the path forward is clear: continue building, continue learning, continue advocating for financial sovereignty. The monetary system of tomorrow will be shaped by the choices made today.</p>
-
-            <p>Whether Bitcoin becomes the foundation of a new global monetary order or remains a niche asset, it has already changed how we think about money. That intellectual revolution—the recognition that money itself can be reimagined—may prove to be Bitcoin's most enduring legacy.</p>
+            <p>
+                Whether Bitcoin becomes the foundation of a new global monetary order or remains
+                a niche asset, it has already changed how we think about money. That intellectual
+                revolution&mdash;the recognition that money itself can be reimagined&mdash;may
+                prove to be Bitcoin's most enduring legacy.
+            </p>
         </section>
 
-        <section id="summary">
-            <h2>Summary: Elementary Bitcoin Complete</h2>
+        <section>
+            <h2>40.12 Summary: Volume V Key Points</h2>
 
-            <div class="key-takeaways">
-                <h3>Volume V Key Points</h3>
-                <ul>
-                    <li><strong>Security threats</strong> like 51% attacks are real but expensive</li>
-                    <li><strong>Defense mechanisms</strong> include checkpoints, confirmations, and social consensus</li>
-                    <li><strong>Security budget</strong> must transition from subsidy to fees over 20-30 years</li>
-                    <li><strong>Quantum computing</strong> will require cryptographic migration—but we have time</li>
-                    <li><strong>Bitcoin's monetary future</strong> ranges from niche asset to global reserve currency</li>
-                    <li><strong>The outcome is not predetermined</strong>—it depends on technical, economic, and social factors</li>
-                </ul>
+            <ul>
+                <li><strong>Security threats</strong> like 51% attacks are real but expensive</li>
+                <li><strong>Defense mechanisms</strong> include checkpoints, confirmations, and social consensus</li>
+                <li><strong>Security budget</strong> must transition from subsidy to fees over 20-30 years</li>
+                <li><strong>Quantum computing</strong> will require cryptographic migration&mdash;but we have time</li>
+                <li><strong>Bitcoin's monetary future</strong> ranges from niche asset to global reserve currency</li>
+                <li><strong>The outcome is not predetermined</strong>&mdash;it depends on technical, economic, and social factors</li>
+            </ul>
+
+            <p>
+                From cryptographic primitives to global monetary futures, Elementary Bitcoin has
+                covered the technical foundations, economic principles, and philosophical
+                implications of this revolutionary technology. The knowledge you've gained
+                provides the foundation for understanding, using, and contributing to Bitcoin's
+                ongoing development. The future is unwritten. Build wisely.
+            </p>
+        </section>
+
+        <section class="exercises">
+            <h2>Exercises</h2>
+
+            <div class="exercise">
+                <p class="exercise-title">Exercise 40.1</p>
+                <p>
+                    Suppose Bitcoin reaches a market capitalization of $4 trillion with a
+                    circulating supply of 19.7 million BTC. Compute the implied price per BTC.
+                    Which scenario of Section 40.4 does this fall under?
+                </p>
             </div>
 
-            <div class="info-box">
-                <h4>The Journey Complete</h4>
-                <p>From cryptographic primitives to global monetary futures, Elementary Bitcoin has covered the technical foundations, economic principles, and philosophical implications of this revolutionary technology. The knowledge you've gained provides the foundation for understanding, using, and contributing to Bitcoin's ongoing development.</p>
-                <p><strong>The future is unwritten. Build wisely.</strong></p>
+            <div class="exercise">
+                <p class="exercise-title">Exercise 40.2</p>
+                <p>
+                    After the 2028 halving the block subsidy falls from 3.125 to
+                    <span class="math">1.5625</span> BTC. Assuming 144 blocks per day, compute the annual flow of
+                    new coins, the total stock at the halving (sum the five completed subsidy
+                    epochs of 210,000 blocks each), and the resulting stock-to-flow ratio.
+                    Compare it with the stock-to-flow of the 2024&ndash;2028 epoch.
+                </p>
+            </div>
+
+            <div class="exercise">
+                <p class="exercise-title">Exercise 40.3</p>
+                <p>
+                    Using the identity price = market cap / supply, compute the implied BTC
+                    price if Bitcoin exactly matches gold's ~$15 trillion market cap at a
+                    circulating supply of 19.7 million BTC. How does the answer compare with
+                    Example 40.5's figure at 20 million BTC?
+                </p>
+            </div>
+
+            <div class="exercise">
+                <p class="exercise-title">Exercise 40.4</p>
+                <p>
+                    Consider the nation-state adoption game of Definition 40.3. Identify its
+                    pure-strategy equilibria, and explain why the game is a stag hunt rather
+                    than a prisoner's dilemma. Why does the absence of a dominant strategy make
+                    a small "hedging" allocation rational for a risk-averse nation?
+                </p>
+            </div>
+
+            <div class="exercise">
+                <p class="exercise-title">Exercise 40.5</p>
+                <p>
+                    In the failure scenario of Definition 40.7, Bitcoin's market cap falls below
+                    $100 billion. What price per BTC does this imply at a supply of 19.7 million
+                    BTC?
+                </p>
+            </div>
+
+            <div class="exercise">
+                <p class="exercise-title">Exercise 40.6</p>
+                <p>
+                    Under the deflationary standard of Definition 40.10, suppose the money
+                    supply is fixed and real output grows 2% per year, so the price level falls
+                    by a factor of <span class="math">1/1.02</span> each year. By what fraction does the price level
+                    fall over 20 years? Relate your answer to the deflation debate of
+                    Remark 40.6.
+                </p>
             </div>
         </section>
 
         <nav class="chapter-navigation">
             <a href="39-quantum-resistance.html" class="prev-chapter">&#8592; Chapter 39: Quantum Resistance</a>
-            <a href="../index.html" class="next-chapter">Return to Index &#8594;</a>
+            <a href="../index.html">Index</a>
+            <span style="color: #999;">Volume V Complete</span>
         </nav>
-    </article>
+    </main>
 
     <footer>
-        <p>Elementary Bitcoin - Volume V: The Path to a Sustainable Future</p>
+        <p>Elementary Bitcoin · Volume V: The Path to a Sustainable Future (Draft)</p>
         <p><em>The End... and The Beginning</em></p>
     </footer>
 </body>


### PR DESCRIPTION
## Summary
The last structural inconsistency in the book: chapters 38-40 used an essay template (callout boxes, no numbered environments, no exercises) while everything else speaks the numbered Definition/Theorem/Remark/Example language. All three are now converted, with Ch 36/37 as the structural reference.

**What each chapter became:**
- **Ch 38**: the three security models are now numbered Definitions with their computations as Examples; Proposition 38.1 proves subsidy termination (last 1-sat era at height 6,720,000, zero at 6,930,000); the fee-sniping condition, threat models, and "it will work out" arguments live in 15 Remarks. Six exercises (daily issuance post-2028, attack cost per day, Model 1 at $20T...).
- **Ch 39**: 15 Definitions (Shor, Grover, address-exposure taxonomy, Mosca's inequality, the PQ schemes, migration strategies); Proposition 39.1 (Grover does not break mining) carries the chapter's one real proof. Six exercises (Lamport sizes, ML-DSA transaction overhead, Mosca arithmetic, Grover parallelization).
- **Ch 40**: scenarios and the layer model are clearly-labeled Definitions with market-cap arithmetic as Examples; the nation-state coordination game matches Ch 26's Schelling treatment; every prediction lives in a Remark. The ASCII scenario trees became semantic lists/tables with no information loss. Nav closes Volume V in the Ch 25 volume-close style.

**Discipline held**: economic heuristics and speculation are Remarks, never Theorems — the only two Propositions in 2,500 lines are the two genuinely provable claims. Numeric-token diffs against HEAD confirm all original facts/figures preserved; all 18 exercise answers verified computationally (and re-verified independently before this merge); tag balance, per-kind sequential numbering, and the complete 37→38→39→40→index nav chain all check out.

Every one of the 40 chapters now follows the same mathematical template, from group axioms to monetary futures.

Fixes #135