### PR TITLE
Add Appendix B (References) and Appendix C (Subject Index)

### DIFF
--- a/chapters/01-groups.html
+++ b/chapters/01-groups.html
@@ -57,7 +57,7 @@
         </section>
 
         <section>
-            <h2>1.1 Sets and Binary Operations</h2>
+            <h2 id="s1-1">1.1 Sets and Binary Operations</h2>
 
             <p>
                 We begin, as mathematicians often do, with the notion of a <em>set</em>&mdash;a collection
@@ -154,7 +154,7 @@
         </section>
 
         <section>
-            <h2>1.2 The Group Axioms</h2>
+            <h2 id="s1-2">1.2 The Group Axioms</h2>
 
             <p>
                 We now arrive at one of the most fundamental structures in all of mathematics: the <em>group</em>.
@@ -285,7 +285,7 @@
         </section>
 
         <section>
-            <h2>1.3 Abelian Groups</h2>
+            <h2 id="s1-3">1.3 Abelian Groups</h2>
 
             <p>
                 Some groups possess an additional property that simplifies many calculations: their
@@ -324,7 +324,7 @@
         </section>
 
         <section>
-            <h2>1.4 Cyclic Groups and Generators</h2>
+            <h2 id="s1-4">1.4 Cyclic Groups and Generators</h2>
 
             <p>
                 Among all groups, there is a particularly simple yet powerful class: <em>cyclic groups</em>.
@@ -494,7 +494,7 @@
         </section>
 
         <section>
-            <h2>1.5 Subgroups</h2>
+            <h2 id="s1-5">1.5 Subgroups</h2>
 
             <p>
                 Within any group, smaller groups may be hiding in plain sight. These
@@ -613,7 +613,7 @@
         </section>
 
         <section>
-            <h2>1.6 The Discrete Logarithm Problem</h2>
+            <h2 id="s1-6">1.6 The Discrete Logarithm Problem</h2>
 
             <p>
                 We arrive now at the mathematical linchpin of elliptic curve cryptography. In a

--- a/chapters/02-finite-fields.html
+++ b/chapters/02-finite-fields.html
@@ -48,7 +48,7 @@
         </section>
 
         <section>
-            <h2>2.1 Modular Arithmetic: Clock Mathematics</h2>
+            <h2 id="s2-1">2.1 Modular Arithmetic: Clock Mathematics</h2>
 
             <p>
                 Consider a 12-hour clock. When it shows 10 o'clock and three hours pass, the clock
@@ -183,7 +183,7 @@
         </section>
 
         <section>
-            <h2>2.2 The Ring ℤₙ</h2>
+            <h2 id="s2-2">2.2 The Ring ℤₙ</h2>
 
             <p>
                 With addition and multiplication defined on residue classes, <span class="math">ℤₙ</span>
@@ -248,7 +248,7 @@
         </section>
 
         <section>
-            <h2>2.3 Multiplicative Inverses and Fields</h2>
+            <h2 id="s2-3">2.3 Multiplicative Inverses and Fields</h2>
 
             <p>
                 A ring becomes a field when every nonzero element has a multiplicative inverse.
@@ -361,7 +361,7 @@
         </section>
 
         <section>
-            <h2>2.4 The Extended Euclidean Algorithm</h2>
+            <h2 id="s2-4">2.4 The Extended Euclidean Algorithm</h2>
 
             <p>
                 How do we efficiently compute multiplicative inverses? The answer is one of the
@@ -479,7 +479,7 @@ function extended_gcd(a, b):
         </section>
 
         <section>
-            <h2>2.5 Fermat's Little Theorem</h2>
+            <h2 id="s2-5">2.5 Fermat's Little Theorem</h2>
 
             <p>
                 An elegant alternative method for computing inverses emerges from a classical
@@ -616,7 +616,7 @@ function power_mod(a, k, n):
         </section>
 
         <section>
-            <h2>2.6 The Multiplicative Group 𝔽ₚ*</h2>
+            <h2 id="s2-6">2.6 The Multiplicative Group 𝔽ₚ*</h2>
 
             <p>
                 The nonzero elements of a prime field form a group under multiplication. This
@@ -734,7 +734,7 @@ function power_mod(a, k, n):
         </section>
 
         <section>
-            <h2>2.7 Division in Finite Fields</h2>
+            <h2 id="s2-7">2.7 Division in Finite Fields</h2>
 
             <p>
                 With multiplicative inverses in hand, division becomes straightforward: to compute
@@ -770,7 +770,7 @@ function power_mod(a, k, n):
         </section>
 
         <section>
-            <h2>2.8 Large Primes in Cryptography</h2>
+            <h2 id="s2-8">2.8 Large Primes in Cryptography</h2>
 
             <p>
                 In practice, cryptographic systems use primes of tremendous size. Bitcoin's

--- a/chapters/03-elliptic-curves-real.html
+++ b/chapters/03-elliptic-curves-real.html
@@ -49,7 +49,7 @@
         </section>
 
         <section>
-            <h2>3.1 The Weierstrass Equation</h2>
+            <h2 id="s3-1">3.1 The Weierstrass Equation</h2>
 
             <div class="definition">
                 <p class="definition-title">Definition 3.1 (Elliptic Curve)</p>
@@ -156,7 +156,7 @@
         </section>
 
         <section>
-            <h2>3.2 The Point at Infinity</h2>
+            <h2 id="s3-2">3.2 The Point at Infinity</h2>
 
             <p>
                 Before defining addition on elliptic curves, we must extend our curve by adding
@@ -234,7 +234,7 @@
         </section>
 
         <section>
-            <h2>3.3 The Chord-and-Tangent Law: Geometric Point Addition</h2>
+            <h2 id="s3-3">3.3 The Chord-and-Tangent Law: Geometric Point Addition</h2>
 
             <p>
                 Here we define the group operation on elliptic curves. The construction is
@@ -381,7 +381,7 @@
         </section>
 
         <section>
-            <h2>3.4 The Addition Formulas</h2>
+            <h2 id="s3-4">3.4 The Addition Formulas</h2>
 
             <p>
                 While the geometric definition is elegant, computation requires explicit formulas.
@@ -534,7 +534,7 @@
         </section>
 
         <section>
-            <h2>3.5 The Group Structure</h2>
+            <h2 id="s3-5">3.5 The Group Structure</h2>
 
             <p>
                 We now verify that elliptic curve addition satisfies the group axioms.
@@ -597,7 +597,7 @@
         </section>
 
         <section>
-            <h2>3.6 Scalar Multiplication</h2>
+            <h2 id="s3-6">3.6 Scalar Multiplication</h2>
 
             <p>
                 Given a point <span class="math">P</span> and a positive integer <span class="math">n</span>,
@@ -709,7 +709,7 @@ function scalar_multiply(n, P):
         </section>
 
         <section>
-            <h2>3.7 Why "Elliptic"?</h2>
+            <h2 id="s3-7">3.7 Why "Elliptic"?</h2>
 
             <p>
                 The curious reader may wonder about the name. Elliptic curves are <em>not</em>

--- a/chapters/04-elliptic-curves-finite.html
+++ b/chapters/04-elliptic-curves-finite.html
@@ -51,7 +51,7 @@
         </section>
 
         <section>
-            <h2>4.1 Definition over Finite Fields</h2>
+            <h2 id="s4-1">4.1 Definition over Finite Fields</h2>
 
             <div class="definition">
                 <p class="definition-title">Definition 4.1 (Elliptic Curve over 𝔽ₚ)</p>
@@ -201,7 +201,7 @@
         </section>
 
         <section>
-            <h2>4.2 Point Addition over 𝔽ₚ</h2>
+            <h2 id="s4-2">4.2 Point Addition over 𝔽ₚ</h2>
 
             <p>
                 The addition formulas from Chapter 3 carry over directly, with all arithmetic
@@ -270,7 +270,7 @@
         </section>
 
         <section>
-            <h2>4.3 The Order of a Curve</h2>
+            <h2 id="s4-3">4.3 The Order of a Curve</h2>
 
             <p>
                 Unlike curves over the reals, which have infinitely many points, curves over
@@ -345,7 +345,7 @@
         </section>
 
         <section>
-            <h2>4.4 Cyclic Subgroups and Generators</h2>
+            <h2 id="s4-4">4.4 Cyclic Subgroups and Generators</h2>
 
             <p>
                 For cryptographic applications, we typically work with a <em>cyclic subgroup</em>
@@ -477,7 +477,7 @@
         </section>
 
         <section>
-            <h2>4.5 The Elliptic Curve Discrete Logarithm Problem</h2>
+            <h2 id="s4-5">4.5 The Elliptic Curve Discrete Logarithm Problem</h2>
 
             <p>
                 We now formalize the computational problem upon which all elliptic curve
@@ -561,7 +561,7 @@
         </section>
 
         <section>
-            <h2>4.6 Choosing Secure Curves</h2>
+            <h2 id="s4-6">4.6 Choosing Secure Curves</h2>
 
             <p>
                 Not all elliptic curves provide adequate security. The following criteria guide
@@ -601,7 +601,7 @@
         </section>
 
         <section>
-            <h2>4.7 From Groups to Cryptography</h2>
+            <h2 id="s4-7">4.7 From Groups to Cryptography</h2>
 
             <p>
                 The elliptic curve group <span class="math">(E(𝔽ₚ), +)</span> provides the

--- a/chapters/05-secp256k1.html
+++ b/chapters/05-secp256k1.html
@@ -48,7 +48,7 @@
         </section>
 
         <section>
-            <h2>5.1 The Name Decoded</h2>
+            <h2 id="s5-1">5.1 The Name Decoded</h2>
 
             <p>
                 The cryptic name "secp256k1" encodes several pieces of information:
@@ -104,7 +104,7 @@
         </section>
 
         <section>
-            <h2>5.2 The Curve Equation</h2>
+            <h2 id="s5-2">5.2 The Curve Equation</h2>
 
             <div class="definition">
                 <p class="definition-title">Definition 5.1 (The secp256k1 Curve)</p>
@@ -163,7 +163,7 @@
         </section>
 
         <section>
-            <h2>5.3 The Field Parameters</h2>
+            <h2 id="s5-3">5.3 The Field Parameters</h2>
 
             <p>
                 The curve is defined over a prime field of size approximately <span class="math">2²⁵⁶</span>.
@@ -212,7 +212,7 @@
         </section>
 
         <section>
-            <h2>5.4 The Generator Point</h2>
+            <h2 id="s5-4">5.4 The Generator Point</h2>
 
             <p>
                 Every point operation in Bitcoin begins with a fixed <em>generator point</em>
@@ -289,7 +289,7 @@ FD17B448 A6855419 9C47D08F FB10D4B8</pre>
         </section>
 
         <section>
-            <h2>5.5 The Group Order</h2>
+            <h2 id="s5-5">5.5 The Group Order</h2>
 
             <p>
                 The order of the generator point <span class="math">G</span>&mdash;and hence the
@@ -344,7 +344,7 @@ FD17B448 A6855419 9C47D08F FB10D4B8</pre>
         </section>
 
         <section>
-            <h2>5.6 Complete Parameter Summary</h2>
+            <h2 id="s5-6">5.6 Complete Parameter Summary</h2>
 
             <p>
                 For reference, here are all the secp256k1 parameters collected together:
@@ -405,7 +405,7 @@ FD17B448 A6855419 9C47D08F FB10D4B8</pre>
         </section>
 
         <section>
-            <h2>5.7 Private and Public Keys</h2>
+            <h2 id="s5-7">5.7 Private and Public Keys</h2>
 
             <p>
                 With the curve parameters established, we can now precisely define what
@@ -479,7 +479,7 @@ FD17B448 A6855419 9C47D08F FB10D4B8</pre>
         </section>
 
         <section>
-            <h2>5.8 Public Key Encoding</h2>
+            <h2 id="s5-8">5.8 Public Key Encoding</h2>
 
             <p>
                 A public key is a point <span class="math">(x, y)</span> on the curve. There
@@ -567,7 +567,7 @@ FD17B448 A6855419 9C47D08F FB10D4B8</pre>
         </section>
 
         <section>
-            <h2>5.9 Why Satoshi Chose secp256k1</h2>
+            <h2 id="s5-9">5.9 Why Satoshi Chose secp256k1</h2>
 
             <p>
                 When Satoshi Nakamoto designed Bitcoin, he chose secp256k1 over the more
@@ -610,7 +610,7 @@ FD17B448 A6855419 9C47D08F FB10D4B8</pre>
         </section>
 
         <section>
-            <h2>5.10 Security Analysis</h2>
+            <h2 id="s5-10">5.10 Security Analysis</h2>
 
             <p>
                 The security of secp256k1 has been extensively analyzed. The main conclusion:

--- a/chapters/06-hash-functions.html
+++ b/chapters/06-hash-functions.html
@@ -48,7 +48,7 @@
         </section>
 
         <section>
-            <h2>6.1 Cryptographic Hash Functions</h2>
+            <h2 id="s6-1">6.1 Cryptographic Hash Functions</h2>
 
             <div class="definition">
                 <p class="definition-title">Definition 6.1 (Cryptographic Hash Function)</p>
@@ -147,7 +147,7 @@
         </section>
 
         <section>
-            <h2>6.2 SHA-256: The Secure Hash Algorithm</h2>
+            <h2 id="s6-2">6.2 SHA-256: The Secure Hash Algorithm</h2>
 
             <p>
                 Bitcoin uses SHA-256 (Secure Hash Algorithm, 256-bit) as its primary hash
@@ -246,7 +246,7 @@
         </section>
 
         <section>
-            <h2>6.3 Double SHA-256 in Bitcoin</h2>
+            <h2 id="s6-3">6.3 Double SHA-256 in Bitcoin</h2>
 
             <p>
                 Bitcoin does not use plain SHA-256 for most purposes. Instead, it uses
@@ -320,7 +320,7 @@
         </section>
 
         <section>
-            <h2>6.4 RIPEMD-160 and HASH160</h2>
+            <h2 id="s6-4">6.4 RIPEMD-160 and HASH160</h2>
 
             <p>
                 For Bitcoin addresses, a different hash combination is used: SHA-256 followed
@@ -394,7 +394,7 @@
         </section>
 
         <section>
-            <h2>6.5 Hash Functions in Digital Signatures</h2>
+            <h2 id="s6-5">6.5 Hash Functions in Digital Signatures</h2>
 
             <p>
                 In digital signature schemes, we do not sign the message directly. Instead, we
@@ -462,7 +462,7 @@
         </section>
 
         <section>
-            <h2>6.6 The Random Oracle Model</h2>
+            <h2 id="s6-6">6.6 The Random Oracle Model</h2>
 
             <p>
                 When analyzing the security of cryptographic schemes, we often model hash
@@ -498,7 +498,7 @@
         </section>
 
         <section>
-            <h2>6.7 Tagged Hashes (BIP-340)</h2>
+            <h2 id="s6-7">6.7 Tagged Hashes (BIP-340)</h2>
 
             <p>
                 Modern Bitcoin protocols like Schnorr signatures (BIP-340) use <em>tagged hashes</em>

--- a/chapters/07-ecdsa.html
+++ b/chapters/07-ecdsa.html
@@ -50,7 +50,7 @@
         </section>
 
         <section>
-            <h2>7.1 What Is a Digital Signature?</h2>
+            <h2 id="s7-1">7.1 What Is a Digital Signature?</h2>
 
             <div class="definition">
                 <p class="definition-title">Definition 7.1 (Digital Signature Scheme)</p>
@@ -165,7 +165,7 @@
         </section>
 
         <section>
-            <h2>7.2 ECDSA Parameters</h2>
+            <h2 id="s7-2">7.2 ECDSA Parameters</h2>
 
             <p>
                 ECDSA operates on an elliptic curve with the following publicly known parameters:
@@ -187,7 +187,7 @@
         </section>
 
         <section>
-            <h2>7.3 Key Generation</h2>
+            <h2 id="s7-3">7.3 Key Generation</h2>
 
             <p>
                 Key generation in ECDSA is remarkably simple: choose a random number, multiply
@@ -248,7 +248,7 @@ KeyGen():
         </section>
 
         <section>
-            <h2>7.4 The Signing Algorithm</h2>
+            <h2 id="s7-4">7.4 The Signing Algorithm</h2>
 
             <p>
                 The ECDSA signing algorithm is where the mathematical elegance emerges. It
@@ -362,7 +362,7 @@ Sign(d, m):
         </section>
 
         <section>
-            <h2>7.5 The Verification Algorithm</h2>
+            <h2 id="s7-5">7.5 The Verification Algorithm</h2>
 
             <p>
                 Verification uses only public information to check whether a signature is valid.
@@ -412,7 +412,7 @@ Verify(P, m, (r, s)):
         </section>
 
         <section>
-            <h2>7.6 Why Verification Works</h2>
+            <h2 id="s7-6">7.6 Why Verification Works</h2>
 
             <p>
                 The verification algorithm may seem like magic, but it follows logically from
@@ -460,7 +460,7 @@ Verify(P, m, (r, s)):
         </section>
 
         <section>
-            <h2>7.7 The Nonce: ECDSA's Achilles' Heel</h2>
+            <h2 id="s7-7">7.7 The Nonce: ECDSA's Achilles' Heel</h2>
 
             <p>
                 The random nonce <span class="math">k</span> is the most critical security
@@ -587,7 +587,7 @@ Verify(P, m, (r, s)):
         </section>
 
         <section>
-            <h2>7.8 Signature Malleability</h2>
+            <h2 id="s7-8">7.8 Signature Malleability</h2>
 
             <p>
                 ECDSA signatures have an inherent property called <em>malleability</em>: given
@@ -637,7 +637,7 @@ Verify(P, m, (r, s)):
         </section>
 
         <section>
-            <h2>7.9 ECDSA in Bitcoin Transactions</h2>
+            <h2 id="s7-9">7.9 ECDSA in Bitcoin Transactions</h2>
 
             <p>
                 In Bitcoin, ECDSA signatures authorize the spending of funds. A transaction

--- a/chapters/08-schnorr.html
+++ b/chapters/08-schnorr.html
@@ -53,7 +53,7 @@
         </section>
 
         <section>
-            <h2>8.1 Why Schnorr?</h2>
+            <h2 id="s8-1">8.1 Why Schnorr?</h2>
 
             <p>
                 Before diving into the mathematics, let us understand why Bitcoin adopted
@@ -122,7 +122,7 @@
         </section>
 
         <section>
-            <h2>8.2 The Core Idea: A Zero-Knowledge Proof of Knowledge</h2>
+            <h2 id="s8-2">8.2 The Core Idea: A Zero-Knowledge Proof of Knowledge</h2>
 
             <p>
                 At its heart, a Schnorr signature is a <em>non-interactive zero-knowledge proof</em>
@@ -197,7 +197,7 @@
         </section>
 
         <section>
-            <h2>8.3 The Fiat-Shamir Transform</h2>
+            <h2 id="s8-3">8.3 The Fiat-Shamir Transform</h2>
 
             <p>
                 Digital signatures require non-interactivity: the signer produces the signature
@@ -232,7 +232,7 @@
         </section>
 
         <section>
-            <h2>8.4 BIP-340: Schnorr for Bitcoin</h2>
+            <h2 id="s8-4">8.4 BIP-340: Schnorr for Bitcoin</h2>
 
             <p>
                 BIP-340 specifies Schnorr signatures for Bitcoin, making several design
@@ -278,7 +278,7 @@
         </section>
 
         <section>
-            <h2>8.5 The BIP-340 Signing Algorithm</h2>
+            <h2 id="s8-5">8.5 The BIP-340 Signing Algorithm</h2>
 
             <div class="definition">
                 <p class="definition-title">Algorithm 8.1 (BIP-340 Schnorr Signing)</p>
@@ -395,7 +395,7 @@ Sign(d, m):
         </section>
 
         <section>
-            <h2>8.6 The BIP-340 Verification Algorithm</h2>
+            <h2 id="s8-6">8.6 The BIP-340 Verification Algorithm</h2>
 
             <div class="definition">
                 <p class="definition-title">Algorithm 8.2 (BIP-340 Schnorr Verification)</p>
@@ -467,7 +467,7 @@ Verify(pk, m, sig):
         </section>
 
         <section>
-            <h2>8.7 The Linearity Property</h2>
+            <h2 id="s8-7">8.7 The Linearity Property</h2>
 
             <p>
                 The defining feature that makes Schnorr signatures powerful is <em>linearity</em>:
@@ -569,7 +569,7 @@ Verify(pk, m, sig):
         </section>
 
         <section>
-            <h2>8.8 MuSig: Secure Multi-Signatures</h2>
+            <h2 id="s8-8">8.8 MuSig: Secure Multi-Signatures</h2>
 
             <p>
                 While naive key and signature aggregation is possible, it is vulnerable to
@@ -620,7 +620,7 @@ Verify(pk, m, sig):
         </section>
 
         <section>
-            <h2>8.9 Batch Verification</h2>
+            <h2 id="s8-9">8.9 Batch Verification</h2>
 
             <p>
                 Schnorr's linearity also enables efficient <em>batch verification</em>: checking
@@ -659,7 +659,7 @@ Verify(pk, m, sig):
         </section>
 
         <section>
-            <h2>8.10 Schnorr in Taproot</h2>
+            <h2 id="s8-10">8.10 Schnorr in Taproot</h2>
 
             <p>
                 Schnorr signatures are the foundation of Bitcoin's Taproot upgrade (BIP-341).

--- a/chapters/09-keys-addresses.html
+++ b/chapters/09-keys-addresses.html
@@ -54,7 +54,7 @@
         </section>
 
         <section>
-            <h2>9.1 Private Keys</h2>
+            <h2 id="s9-1">9.1 Private Keys</h2>
 
             <p>
                 A Bitcoin private key is, at its core, simply a number. But not just any number&mdash;it
@@ -111,7 +111,7 @@
                 </p>
             </div>
 
-            <h3>9.1.1 The Keyspace</h3>
+            <h3 id="s9-1-1">9.1.1 The Keyspace</h3>
 
             <p>
                 The set of valid private keys contains approximately 2²⁵⁶ elements. To appreciate
@@ -148,7 +148,7 @@
         </section>
 
         <section>
-            <h2>9.2 Public Keys</h2>
+            <h2 id="s9-2">9.2 Public Keys</h2>
 
             <p>
                 Given a private key <span class="math">d</span>, the corresponding public key is
@@ -208,7 +208,7 @@
                 <figcaption>Figure 9.1: Public key derivation from private key via scalar multiplication.</figcaption>
             </figure>
 
-            <h3>9.2.1 Public Key Serialization</h3>
+            <h3 id="s9-2-1">9.2.1 Public Key Serialization</h3>
 
             <p>
                 A public key is a point <span class="math">P = (x, y)</span> on the secp256k1 curve.
@@ -286,7 +286,7 @@
         </section>
 
         <section>
-            <h2>9.3 Hash Functions in Address Generation</h2>
+            <h2 id="s9-3">9.3 Hash Functions in Address Generation</h2>
 
             <p>
                 Bitcoin addresses are not public keys directly, but rather hashes of public keys.
@@ -352,7 +352,7 @@
         </section>
 
         <section>
-            <h2>9.4 Base58Check Encoding</h2>
+            <h2 id="s9-4">9.4 Base58Check Encoding</h2>
 
             <p>
                 Raw binary data is inconvenient for humans to read, copy, or transcribe.
@@ -360,7 +360,7 @@
                 designed for clarity and error detection.
             </p>
 
-            <h3>9.4.1 The Base58 Alphabet</h3>
+            <h3 id="s9-4-1">9.4.1 The Base58 Alphabet</h3>
 
             <div class="definition">
                 <p class="definition-title">Definition 9.6 (Base58 Alphabet)</p>
@@ -380,7 +380,7 @@
                 it to base 58, mapping each digit to the corresponding alphabet character.
             </p>
 
-            <h3>9.4.2 Adding the Checksum</h3>
+            <h3 id="s9-4-2">9.4.2 Adding the Checksum</h3>
 
             <div class="definition">
                 <p class="definition-title">Definition 9.7 (Base58Check)</p>
@@ -469,7 +469,7 @@
         </section>
 
         <section>
-            <h2>9.5 Legacy Addresses (P2PKH)</h2>
+            <h2 id="s9-5">9.5 Legacy Addresses (P2PKH)</h2>
 
             <p>
                 The original Bitcoin address format encodes a public key hash with a version
@@ -546,7 +546,7 @@
         </section>
 
         <section>
-            <h2>9.6 Script Hash Addresses (P2SH)</h2>
+            <h2 id="s9-6">9.6 Script Hash Addresses (P2SH)</h2>
 
             <p>
                 P2SH addresses, introduced in BIP-16, allow payments to arbitrary scripts
@@ -599,7 +599,7 @@
         </section>
 
         <section>
-            <h2>9.7 Bech32 and Native SegWit (P2WPKH)</h2>
+            <h2 id="s9-7">9.7 Bech32 and Native SegWit (P2WPKH)</h2>
 
             <p>
                 Segregated Witness (SegWit), activated in 2017, introduced a new address format
@@ -607,7 +607,7 @@
                 detection and are more efficient on-chain.
             </p>
 
-            <h3>9.7.1 The Bech32 Alphabet</h3>
+            <h3 id="s9-7-1">9.7.1 The Bech32 Alphabet</h3>
 
             <div class="definition">
                 <p class="definition-title">Definition 9.10 (Bech32 Alphabet)</p>
@@ -621,7 +621,7 @@
                 </p>
             </div>
 
-            <h3>9.7.2 Address Structure</h3>
+            <h3 id="s9-7-2">9.7.2 Address Structure</h3>
 
             <p>
                 A Bech32 address has three parts:
@@ -659,7 +659,7 @@
                 </p>
             </div>
 
-            <h3>9.7.3 Error Detection</h3>
+            <h3 id="s9-7-3">9.7.3 Error Detection</h3>
 
             <p>
                 Bech32 uses a BCH code for error detection, offering stronger guarantees than
@@ -689,7 +689,7 @@
         </section>
 
         <section>
-            <h2>9.8 Taproot Addresses (P2TR)</h2>
+            <h2 id="s9-8">9.8 Taproot Addresses (P2TR)</h2>
 
             <p>
                 Taproot, activated in November 2021, introduced a new output type using
@@ -726,7 +726,7 @@
                 </p>
             </div>
 
-            <h3>9.8.1 Bech32 vs. Bech32m</h3>
+            <h3 id="s9-8-1">9.8.1 Bech32 vs. Bech32m</h3>
 
             <p>
                 BIP-350 introduced Bech32m, a slight modification of Bech32 that fixes an
@@ -762,7 +762,7 @@
         </section>
 
         <section>
-            <h2>9.9 Wallet Import Format (WIF)</h2>
+            <h2 id="s9-9">9.9 Wallet Import Format (WIF)</h2>
 
             <p>
                 Private keys also need a human-readable encoding for backup and import.
@@ -834,7 +834,7 @@
         </section>
 
         <section>
-            <h2>9.10 Summary of Address Types</h2>
+            <h2 id="s9-10">9.10 Summary of Address Types</h2>
 
             <figure>
                 <svg class="diagram" width="520" height="280" viewBox="0 0 520 280">

--- a/chapters/10-transactions.html
+++ b/chapters/10-transactions.html
@@ -52,7 +52,7 @@
         </section>
 
         <section>
-            <h2>10.1 The UTXO Model</h2>
+            <h2 id="s10-1">10.1 The UTXO Model</h2>
 
             <p>
                 Bitcoin does not track account balances. Instead, it tracks individual
@@ -144,7 +144,7 @@
         </section>
 
         <section>
-            <h2>10.2 Transaction Structure</h2>
+            <h2 id="s10-2">10.2 Transaction Structure</h2>
 
             <p>
                 A Bitcoin transaction consists of four main components, serialized in a
@@ -203,7 +203,7 @@
                 <figcaption>Figure 10.2: High-level transaction structure.</figcaption>
             </figure>
 
-            <h3>10.2.1 Version Field</h3>
+            <h3 id="s10-2-1">10.2.1 Version Field</h3>
 
             <p>
                 The version field indicates which transaction validation rules apply.
@@ -233,7 +233,7 @@
                 <code>01000000</code> in hex; version 2 is <code>02000000</code>.
             </p>
 
-            <h3>10.2.2 Locktime</h3>
+            <h3 id="s10-2-2">10.2.2 Locktime</h3>
 
             <div class="definition">
                 <p class="definition-title">Definition 10.3 (Locktime)</p>
@@ -255,7 +255,7 @@
         </section>
 
         <section>
-            <h2>10.3 Transaction Inputs</h2>
+            <h2 id="s10-3">10.3 Transaction Inputs</h2>
 
             <p>
                 Each input references a specific output from a previous transaction and
@@ -309,7 +309,7 @@
                 <figcaption>Figure 10.3: Structure of a transaction input.</figcaption>
             </figure>
 
-            <h3>10.3.1 The Outpoint</h3>
+            <h3 id="s10-3-1">10.3.1 The Outpoint</h3>
 
             <p>
                 An outpoint uniquely identifies a UTXO by specifying which transaction created
@@ -331,7 +331,7 @@ efcdab78563412...f6e5d4c3b2a1
 01000000</pre>
             </div>
 
-            <h3>10.3.2 Sequence Numbers</h3>
+            <h3 id="s10-3-2">10.3.2 Sequence Numbers</h3>
 
             <p>
                 Originally intended for transaction replacement, sequence numbers now serve
@@ -363,7 +363,7 @@ efcdab78563412...f6e5d4c3b2a1
         </section>
 
         <section>
-            <h2>10.4 Transaction Outputs</h2>
+            <h2 id="s10-4">10.4 Transaction Outputs</h2>
 
             <p>
                 Each output specifies an amount and a locking condition.
@@ -425,7 +425,7 @@ efcdab78563412...f6e5d4c3b2a1
         </section>
 
         <section>
-            <h2>10.5 Standard ScriptPubKey Types</h2>
+            <h2 id="s10-5">10.5 Standard ScriptPubKey Types</h2>
 
             <p>
                 While Bitcoin Script allows arbitrary programs, most outputs use one of
@@ -434,7 +434,7 @@ efcdab78563412...f6e5d4c3b2a1
                 Chapter 11; here we only need their names.)
             </p>
 
-            <h3>10.5.1 P2PKH (Pay-to-Public-Key-Hash)</h3>
+            <h3 id="s10-5-1">10.5.1 P2PKH (Pay-to-Public-Key-Hash)</h3>
 
             <div class="definition">
                 <p class="definition-title">Definition 10.7 (P2PKH ScriptPubKey)</p>
@@ -447,7 +447,7 @@ efcdab78563412...f6e5d4c3b2a1
                 </p>
             </div>
 
-            <h3>10.5.2 P2SH (Pay-to-Script-Hash)</h3>
+            <h3 id="s10-5-2">10.5.2 P2SH (Pay-to-Script-Hash)</h3>
 
             <div class="definition">
                 <p class="definition-title">Definition 10.8 (P2SH ScriptPubKey)</p>
@@ -460,7 +460,7 @@ efcdab78563412...f6e5d4c3b2a1
                 </p>
             </div>
 
-            <h3>10.5.3 Native SegWit (P2WPKH, P2WSH)</h3>
+            <h3 id="s10-5-3">10.5.3 Native SegWit (P2WPKH, P2WSH)</h3>
 
             <div class="definition">
                 <p class="definition-title">Definition 10.9 (Witness Program)</p>
@@ -474,7 +474,7 @@ efcdab78563412...f6e5d4c3b2a1
                 </p>
             </div>
 
-            <h3>10.5.4 Taproot (P2TR)</h3>
+            <h3 id="s10-5-4">10.5.4 Taproot (P2TR)</h3>
 
             <div class="definition">
                 <p class="definition-title">Definition 10.10 (P2TR ScriptPubKey)</p>
@@ -526,7 +526,7 @@ efcdab78563412...f6e5d4c3b2a1
         </section>
 
         <section>
-            <h2>10.6 Segregated Witness</h2>
+            <h2 id="s10-6">10.6 Segregated Witness</h2>
 
             <p>
                 Segregated Witness (SegWit), activated in August 2017, separates signature
@@ -543,7 +543,7 @@ efcdab78563412...f6e5d4c3b2a1
                 </p>
             </div>
 
-            <h3>10.6.1 SegWit Transaction Format</h3>
+            <h3 id="s10-6-1">10.6.1 SegWit Transaction Format</h3>
 
             <p>
                 A SegWit transaction includes additional marker, flag, and witness fields:
@@ -594,7 +594,7 @@ efcdab78563412...f6e5d4c3b2a1
                 <figcaption>Figure 10.5: SegWit transaction structure with marker, flag, and witness fields.</figcaption>
             </figure>
 
-            <h3>10.6.2 Transaction IDs</h3>
+            <h3 id="s10-6-2">10.6.2 Transaction IDs</h3>
 
             <div class="definition">
                 <p class="definition-title">Definition 10.12 (Txid and Wtxid)</p>
@@ -615,7 +615,7 @@ efcdab78563412...f6e5d4c3b2a1
         </section>
 
         <section>
-            <h2>10.7 Signature Hash Types</h2>
+            <h2 id="s10-7">10.7 Signature Hash Types</h2>
 
             <p>
                 When signing an input, the signer commits to a specific subset of the transaction
@@ -682,7 +682,7 @@ efcdab78563412...f6e5d4c3b2a1
         </section>
 
         <section>
-            <h2>10.8 Transaction Fees</h2>
+            <h2 id="s10-8">10.8 Transaction Fees</h2>
 
             <p>
                 Transaction fees incentivize miners and prevent spam.
@@ -702,7 +702,7 @@ efcdab78563412...f6e5d4c3b2a1
                 </p>
             </div>
 
-            <h3>10.8.1 Virtual Size</h3>
+            <h3 id="s10-8-1">10.8.1 Virtual Size</h3>
 
             <p>
                 SegWit introduced <em>weight units</em> to discount witness data.
@@ -735,7 +735,7 @@ efcdab78563412...f6e5d4c3b2a1
         </section>
 
         <section>
-            <h2>10.9 A Complete Transaction Example</h2>
+            <h2 id="s10-9">10.9 A Complete Transaction Example</h2>
 
             <div class="example">
                 <p class="example-title">Example 10.4 (Parsing a Raw Transaction)</p>
@@ -762,7 +762,7 @@ efcdab78563412...f6e5d4c3b2a1
         </section>
 
         <section>
-            <h2>10.10 The Coinbase Transaction</h2>
+            <h2 id="s10-10">10.10 The Coinbase Transaction</h2>
 
             <p>
                 Every block contains exactly one special transaction: the coinbase.

--- a/chapters/11-script.html
+++ b/chapters/11-script.html
@@ -53,7 +53,7 @@
         </section>
 
         <section>
-            <h2>11.1 The Execution Model</h2>
+            <h2 id="s11-1">11.1 The Execution Model</h2>
 
             <p>
                 Script programs operate on two stacks: the main stack and an auxiliary "alt" stack.
@@ -126,7 +126,7 @@
                 <figcaption>Figure 11.1: Script execution processes elements left-to-right, manipulating the stack.</figcaption>
             </figure>
 
-            <h3>11.1.1 Script Concatenation</h3>
+            <h3 id="s11-1-1">11.1.1 Script Concatenation</h3>
 
             <p>
                 To validate a transaction input, the scriptSig (unlocking script) is concatenated
@@ -159,7 +159,7 @@
         </section>
 
         <section>
-            <h2>11.2 Data Push Operations</h2>
+            <h2 id="s11-2">11.2 Data Push Operations</h2>
 
             <p>
                 Non-opcode bytes in a script represent data to be pushed onto the stack.
@@ -226,7 +226,7 @@
         </section>
 
         <section>
-            <h2>11.3 Stack Manipulation Opcodes</h2>
+            <h2 id="s11-3">11.3 Stack Manipulation Opcodes</h2>
 
             <p>
                 These opcodes rearrange elements on the stack without performing computation.
@@ -325,7 +325,7 @@
         </section>
 
         <section>
-            <h2>11.4 Arithmetic Opcodes</h2>
+            <h2 id="s11-4">11.4 Arithmetic Opcodes</h2>
 
             <p>
                 Script supports limited arithmetic on 32-bit signed integers.
@@ -414,13 +414,13 @@
         </section>
 
         <section>
-            <h2>11.5 Cryptographic Opcodes</h2>
+            <h2 id="s11-5">11.5 Cryptographic Opcodes</h2>
 
             <p>
                 The most important opcodes perform cryptographic operations.
             </p>
 
-            <h3>11.5.1 Hash Functions</h3>
+            <h3 id="s11-5-1">11.5.1 Hash Functions</h3>
 
             <table class="data-table">
                 <thead>
@@ -459,7 +459,7 @@
                 </tbody>
             </table>
 
-            <h3>11.5.2 Signature Verification</h3>
+            <h3 id="s11-5-2">11.5.2 Signature Verification</h3>
 
             <table class="data-table">
                 <thead>
@@ -505,7 +505,7 @@
         </section>
 
         <section>
-            <h2>11.6 Flow Control</h2>
+            <h2 id="s11-6">11.6 Flow Control</h2>
 
             <p>
                 Script supports conditional execution (but not loops).
@@ -569,7 +569,7 @@ OP_CHECKSIG</pre>
         </section>
 
         <section>
-            <h2>11.7 Time Lock Opcodes</h2>
+            <h2 id="s11-7">11.7 Time Lock Opcodes</h2>
 
             <p>
                 BIP-65 and BIP-112 introduced opcodes for time-based spending conditions.
@@ -615,14 +615,14 @@ OP_DUP OP_HASH160 &lt;pubkey_hash&gt; OP_EQUALVERIFY OP_CHECKSIG</pre>
         </section>
 
         <section>
-            <h2>11.8 Standard Script Templates</h2>
+            <h2 id="s11-8">11.8 Standard Script Templates</h2>
 
             <p>
                 While Script allows arbitrary programs, nodes relay only "standard" transactions
                 using recognized templates.
             </p>
 
-            <h3>11.8.1 P2PKH (Pay-to-Public-Key-Hash)</h3>
+            <h3 id="s11-8-1">11.8.1 P2PKH (Pay-to-Public-Key-Hash)</h3>
 
             <div class="definition">
                 <p class="definition-title">Definition 11.4 (P2PKH Scripts)</p>
@@ -701,7 +701,7 @@ OP_DUP OP_HASH160 &lt;pubkey_hash&gt; OP_EQUALVERIFY OP_CHECKSIG</pre>
                 <figcaption>Figure 11.3: Step-by-step execution of a P2PKH script.</figcaption>
             </figure>
 
-            <h3>11.8.2 P2SH (Pay-to-Script-Hash)</h3>
+            <h3 id="s11-8-2">11.8.2 P2SH (Pay-to-Script-Hash)</h3>
 
             <div class="definition">
                 <p class="definition-title">Definition 11.5 (P2SH Execution)</p>
@@ -722,7 +722,7 @@ OP_DUP OP_HASH160 &lt;pubkey_hash&gt; OP_EQUALVERIFY OP_CHECKSIG</pre>
                 <pre class="code-block">&lt;...signatures...&gt; &lt;redeem_script&gt;</pre>
             </div>
 
-            <h3>11.8.3 Multisignature</h3>
+            <h3 id="s11-8-3">11.8.3 Multisignature</h3>
 
             <div class="definition">
                 <p class="definition-title">Definition 11.6 (m-of-n Multisig)</p>
@@ -744,7 +744,7 @@ OP_DUP OP_HASH160 &lt;pubkey_hash&gt; OP_EQUALVERIFY OP_CHECKSIG</pre>
         </section>
 
         <section>
-            <h2>11.9 OP_RETURN and Data Embedding</h2>
+            <h2 id="s11-9">11.9 OP_RETURN and Data Embedding</h2>
 
             <p>
                 <code>OP_RETURN</code> creates a provably unspendable output, useful for
@@ -778,7 +778,7 @@ OP_DUP OP_HASH160 &lt;pubkey_hash&gt; OP_EQUALVERIFY OP_CHECKSIG</pre>
         </section>
 
         <section>
-            <h2>11.10 SegWit Script Execution</h2>
+            <h2 id="s11-10">11.10 SegWit Script Execution</h2>
 
             <p>
                 Native SegWit outputs use a different execution model. The scriptPubKey
@@ -825,7 +825,7 @@ OP_DUP OP_HASH160 &lt;pubkey_hash&gt; OP_EQUALVERIFY OP_CHECKSIG</pre>
         </section>
 
         <section>
-            <h2>11.11 Tapscript</h2>
+            <h2 id="s11-11">11.11 Tapscript</h2>
 
             <p>
                 Taproot (BIP-341, BIP-342) introduces Tapscript, an upgraded Script with
@@ -862,7 +862,7 @@ OP_2 OP_NUMEQUAL</pre>
         </section>
 
         <section>
-            <h2>11.12 Script Limitations</h2>
+            <h2 id="s11-12">11.12 Script Limitations</h2>
 
             <p>
                 Script's restrictions are intentional, ensuring predictable validation.

--- a/chapters/12-merkle-trees.html
+++ b/chapters/12-merkle-trees.html
@@ -53,7 +53,7 @@
         </section>
 
         <section>
-            <h2>12.1 Binary Hash Trees</h2>
+            <h2 id="s12-1">12.1 Binary Hash Trees</h2>
 
             <p>
                 A Merkle tree is a binary tree where each leaf node contains a hash of data,
@@ -154,7 +154,7 @@
         </section>
 
         <section>
-            <h2>12.2 Computing the Merkle Root</h2>
+            <h2 id="s12-2">12.2 Computing the Merkle Root</h2>
 
             <p>
                 The Merkle root is computed bottom-up, starting from the transaction hashes.
@@ -267,7 +267,7 @@ H(CD) = SHA256(SHA256(1c8d...2e3f || 9a4b...5c6d))</pre>
         </section>
 
         <section>
-            <h2>12.3 Merkle Proofs</h2>
+            <h2 id="s12-3">12.3 Merkle Proofs</h2>
 
             <p>
                 The key insight of Merkle trees is that the inclusion of any element can be proven
@@ -399,7 +399,7 @@ H(CD) = SHA256(SHA256(1c8d...2e3f || 9a4b...5c6d))</pre>
         </section>
 
         <section>
-            <h2>12.4 Verifying Merkle Proofs</h2>
+            <h2 id="s12-4">12.4 Verifying Merkle Proofs</h2>
 
             <p>
                 Given a transaction, a Merkle proof, and the expected root, verification
@@ -455,7 +455,7 @@ H(CD) = SHA256(SHA256(1c8d...2e3f || 9a4b...5c6d))</pre>
         </section>
 
         <section>
-            <h2>12.5 Transaction Merkle Tree in Bitcoin</h2>
+            <h2 id="s12-5">12.5 Transaction Merkle Tree in Bitcoin</h2>
 
             <p>
                 Every Bitcoin block contains a Merkle root that commits to all transactions
@@ -538,7 +538,7 @@ H(CD) = SHA256(SHA256(1c8d...2e3f || 9a4b...5c6d))</pre>
         </section>
 
         <section>
-            <h2>12.6 Witness Commitment</h2>
+            <h2 id="s12-6">12.6 Witness Commitment</h2>
 
             <p>
                 SegWit introduced a second Merkle tree that commits to witness data.
@@ -586,7 +586,7 @@ H(CD) = SHA256(SHA256(1c8d...2e3f || 9a4b...5c6d))</pre>
         </section>
 
         <section>
-            <h2>12.7 SPV and Merkle Proofs</h2>
+            <h2 id="s12-7">12.7 SPV and Merkle Proofs</h2>
 
             <p>
                 Merkle proofs enable Simplified Payment Verification (SPV), where a lightweight
@@ -633,9 +633,9 @@ H(CD) = SHA256(SHA256(1c8d...2e3f || 9a4b...5c6d))</pre>
         </section>
 
         <section>
-            <h2>12.8 Security Considerations</h2>
+            <h2 id="s12-8">12.8 Security Considerations</h2>
 
-            <h3>12.8.1 CVE-2012-2459: Merkle Tree Malleability</h3>
+            <h3 id="s12-8-1">12.8.1 CVE-2012-2459: Merkle Tree Malleability</h3>
 
             <p>
                 A vulnerability in Bitcoin's original implementation allowed malformed blocks
@@ -651,7 +651,7 @@ H(CD) = SHA256(SHA256(1c8d...2e3f || 9a4b...5c6d))</pre>
                 </p>
             </div>
 
-            <h3>12.8.2 Leaf vs. Internal Node Ambiguity</h3>
+            <h3 id="s12-8-2">12.8.2 Leaf vs. Internal Node Ambiguity</h3>
 
             <p>
                 Bitcoin's Merkle tree does not distinguish leaves from internal nodes: an
@@ -669,20 +669,20 @@ H(CD) = SHA256(SHA256(1c8d...2e3f || 9a4b...5c6d))</pre>
         </section>
 
         <section>
-            <h2>12.9 Generalized Merkle Trees</h2>
+            <h2 id="s12-9">12.9 Generalized Merkle Trees</h2>
 
             <p>
                 Several Bitcoin proposals extend the basic Merkle tree concept.
             </p>
 
-            <h3>12.9.1 Merkle Mountain Ranges</h3>
+            <h3 id="s12-9-1">12.9.1 Merkle Mountain Ranges</h3>
 
             <p>
                 Merkle Mountain Ranges (MMRs) allow efficient append-only commitment, useful
                 for UTXOs and chain state.
             </p>
 
-            <h3>12.9.2 Merkle-ized Abstract Syntax Trees (MAST)</h3>
+            <h3 id="s12-9-2">12.9.2 Merkle-ized Abstract Syntax Trees (MAST)</h3>
 
             <p>
                 MAST (now realized through Taproot) allows committing to multiple spending

--- a/chapters/13-blocks.html
+++ b/chapters/13-blocks.html
@@ -51,7 +51,7 @@
         </section>
 
         <section>
-            <h2>13.1 Block Structure</h2>
+            <h2 id="s13-1">13.1 Block Structure</h2>
 
             <p>
                 A Bitcoin block consists of two parts: a compact header and a list of transactions.
@@ -112,7 +112,7 @@
         </section>
 
         <section>
-            <h2>13.2 The Block Header</h2>
+            <h2 id="s13-2">13.2 The Block Header</h2>
 
             <p>
                 The block header is the most critical 80 bytes in Bitcoin. It contains
@@ -203,7 +203,7 @@
                 <figcaption>Figure 13.2: The six fields of a block header, all stored in little-endian format.</figcaption>
             </figure>
 
-            <h3>13.2.1 Version</h3>
+            <h3 id="s13-2-1">13.2.1 Version</h3>
 
             <p>
                 The version field signals support for consensus rule changes and soft forks.
@@ -218,7 +218,7 @@
                 </p>
             </div>
 
-            <h3>13.2.2 Previous Block Hash</h3>
+            <h3 id="s13-2-2">13.2.2 Previous Block Hash</h3>
 
             <p>
                 This field creates the chain structure by referencing the parent block.
@@ -246,13 +246,13 @@
                 </p>
             </div>
 
-            <h3>13.2.3 Merkle Root</h3>
+            <h3 id="s13-2-3">13.2.3 Merkle Root</h3>
 
             <p>
                 The Merkle root commits to all transactions in the block, as detailed in Chapter 12.
             </p>
 
-            <h3>13.2.4 Timestamp</h3>
+            <h3 id="s13-2-4">13.2.4 Timestamp</h3>
 
             <div class="definition">
                 <p class="definition-title">Definition 13.5 (Block Timestamp)</p>
@@ -273,7 +273,7 @@
                 </ul>
             </div>
 
-            <h3>13.2.5 Bits (Difficulty Target)</h3>
+            <h3 id="s13-2-5">13.2.5 Bits (Difficulty Target)</h3>
 
             <p>
                 The <code>bits</code> field encodes the difficulty target in a compact format.
@@ -305,7 +305,7 @@ target = 0x00ffff × 256^(29-3)
        = 0x00000000ffff0000...0000 (with many trailing zeros)</pre>
             </div>
 
-            <h3>13.2.6 Nonce</h3>
+            <h3 id="s13-2-6">13.2.6 Nonce</h3>
 
             <p>
                 The nonce is the "free" field that miners vary to search for a valid proof of work.
@@ -330,7 +330,7 @@ target = 0x00ffff × 256^(29-3)
         </section>
 
         <section>
-            <h2>13.3 Block Hashing and the Chain</h2>
+            <h2 id="s13-3">13.3 Block Hashing and the Chain</h2>
 
             <p>
                 The blockchain is formed by each block referencing its predecessor's hash.
@@ -403,13 +403,13 @@ target = 0x00ffff × 256^(29-3)
         </section>
 
         <section>
-            <h2>13.4 Block Size and Weight</h2>
+            <h2 id="s13-4">13.4 Block Size and Weight</h2>
 
             <p>
                 Bitcoin limits block size to prevent resource exhaustion attacks.
             </p>
 
-            <h3>13.4.1 Legacy Block Size Limit</h3>
+            <h3 id="s13-4-1">13.4.1 Legacy Block Size Limit</h3>
 
             <div class="definition">
                 <p class="definition-title">Definition 13.8 (Block Size Limit)</p>
@@ -421,7 +421,7 @@ target = 0x00ffff × 256^(29-3)
                 </p>
             </div>
 
-            <h3>13.4.2 Block Weight (SegWit)</h3>
+            <h3 id="s13-4-2">13.4.2 Block Weight (SegWit)</h3>
 
             <p>
                 SegWit replaced the size limit with a weight limit, providing a discount
@@ -475,7 +475,7 @@ target = 0x00ffff × 256^(29-3)
         </section>
 
         <section>
-            <h2>13.5 Block Validation Rules</h2>
+            <h2 id="s13-5">13.5 Block Validation Rules</h2>
 
             <p>
                 A block must satisfy numerous rules to be considered valid.
@@ -523,7 +523,7 @@ target = 0x00ffff × 256^(29-3)
         </section>
 
         <section>
-            <h2>13.6 The Genesis Block</h2>
+            <h2 id="s13-6">13.6 The Genesis Block</h2>
 
             <p>
                 The blockchain begins with a special hardcoded block: the genesis block.
@@ -593,7 +593,7 @@ target = 0x00ffff × 256^(29-3)
         </section>
 
         <section>
-            <h2>13.7 Block Height and Depth</h2>
+            <h2 id="s13-7">13.7 Block Height and Depth</h2>
 
             <div class="definition">
                 <p class="definition-title">Definition 13.12 (Block Height)</p>
@@ -646,7 +646,7 @@ target = 0x00ffff × 256^(29-3)
         </section>
 
         <section>
-            <h2>13.8 Orphan and Stale Blocks</h2>
+            <h2 id="s13-8">13.8 Orphan and Stale Blocks</h2>
 
             <p>
                 Not all valid blocks become part of the main chain.
@@ -705,7 +705,7 @@ target = 0x00ffff × 256^(29-3)
         </section>
 
         <section>
-            <h2>13.9 Block Propagation</h2>
+            <h2 id="s13-9">13.9 Block Propagation</h2>
 
             <p>
                 For the network to function, new blocks must propagate quickly to all nodes.

--- a/chapters/14-proof-of-work.html
+++ b/chapters/14-proof-of-work.html
@@ -52,7 +52,7 @@
         </section>
 
         <section>
-            <h2>14.1 The Concept of Proof of Work</h2>
+            <h2 id="s14-1">14.1 The Concept of Proof of Work</h2>
 
             <p>
                 Proof of work was invented independently multiple times, notably by Cynthia
@@ -104,7 +104,7 @@
         </section>
 
         <section>
-            <h2>14.2 Bitcoin's Hash Puzzle</h2>
+            <h2 id="s14-2">14.2 Bitcoin's Hash Puzzle</h2>
 
             <p>
                 Bitcoin uses a hash-based proof of work: find an input that produces a hash
@@ -202,7 +202,7 @@
         </section>
 
         <section>
-            <h2>14.3 Difficulty and Target</h2>
+            <h2 id="s14-3">14.3 Difficulty and Target</h2>
 
             <p>
                 The target is encoded in the block header's <code>bits</code> field and determines
@@ -235,7 +235,7 @@
                 </ul>
             </div>
 
-            <h3>14.3.1 Leading Zeros</h3>
+            <h3 id="s14-3-1">14.3.1 Leading Zeros</h3>
 
             <p>
                 A lower target means more leading zeros are required in the hash.
@@ -260,7 +260,7 @@
         </section>
 
         <section>
-            <h2>14.4 The Difficulty Adjustment Algorithm</h2>
+            <h2 id="s14-4">14.4 The Difficulty Adjustment Algorithm</h2>
 
             <p>
                 Bitcoin automatically adjusts difficulty to maintain approximately 10-minute
@@ -360,7 +360,7 @@ new_difficulty = old_difficulty / 0.857
         </section>
 
         <section>
-            <h2>14.5 The Mining Process</h2>
+            <h2 id="s14-5">14.5 The Mining Process</h2>
 
             <p>
                 Mining is the iterative process of searching for a valid proof of work.
@@ -439,7 +439,7 @@ new_difficulty = old_difficulty / 0.857
         </section>
 
         <section>
-            <h2>14.6 Hash Rate and Work</h2>
+            <h2 id="s14-6">14.6 Hash Rate and Work</h2>
 
             <div class="definition">
                 <p class="definition-title">Definition 14.5 (Hash Rate)</p>
@@ -482,7 +482,7 @@ new_difficulty = old_difficulty / 0.857
         </section>
 
         <section>
-            <h2>14.7 Mining Economics</h2>
+            <h2 id="s14-7">14.7 Mining Economics</h2>
 
             <p>
                 Mining is economically rational only when revenue exceeds costs.
@@ -537,13 +537,13 @@ Daily profit = $3.60 - $3.60 = $0.00</pre>
         </section>
 
         <section>
-            <h2>14.8 Security Analysis</h2>
+            <h2 id="s14-8">14.8 Security Analysis</h2>
 
             <p>
                 Proof of work provides security through economic cost.
             </p>
 
-            <h3>14.8.1 Double-Spend Attacks</h3>
+            <h3 id="s14-8-1">14.8.1 Double-Spend Attacks</h3>
 
             <div class="definition">
                 <p class="definition-title">Definition 14.9 (Double-Spend Attack)</p>
@@ -611,7 +611,7 @@ Daily profit = $3.60 - $3.60 = $0.00</pre>
                 </tbody>
             </table>
 
-            <h3>14.8.2 The 51% Attack</h3>
+            <h3 id="s14-8-2">14.8.2 The 51% Attack</h3>
 
             <div class="theorem">
                 <p class="theorem-title">Theorem 14.5 (Majority Attack)</p>
@@ -633,7 +633,7 @@ Daily profit = $3.60 - $3.60 = $0.00</pre>
                 </ul>
             </div>
 
-            <h3>14.8.3 Selfish Mining</h3>
+            <h3 id="s14-8-3">14.8.3 Selfish Mining</h3>
 
             <div class="remark">
                 <p class="remark-title">Remark 14.2 (Selfish Mining)</p>
@@ -646,7 +646,7 @@ Daily profit = $3.60 - $3.60 = $0.00</pre>
         </section>
 
         <section>
-            <h2>14.9 Energy and Thermodynamics</h2>
+            <h2 id="s14-9">14.9 Energy and Thermodynamics</h2>
 
             <p>
                 Proof of work converts electricity into security through an irreversible
@@ -686,7 +686,7 @@ Daily profit = $3.60 - $3.60 = $0.00</pre>
         </section>
 
         <section>
-            <h2>14.10 Mining Hardware Evolution</h2>
+            <h2 id="s14-10">14.10 Mining Hardware Evolution</h2>
 
             <p>
                 Mining hardware has evolved through several generations.

--- a/chapters/15-consensus-parameters.html
+++ b/chapters/15-consensus-parameters.html
@@ -52,7 +52,7 @@
         </section>
 
         <section>
-            <h2>15.1 The 21 Million Cap</h2>
+            <h2 id="s15-1">15.1 The 21 Million Cap</h2>
 
             <p>
                 Bitcoin's most famous parameter is its fixed supply limit.
@@ -155,7 +155,7 @@
         </section>
 
         <section>
-            <h2>15.2 The Block Subsidy Schedule</h2>
+            <h2 id="s15-2">15.2 The Block Subsidy Schedule</h2>
 
             <p>
                 New bitcoins are created exclusively through block subsidies, which halve
@@ -256,7 +256,7 @@
         </section>
 
         <section>
-            <h2>15.3 Block Timing Parameters</h2>
+            <h2 id="s15-3">15.3 Block Timing Parameters</h2>
 
             <div class="definition">
                 <p class="definition-title">Definition 15.3 (Target Block Time)</p>
@@ -310,7 +310,7 @@ Time between halvings: 210,000 × 10 min = 2,100,000 min
         </section>
 
         <section>
-            <h2>15.4 Block Size and Weight Limits</h2>
+            <h2 id="s15-4">15.4 Block Size and Weight Limits</h2>
 
             <div class="definition">
                 <p class="definition-title">Definition 15.5 (Block Weight Limit)</p>
@@ -371,7 +371,7 @@ Time between halvings: 210,000 × 10 min = 2,100,000 min
         </section>
 
         <section>
-            <h2>15.5 Coinbase Maturity</h2>
+            <h2 id="s15-5">15.5 Coinbase Maturity</h2>
 
             <div class="definition">
                 <p class="definition-title">Definition 15.7 (Coinbase Maturity)</p>
@@ -404,7 +404,7 @@ Time between halvings: 210,000 × 10 min = 2,100,000 min
         </section>
 
         <section>
-            <h2>15.6 Timestamp Rules</h2>
+            <h2 id="s15-6">15.6 Timestamp Rules</h2>
 
             <div class="definition">
                 <p class="definition-title">Definition 15.8 (Median Time Past)</p>
@@ -455,7 +455,7 @@ Time between halvings: 210,000 × 10 min = 2,100,000 min
         </section>
 
         <section>
-            <h2>15.7 Script and Transaction Limits</h2>
+            <h2 id="s15-7">15.7 Script and Transaction Limits</h2>
 
             <table class="data-table">
                 <thead>
@@ -516,7 +516,7 @@ Time between halvings: 210,000 × 10 min = 2,100,000 min
         </section>
 
         <section>
-            <h2>15.8 Network Protocol Constants</h2>
+            <h2 id="s15-8">15.8 Network Protocol Constants</h2>
 
             <div class="definition">
                 <p class="definition-title">Definition 15.10 (Protocol Version)</p>
@@ -567,13 +567,13 @@ Time between halvings: 210,000 × 10 min = 2,100,000 min
         </section>
 
         <section>
-            <h2>15.9 Economic Design Rationale</h2>
+            <h2 id="s15-9">15.9 Economic Design Rationale</h2>
 
             <p>
                 The parameters were chosen to create specific economic properties.
             </p>
 
-            <h3>15.9.1 Scarcity</h3>
+            <h3 id="s15-9-1">15.9.1 Scarcity</h3>
 
             <div class="remark">
                 <p class="remark-title">Remark 15.4 (Digital Scarcity)</p>
@@ -584,7 +584,7 @@ Time between halvings: 210,000 × 10 min = 2,100,000 min
                 </p>
             </div>
 
-            <h3>15.9.2 Diminishing Inflation</h3>
+            <h3 id="s15-9-2">15.9.2 Diminishing Inflation</h3>
 
             <div class="theorem">
                 <p class="theorem-title">Theorem 15.3 (Inflation Rate)</p>
@@ -636,7 +636,7 @@ Time between halvings: 210,000 × 10 min = 2,100,000 min
                 </tbody>
             </table>
 
-            <h3>15.9.3 Security Budget Transition</h3>
+            <h3 id="s15-9-3">15.9.3 Security Budget Transition</h3>
 
             <div class="remark">
                 <p class="remark-title">Remark 15.5 (Fee Transition)</p>
@@ -649,7 +649,7 @@ Time between halvings: 210,000 × 10 min = 2,100,000 min
         </section>
 
         <section>
-            <h2>15.10 Parameter Immutability</h2>
+            <h2 id="s15-10">15.10 Parameter Immutability</h2>
 
             <p>
                 Consensus parameters are not merely difficult to change&mdash;altering them would
@@ -692,7 +692,7 @@ Time between halvings: 210,000 × 10 min = 2,100,000 min
         </section>
 
         <section>
-            <h2>15.11 Summary of Key Constants</h2>
+            <h2 id="s15-11">15.11 Summary of Key Constants</h2>
 
             <table class="data-table">
                 <thead>

--- a/chapters/16-soft-forks.html
+++ b/chapters/16-soft-forks.html
@@ -48,7 +48,7 @@
         </section>
 
         <section>
-            <h2>16.1 Policy vs Consensus</h2>
+            <h2 id="s16-1">16.1 Policy vs Consensus</h2>
 
             <p>
                 Bitcoin nodes enforce two distinct sets of rules, and understanding their
@@ -159,7 +159,7 @@
         </section>
 
         <section>
-            <h2>16.2 Hard Forks vs Soft Forks</h2>
+            <h2 id="s16-2">16.2 Hard Forks vs Soft Forks</h2>
 
             <p>
                 Protocol changes are categorized by their compatibility properties.
@@ -236,14 +236,14 @@
         </section>
 
         <section>
-            <h2>16.3 Activation Mechanisms</h2>
+            <h2 id="s16-3">16.3 Activation Mechanisms</h2>
 
             <p>
                 Soft forks require coordination to activate safely. Several mechanisms
                 have been developed.
             </p>
 
-            <h3>16.3.1 Flag Day Activation</h3>
+            <h3 id="s16-3-1">16.3.1 Flag Day Activation</h3>
 
             <div class="definition">
                 <p class="definition-title">Definition 16.5 (Flag Day)</p>
@@ -253,7 +253,7 @@
                 </p>
             </div>
 
-            <h3>16.3.2 BIP-9: Miner Signaling</h3>
+            <h3 id="s16-3-2">16.3.2 BIP-9: Miner Signaling</h3>
 
             <div class="definition">
                 <p class="definition-title">Definition 16.6 (BIP-9 Version Bits)</p>
@@ -302,7 +302,7 @@
                 <figcaption>Figure 16.3: BIP-9 state machine for soft fork activation.</figcaption>
             </figure>
 
-            <h3>16.3.3 BIP-8: Mandatory Activation</h3>
+            <h3 id="s16-3-3">16.3.3 BIP-8: Mandatory Activation</h3>
 
             <div class="definition">
                 <p class="definition-title">Definition 16.7 (BIP-8)</p>
@@ -313,7 +313,7 @@
                 </p>
             </div>
 
-            <h3>16.3.4 Speedy Trial</h3>
+            <h3 id="s16-3-4">16.3.4 Speedy Trial</h3>
 
             <div class="definition">
                 <p class="definition-title">Definition 16.8 (Speedy Trial)</p>
@@ -325,7 +325,7 @@
         </section>
 
         <section>
-            <h2>16.4 Major Soft Forks in Bitcoin History</h2>
+            <h2 id="s16-4">16.4 Major Soft Forks in Bitcoin History</h2>
 
             <table class="data-table">
                 <thead>
@@ -376,7 +376,7 @@
                 </tbody>
             </table>
 
-            <h3>16.4.1 P2SH (BIP-16)</h3>
+            <h3 id="s16-4-1">16.4.1 P2SH (BIP-16)</h3>
 
             <div class="remark">
                 <p class="remark-title">Remark 16.2 (P2SH Soft Fork)</p>
@@ -388,7 +388,7 @@
                 </p>
             </div>
 
-            <h3>16.4.2 Segregated Witness (BIP-141)</h3>
+            <h3 id="s16-4-2">16.4.2 Segregated Witness (BIP-141)</h3>
 
             <div class="remark">
                 <p class="remark-title">Remark 16.3 (SegWit Soft Fork)</p>
@@ -407,7 +407,7 @@
                 </p>
             </div>
 
-            <h3>16.4.3 Taproot (BIP-341)</h3>
+            <h3 id="s16-4-3">16.4.3 Taproot (BIP-341)</h3>
 
             <div class="remark">
                 <p class="remark-title">Remark 16.4 (Taproot Soft Fork)</p>
@@ -427,7 +427,7 @@
         </section>
 
         <section>
-            <h2>16.5 The Soft Fork Design Pattern</h2>
+            <h2 id="s16-5">16.5 The Soft Fork Design Pattern</h2>
 
             <p>
                 Most soft forks follow a common pattern: redefine outputs that old nodes
@@ -483,7 +483,7 @@
         </section>
 
         <section>
-            <h2>16.6 Standardness as Soft Fork Preparation</h2>
+            <h2 id="s16-6">16.6 Standardness as Soft Fork Preparation</h2>
 
             <p>
                 Policy rules often prepare the ground for future consensus changes.
@@ -531,9 +531,9 @@
         </section>
 
         <section>
-            <h2>16.7 Risks and Challenges</h2>
+            <h2 id="s16-7">16.7 Risks and Challenges</h2>
 
-            <h3>16.7.1 Chain Split Risk</h3>
+            <h3 id="s16-7-1">16.7.1 Chain Split Risk</h3>
 
             <div class="theorem">
                 <p class="theorem-title">Theorem 16.3 (Soft Fork Split Conditions)</p>
@@ -551,7 +551,7 @@
                 </p>
             </div>
 
-            <h3>16.7.2 Coordination Challenges</h3>
+            <h3 id="s16-7-2">16.7.2 Coordination Challenges</h3>
 
             <div class="remark">
                 <p class="remark-title">Remark 16.6 (Upgrade Coordination)</p>
@@ -570,7 +570,7 @@
                 </p>
             </div>
 
-            <h3>16.7.3 Irreversibility</h3>
+            <h3 id="s16-7-3">16.7.3 Irreversibility</h3>
 
             <p>
                 Once a soft fork activates, reversing it would require a hard fork (the
@@ -579,13 +579,13 @@
         </section>
 
         <section>
-            <h2>16.8 Future Upgrade Paths</h2>
+            <h2 id="s16-8">16.8 Future Upgrade Paths</h2>
 
             <p>
                 Bitcoin's design includes provisions for future upgrades.
             </p>
 
-            <h3>16.8.1 Witness Versions</h3>
+            <h3 id="s16-8-1">16.8.1 Witness Versions</h3>
 
             <div class="definition">
                 <p class="definition-title">Definition 16.10 (Witness Versions)</p>
@@ -599,7 +599,7 @@
                 </ul>
             </div>
 
-            <h3>16.8.2 Taproot's OP_SUCCESS</h3>
+            <h3 id="s16-8-2">16.8.2 Taproot's OP_SUCCESS</h3>
 
             <div class="definition">
                 <p class="definition-title">Definition 16.11 (OP_SUCCESS)</p>
@@ -610,7 +610,7 @@
                 </p>
             </div>
 
-            <h3>16.8.3 Proposed Soft Forks</h3>
+            <h3 id="s16-8-3">16.8.3 Proposed Soft Forks</h3>
 
             <p>
                 Several soft forks are under discussion (as of 2024):
@@ -624,7 +624,7 @@
         </section>
 
         <section>
-            <h2>16.9 The Social Layer</h2>
+            <h2 id="s16-9">16.9 The Social Layer</h2>
 
             <p>
                 Technical mechanisms are necessary but not sufficient for upgrades.

--- a/chapters/17-spv-theory.html
+++ b/chapters/17-spv-theory.html
@@ -53,7 +53,7 @@
         </section>
 
         <section>
-            <h2>17.1 The Original Text</h2>
+            <h2 id="s17-1">17.1 The Original Text</h2>
 
             <p>
                 Let us quote Section 8 of the whitepaper in full, then analyze it systematically.
@@ -91,7 +91,7 @@
         </section>
 
         <section>
-            <h2>17.2 The SPV Data Model</h2>
+            <h2 id="s17-2">17.2 The SPV Data Model</h2>
 
             <p>
                 An SPV client maintains a minimal data set compared to a full node.
@@ -173,7 +173,7 @@
         </section>
 
         <section>
-            <h2>17.3 What SPV Proves</h2>
+            <h2 id="s17-3">17.3 What SPV Proves</h2>
 
             <p>
                 The fundamental claim of SPV is that a Merkle proof demonstrates transaction
@@ -274,7 +274,7 @@
         </section>
 
         <section>
-            <h2>17.4 What SPV Does Not Prove</h2>
+            <h2 id="s17-4">17.4 What SPV Does Not Prove</h2>
 
             <p>
                 This is where misunderstandings flourish. Let us be explicit about what
@@ -331,7 +331,7 @@
         </section>
 
         <section>
-            <h2>17.5 The Security Model</h2>
+            <h2 id="s17-5">17.5 The Security Model</h2>
 
             <p>
                 Let us formalize the SPV security assumption.
@@ -364,7 +364,7 @@
                 </ol>
             </div>
 
-            <h3>17.5.1 Fabrication Attacks</h3>
+            <h3 id="s17-5-1">17.5.1 Fabrication Attacks</h3>
 
             <p>
                 Can an attacker fool an SPV client with a fake transaction?
@@ -399,7 +399,7 @@
                 </ul>
             </div>
 
-            <h3>17.5.2 Eclipse Attacks</h3>
+            <h3 id="s17-5-2">17.5.2 Eclipse Attacks</h3>
 
             <div class="definition">
                 <p class="definition-title">Definition 17.4 (Eclipse Attack)</p>
@@ -455,7 +455,7 @@
         </section>
 
         <section>
-            <h2>17.6 Confirmation Security</h2>
+            <h2 id="s17-6">17.6 Confirmation Security</h2>
 
             <p>
                 The number of confirmations affects security against double-spend attacks.
@@ -531,7 +531,7 @@
         </section>
 
         <section>
-            <h2>17.7 The Fraud Proof Concept</h2>
+            <h2 id="s17-7">17.7 The Fraud Proof Concept</h2>
 
             <p>
                 Satoshi's whitepaper hints at a defense mechanism: fraud proofs.
@@ -568,7 +568,7 @@
         </section>
 
         <section>
-            <h2>17.8 SPV vs Full Verification: A Comparison</h2>
+            <h2 id="s17-8">17.8 SPV vs Full Verification: A Comparison</h2>
 
             <table class="data-table">
                 <thead>
@@ -624,7 +624,7 @@
         </section>
 
         <section>
-            <h2>17.9 When Is SPV Appropriate?</h2>
+            <h2 id="s17-9">17.9 When Is SPV Appropriate?</h2>
 
             <p>
                 Given the security trade-offs, when should SPV be used?
@@ -660,7 +660,7 @@
         </section>
 
         <section>
-            <h2>17.10 Historical Context</h2>
+            <h2 id="s17-10">17.10 Historical Context</h2>
 
             <p>
                 The term "SPV" and its security model have been subject to much debate.

--- a/chapters/18-bloom-filters.html
+++ b/chapters/18-bloom-filters.html
@@ -99,7 +99,7 @@
         </div>
 
         <section>
-            <h2>18.1 Bloom Filter Fundamentals</h2>
+            <h2 id="s18-1">18.1 Bloom Filter Fundamentals</h2>
 
             <p>
                 A Bloom filter is a space-efficient probabilistic data structure that tests
@@ -297,7 +297,7 @@
         </section>
 
         <section>
-            <h2>18.2 BIP-37 Protocol Specification</h2>
+            <h2 id="s18-2">18.2 BIP-37 Protocol Specification</h2>
 
             <p>
                 BIP-37 defines how SPV clients communicate Bloom filters to full nodes
@@ -521,7 +521,7 @@
         </section>
 
         <section>
-            <h2>18.3 The Privacy Catastrophe</h2>
+            <h2 id="s18-3">18.3 The Privacy Catastrophe</h2>
 
             <p>
                 BIP-37's fundamental flaw is that the client sends its filter directly to
@@ -684,7 +684,7 @@
         </section>
 
         <section>
-            <h2>18.4 Denial of Service Vulnerabilities</h2>
+            <h2 id="s18-4">18.4 Denial of Service Vulnerabilities</h2>
 
             <p>
                 Beyond privacy, BIP-37 exposes full nodes to denial-of-service attacks.
@@ -770,7 +770,7 @@
         </section>
 
         <section>
-            <h2>18.5 Implementation Details</h2>
+            <h2 id="s18-5">18.5 Implementation Details</h2>
 
             <h3>MurmurHash3 Specification</h3>
 
@@ -918,7 +918,7 @@
         </section>
 
         <section>
-            <h2>18.6 Historical Context and Lessons</h2>
+            <h2 id="s18-6">18.6 Historical Context and Lessons</h2>
 
             <h3>Timeline</h3>
 
@@ -997,7 +997,7 @@
         </section>
 
         <section>
-            <h2>18.7 Why Some Wallets Still Use BIP-37</h2>
+            <h2 id="s18-7">18.7 Why Some Wallets Still Use BIP-37</h2>
 
             <p>
                 Despite its flaws, BIP-37 remains in use by some wallets because:

--- a/chapters/19-compact-filters.html
+++ b/chapters/19-compact-filters.html
@@ -82,7 +82,7 @@
         </div>
 
         <section>
-            <h2>19.1 The Architectural Inversion</h2>
+            <h2 id="s19-1">19.1 The Architectural Inversion</h2>
 
             <p>
                 BIP-157/158 inverts the BIP-37 model:
@@ -223,7 +223,7 @@
         </section>
 
         <section>
-            <h2>19.2 Golomb-Rice Coding</h2>
+            <h2 id="s19-2">19.2 Golomb-Rice Coding</h2>
 
             <p>
                 Compact block filters achieve their small size through Golomb-Rice coding,
@@ -429,7 +429,7 @@
         </section>
 
         <section>
-            <h2>19.3 BIP-158 Filter Construction</h2>
+            <h2 id="s19-3">19.3 BIP-158 Filter Construction</h2>
 
             <p>
                 BIP-158 specifies exactly how to construct the "basic" filter type for
@@ -586,7 +586,7 @@
         </section>
 
         <section>
-            <h2>19.4 BIP-157 Protocol</h2>
+            <h2 id="s19-4">19.4 BIP-157 Protocol</h2>
 
             <p>
                 BIP-157 defines the network protocol for requesting and serving compact
@@ -812,7 +812,7 @@
         </section>
 
         <section>
-            <h2>19.5 Security Analysis</h2>
+            <h2 id="s19-5">19.5 Security Analysis</h2>
 
             <h3>False Positive Rate</h3>
 
@@ -898,7 +898,7 @@
         </section>
 
         <section>
-            <h2>19.6 Implementation Considerations</h2>
+            <h2 id="s19-6">19.6 Implementation Considerations</h2>
 
             <h3>Storage Requirements</h3>
 
@@ -1000,7 +1000,7 @@
         </section>
 
         <section>
-            <h2>19.7 Neutrino: A Reference Implementation</h2>
+            <h2 id="s19-7">19.7 Neutrino: A Reference Implementation</h2>
 
             <p>
                 Neutrino is the reference light client implementation of BIP-157/158,

--- a/chapters/20-light-clients.html
+++ b/chapters/20-light-clients.html
@@ -86,7 +86,7 @@
         </section>
 
         <section>
-            <h2>20.1 The Light Client Spectrum</h2>
+            <h2 id="s20-1">20.1 The Light Client Spectrum</h2>
 
             <p>
                 Light clients exist on a spectrum from "minimal trust, maximal resources" to
@@ -179,7 +179,7 @@
         </section>
 
         <section>
-            <h2>20.2 The Electrum Protocol</h2>
+            <h2 id="s20-2">20.2 The Electrum Protocol</h2>
 
             <p>
                 Electrum, created in 2011, pioneered the client-server model for Bitcoin
@@ -401,7 +401,7 @@ script_hash (little-endian hex) = 56f4de...23c1ab</code></pre>
         </section>
 
         <section>
-            <h2>20.3 Privacy Analysis of Electrum</h2>
+            <h2 id="s20-3">20.3 Privacy Analysis of Electrum</h2>
 
             <h3>What the Server Learns</h3>
 
@@ -468,7 +468,7 @@ script_hash (little-endian hex) = 56f4de...23c1ab</code></pre>
         </section>
 
         <section>
-            <h2>20.4 Esplora and Block Explorer APIs</h2>
+            <h2 id="s20-4">20.4 Esplora and Block Explorer APIs</h2>
 
             <p>
                 Many wallets use HTTP APIs provided by block explorers. While convenient,
@@ -549,7 +549,7 @@ Response:
         </section>
 
         <section>
-            <h2>20.5 Hybrid Approaches</h2>
+            <h2 id="s20-5">20.5 Hybrid Approaches</h2>
 
             <p>
                 Modern wallets often combine multiple approaches to optimize for different
@@ -684,7 +684,7 @@ Response:
         </section>
 
         <section>
-            <h2>20.6 The Validation Gap</h2>
+            <h2 id="s20-6">20.6 The Validation Gap</h2>
 
             <p>
                 The previous sections described how light clients obtain and verify
@@ -1028,7 +1028,7 @@ Response:
         </section>
 
         <section>
-            <h2>20.7 Wallet Architectures in Practice</h2>
+            <h2 id="s20-7">20.7 Wallet Architectures in Practice</h2>
 
             <h3>Desktop Wallets</h3>
 
@@ -1123,7 +1123,7 @@ Response:
         </section>
 
         <section>
-            <h2>20.8 Choosing an Architecture</h2>
+            <h2 id="s20-8">20.8 Choosing an Architecture</h2>
 
             <h3>Decision Framework</h3>
 

--- a/chapters/21-node-optimizations.html
+++ b/chapters/21-node-optimizations.html
@@ -78,7 +78,7 @@
         </section>
 
         <section>
-            <h2>21.1 Initial Block Download (IBD)</h2>
+            <h2 id="s21-1">21.1 Initial Block Download (IBD)</h2>
 
             <p>
                 When a new node joins the network, it must download and validate every
@@ -241,7 +241,7 @@
         </section>
 
         <section>
-            <h2>21.2 AssumeValid</h2>
+            <h2 id="s21-2">21.2 AssumeValid</h2>
 
             <p>
                 The most time-consuming part of IBD is signature validation&mdash;verifying every
@@ -389,7 +389,7 @@ bitcoind -assumevalid=00000000000000000001...</code></pre>
         </section>
 
         <section>
-            <h2>21.3 AssumeUTXO</h2>
+            <h2 id="s21-3">21.3 AssumeUTXO</h2>
 
             <p>
                 While AssumeValid speeds up validation, it does not eliminate the need to
@@ -551,7 +551,7 @@ bitcoin-cli loadtxoutset /path/to/utxo.dat
         </section>
 
         <section>
-            <h2>21.4 Pruning</h2>
+            <h2 id="s21-4">21.4 Pruning</h2>
 
             <p>
                 Pruned nodes discard old block data after validation, keeping only the
@@ -625,7 +625,7 @@ prune=550</code></pre>
         </section>
 
         <section>
-            <h2>21.5 Utreexo</h2>
+            <h2 id="s21-5">21.5 Utreexo</h2>
 
             <p>
                 Utreexo is a cryptographic accumulator that dramatically reduces the storage
@@ -830,7 +830,7 @@ prune=550</code></pre>
         </section>
 
         <section>
-            <h2>21.6 Comparison and Recommendations</h2>
+            <h2 id="s21-6">21.6 Comparison and Recommendations</h2>
 
             <h3>Optimization Summary</h3>
 

--- a/chapters/22-client-side-validation.html
+++ b/chapters/22-client-side-validation.html
@@ -85,7 +85,7 @@
         </section>
 
         <section>
-            <h2>22.1 The Validation Paradigm Shift</h2>
+            <h2 id="s22-1">22.1 The Validation Paradigm Shift</h2>
 
             <p>
                 Traditional blockchain design couples state transitions with global consensus:
@@ -161,7 +161,7 @@
         </section>
 
         <section>
-            <h2>22.2 Single-Use Seals</h2>
+            <h2 id="s22-2">22.2 Single-Use Seals</h2>
 
             <p>
                 The theoretical foundation of client-side validation is the <em>single-use seal</em>,
@@ -346,7 +346,7 @@
         </section>
 
         <section>
-            <h2>22.3 RGB Protocol</h2>
+            <h2 id="s22-3">22.3 RGB Protocol</h2>
 
             <p>
                 RGB is the most developed client-side validation protocol for Bitcoin,
@@ -549,7 +549,7 @@
         </section>
 
         <section>
-            <h2>22.4 Taproot Assets (Taro)</h2>
+            <h2 id="s22-4">22.4 Taproot Assets (Taro)</h2>
 
             <p>
                 Taproot Assets (formerly Taro) is Lightning Labs' implementation of client-side
@@ -679,7 +679,7 @@
         </section>
 
         <section>
-            <h2>22.5 Scalability Analysis</h2>
+            <h2 id="s22-5">22.5 Scalability Analysis</h2>
 
             <h3>On-Chain Footprint</h3>
 
@@ -774,7 +774,7 @@
         </section>
 
         <section>
-            <h2>22.6 Applications</h2>
+            <h2 id="s22-6">22.6 Applications</h2>
 
             <h3>Use Cases</h3>
 

--- a/chapters/23-payment-channels.html
+++ b/chapters/23-payment-channels.html
@@ -90,7 +90,7 @@
         </section>
 
         <section>
-            <h2>23.1 The Scaling Problem</h2>
+            <h2 id="s23-1">23.1 The Scaling Problem</h2>
 
             <p>
                 Bitcoin's on-chain capacity is fundamentally limited:
@@ -135,7 +135,7 @@
         </section>
 
         <section>
-            <h2>23.2 Unidirectional Payment Channels</h2>
+            <h2 id="s23-2">23.2 Unidirectional Payment Channels</h2>
 
             <p>
                 We begin with the simplest channel type: one party (customer) pays another
@@ -305,7 +305,7 @@ OP_ENDIF</code></pre>
         </section>
 
         <section>
-            <h2>23.3 The Bidirectional Channel Problem</h2>
+            <h2 id="s23-3">23.3 The Bidirectional Channel Problem</h2>
 
             <p>
                 Unidirectional channels only allow value to flow one way. For general payment
@@ -368,7 +368,7 @@ OP_ENDIF</code></pre>
         </section>
 
         <section>
-            <h2>23.4 LN-Penalty Channels</h2>
+            <h2 id="s23-4">23.4 LN-Penalty Channels</h2>
 
             <p>
                 The Lightning Network uses <em>revocable commitment transactions</em> with
@@ -541,7 +541,7 @@ OP_ENDIF</code></pre>
         </section>
 
         <section>
-            <h2>23.5 Channel Operations</h2>
+            <h2 id="s23-5">23.5 Channel Operations</h2>
 
             <h3>Channel Lifecycle</h3>
 
@@ -669,7 +669,7 @@ OP_ENDIF</code></pre>
         </section>
 
         <section>
-            <h2>23.6 HTLCs: Conditional Payments</h2>
+            <h2 id="s23-6">23.6 HTLCs: Conditional Payments</h2>
 
             <p>
                 Payment channels become far more capable when combined with Hash Time-Locked
@@ -737,7 +737,7 @@ OP_ENDIF</code></pre>
         </section>
 
         <section>
-            <h2>23.7 Watchtowers</h2>
+            <h2 id="s23-7">23.7 Watchtowers</h2>
 
             <p>
                 A key requirement of LN-Penalty channels: the honest party must monitor the

--- a/chapters/24-lightning.html
+++ b/chapters/24-lightning.html
@@ -84,7 +84,7 @@
         </section>
 
         <section>
-            <h2>24.1 Multi-Hop Payments</h2>
+            <h2 id="s24-1">24.1 Multi-Hop Payments</h2>
 
             <p>
                 The key insight of Lightning: if Alice has a channel with Bob, and Bob has a
@@ -245,7 +245,7 @@
         </section>
 
         <section>
-            <h2>24.2 Onion Routing</h2>
+            <h2 id="s24-2">24.2 Onion Routing</h2>
 
             <p>
                 Lightning uses Sphinx-style onion routing to preserve payment privacy.
@@ -382,7 +382,7 @@
         </section>
 
         <section>
-            <h2>24.3 Invoices and Payment Requests</h2>
+            <h2 id="s24-3">24.3 Invoices and Payment Requests</h2>
 
             <p>
                 Lightning payments are typically initiated by the receiver generating an
@@ -441,7 +441,7 @@ lnbc1pvjluezsp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygspp5qqqsyqcyq5
         </section>
 
         <section>
-            <h2>24.4 Pathfinding and Routing</h2>
+            <h2 id="s24-4">24.4 Pathfinding and Routing</h2>
 
             <p>
                 Finding efficient payment paths through the Lightning Network is a complex
@@ -587,7 +587,7 @@ lnbc1pvjluezsp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygspp5qqqsyqcyq5
         </section>
 
         <section>
-            <h2>24.5 BOLT Specifications</h2>
+            <h2 id="s24-5">24.5 BOLT Specifications</h2>
 
             <p>
                 The Lightning Network is defined by the BOLT (Basis of Lightning Technology)
@@ -663,7 +663,7 @@ lnbc1pvjluezsp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygspp5qqqsyqcyq5
         </section>
 
         <section>
-            <h2>24.6 Network Topology</h2>
+            <h2 id="s24-6">24.6 Network Topology</h2>
 
             <h3>Network Statistics</h3>
 
@@ -733,7 +733,7 @@ lnbc1pvjluezsp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygspp5qqqsyqcyq5
         </section>
 
         <section>
-            <h2>24.7 Future Developments</h2>
+            <h2 id="s24-7">24.7 Future Developments</h2>
 
             <h3>eltoo / LN-Symmetry</h3>
 

--- a/chapters/25-debunking-myths.html
+++ b/chapters/25-debunking-myths.html
@@ -95,7 +95,7 @@
         </section>
 
         <section>
-            <h2>25.1 SPV Myths</h2>
+            <h2 id="s25-1">25.1 SPV Myths</h2>
 
             <div class="myth-box">
                 <h4>Myth: "SPV provides the same security as a full node"</h4>
@@ -197,7 +197,7 @@
         </section>
 
         <section>
-            <h2>25.2 Scaling Myths</h2>
+            <h2 id="s25-2">25.2 Scaling Myths</h2>
 
             <div class="myth-box">
                 <h4>Myth: "Bigger blocks are the only way to scale"</h4>
@@ -347,7 +347,7 @@
         </section>
 
         <section>
-            <h2>25.3 Cryptography Myths</h2>
+            <h2 id="s25-3">25.3 Cryptography Myths</h2>
 
             <div class="myth-box">
                 <h4>Myth: "Quantum computers will break Bitcoin"</h4>
@@ -435,7 +435,7 @@
         </section>
 
         <section>
-            <h2>25.4 Consensus Myths</h2>
+            <h2 id="s25-4">25.4 Consensus Myths</h2>
 
             <div class="myth-box">
                 <h4>Myth: "51% attack means attackers control Bitcoin"</h4>
@@ -528,7 +528,7 @@
         </section>
 
         <section>
-            <h2>25.5 Economic Myths</h2>
+            <h2 id="s25-5">25.5 Economic Myths</h2>
 
             <div class="myth-box">
                 <h4>Myth: "Bitcoin can't work when block subsidy goes to zero"</h4>
@@ -628,7 +628,7 @@
         </section>
 
         <section>
-            <h2>25.6 Technical Misconceptions</h2>
+            <h2 id="s25-6">25.6 Technical Misconceptions</h2>
 
             <div class="myth-box">
                 <h4>Myth: "Bitcoin addresses can be 'frozen' or 'blacklisted'"</h4>
@@ -692,7 +692,7 @@
         </section>
 
         <section>
-            <h2>25.7 Methodology for Myth Evaluation</h2>
+            <h2 id="s25-7">25.7 Methodology for Myth Evaluation</h2>
 
             <p>
                 When encountering claims about Bitcoin, apply this framework:

--- a/chapters/26-fork-theory.html
+++ b/chapters/26-fork-theory.html
@@ -33,7 +33,7 @@
         </section>
 
         <section>
-            <h2>26.1 Defining Forks Formally</h2>
+            <h2 id="s26-1">26.1 Defining Forks Formally</h2>
 
             <p>
                 The term "fork" is overloaded in Bitcoin discourse. We begin with precise definitions.
@@ -127,7 +127,7 @@
         </section>
 
         <section>
-            <h2>26.2 Natural Fork Probability</h2>
+            <h2 id="s26-2">26.2 Natural Fork Probability</h2>
 
             <p>
                 Natural forks occur when network latency allows multiple miners to find blocks
@@ -223,7 +223,7 @@
         </section>
 
         <section>
-            <h2>26.3 The Rule Compatibility Hierarchy</h2>
+            <h2 id="s26-3">26.3 The Rule Compatibility Hierarchy</h2>
 
             <p>
                 Protocol changes are classified by their compatibility properties with existing nodes.
@@ -322,7 +322,7 @@
         </section>
 
         <section>
-            <h2>26.4 Game Theory of Fork Adoption</h2>
+            <h2 id="s26-4">26.4 Game Theory of Fork Adoption</h2>
 
             <p>
                 Fork adoption decisions can be modeled as coordination games with network effects.
@@ -408,7 +408,7 @@
         </section>
 
         <section>
-            <h2>26.5 Replay Protection</h2>
+            <h2 id="s26-5">26.5 Replay Protection</h2>
 
             <p>
                 When chains diverge, transactions valid on one chain may be valid on both&mdash;a
@@ -503,7 +503,7 @@
         </section>
 
         <section>
-            <h2>26.6 Fork Choice Rules</h2>
+            <h2 id="s26-6">26.6 Fork Choice Rules</h2>
 
             <p>
                 Different protocols use different rules to select between competing chains.
@@ -565,7 +565,7 @@
         </section>
 
         <section>
-            <h2>26.7 Finality and Reorg Depth</h2>
+            <h2 id="s26-7">26.7 Finality and Reorg Depth</h2>
 
             <p>
                 Unlike some consensus systems, Bitcoin has probabilistic rather than
@@ -651,7 +651,7 @@
         </section>
 
         <section>
-            <h2>26.8 The Economics of Fork Creation</h2>
+            <h2 id="s26-8">26.8 The Economics of Fork Creation</h2>
 
             <p>
                 Creating a successful fork requires overcoming significant economic barriers.
@@ -706,7 +706,7 @@
         </section>
 
         <section>
-            <h2>26.9 Contentious vs. Non-Contentious Forks</h2>
+            <h2 id="s26-9">26.9 Contentious vs. Non-Contentious Forks</h2>
 
             <p>
                 The social dynamics of forks depend critically on whether the change is

--- a/chapters/27-historical-forks.html
+++ b/chapters/27-historical-forks.html
@@ -32,7 +32,7 @@
         </section>
 
         <section>
-            <h2>27.1 The Block Size Debate: Background</h2>
+            <h2 id="s27-1">27.1 The Block Size Debate: Background</h2>
 
             <p>
                 To understand Bitcoin's hard forks, we must first understand the conflict that
@@ -132,14 +132,14 @@ if (block.GetSerializeSize() > MAX_BLOCK_SIZE)
         </section>
 
         <section>
-            <h2>27.2 Failed Fork Attempts (2015&ndash;2017)</h2>
+            <h2 id="s27-2">27.2 Failed Fork Attempts (2015&ndash;2017)</h2>
 
             <p>
                 Before Bitcoin Cash, several attempts to increase the block size failed to
                 gain sufficient support.
             </p>
 
-            <h3>27.2.1 Bitcoin XT (August 2015)</h3>
+            <h3 id="s27-2-1">27.2.1 Bitcoin XT (August 2015)</h3>
 
             <div class="definition">
                 <p class="definition-title">Definition 27.3 (Bitcoin XT)</p>
@@ -170,7 +170,7 @@ if (block.GetSerializeSize() > MAX_BLOCK_SIZE)
                 </p>
             </div>
 
-            <h3>27.2.2 Bitcoin Classic (February 2016)</h3>
+            <h3 id="s27-2-2">27.2.2 Bitcoin Classic (February 2016)</h3>
 
             <div class="definition">
                 <p class="definition-title">Definition 27.4 (Bitcoin Classic)</p>
@@ -184,7 +184,7 @@ if (block.GetSerializeSize() > MAX_BLOCK_SIZE)
                 </ul>
             </div>
 
-            <h3>27.2.3 Bitcoin Unlimited (announced December 2015, released January 2016)</h3>
+            <h3 id="s27-2-3">27.2.3 Bitcoin Unlimited (announced December 2015, released January 2016)</h3>
 
             <div class="definition">
                 <p class="definition-title">Definition 27.5 (Bitcoin Unlimited)</p>
@@ -217,7 +217,7 @@ if (block.GetSerializeSize() > MAX_BLOCK_SIZE)
         </section>
 
         <section>
-            <h2>27.3 Bitcoin Cash (BCH)</h2>
+            <h2 id="s27-3">27.3 Bitcoin Cash (BCH)</h2>
 
             <p>
                 Bitcoin Cash represents the most successful Bitcoin hard fork, creating a
@@ -276,7 +276,7 @@ if (block.GetSerializeSize() > MAX_BLOCK_SIZE)
                 <figcaption>Figure 27.2: Bitcoin Cash fork from block 478,558.</figcaption>
             </figure>
 
-            <h3>27.3.1 Emergency Difficulty Adjustment</h3>
+            <h3 id="s27-3-1">27.3.1 Emergency Difficulty Adjustment</h3>
 
             <div class="definition">
                 <p class="definition-title">Definition 27.7 (EDA Algorithm)</p>
@@ -319,7 +319,7 @@ if (timeSince6Blocks > 12 hours):
                 </ul>
             </div>
 
-            <h3>27.3.2 BCH Economic Performance</h3>
+            <h3 id="s27-3-2">27.3.2 BCH Economic Performance</h3>
 
             <table class="data-table">
                 <thead>
@@ -360,7 +360,7 @@ if (timeSince6Blocks > 12 hours):
         </section>
 
         <section>
-            <h2>27.4 Bitcoin SV (BSV)</h2>
+            <h2 id="s27-4">27.4 Bitcoin SV (BSV)</h2>
 
             <p>
                 Bitcoin SV emerged from a schism within the Bitcoin Cash community.
@@ -433,7 +433,7 @@ if (timeSince6Blocks > 12 hours):
                 <figcaption>Figure 27.3: BCH → BSV fork and subsequent developments.</figcaption>
             </figure>
 
-            <h3>27.4.1 Technical Differences</h3>
+            <h3 id="s27-4-1">27.4.1 Technical Differences</h3>
 
             <table class="data-table">
                 <thead>
@@ -488,7 +488,7 @@ if (timeSince6Blocks > 12 hours):
         </section>
 
         <section>
-            <h2>27.5 Bitcoin Gold (BTG)</h2>
+            <h2 id="s27-5">27.5 Bitcoin Gold (BTG)</h2>
 
             <p>
                 Bitcoin Gold represents a different type of fork: changing the mining algorithm.
@@ -559,9 +559,9 @@ if (timeSince6Blocks > 12 hours):
         </section>
 
         <section>
-            <h2>27.6 Other Notable Forks</h2>
+            <h2 id="s27-6">27.6 Other Notable Forks</h2>
 
-            <h3>27.6.1 Bitcoin Diamond (BCD)</h3>
+            <h3 id="s27-6-1">27.6.1 Bitcoin Diamond (BCD)</h3>
 
             <div class="definition">
                 <p class="definition-title">Definition 27.10 (Bitcoin Diamond)</p>
@@ -579,7 +579,7 @@ if (timeSince6Blocks > 12 hours):
                 </p>
             </div>
 
-            <h3>27.6.2 Bitcoin Private (BTCP)</h3>
+            <h3 id="s27-6-2">27.6.2 Bitcoin Private (BTCP)</h3>
 
             <div class="definition">
                 <p class="definition-title">Definition 27.11 (Bitcoin Private)</p>
@@ -596,7 +596,7 @@ if (timeSince6Blocks > 12 hours):
                 </p>
             </div>
 
-            <h3>27.6.3 eCash (XEC)</h3>
+            <h3 id="s27-6-3">27.6.3 eCash (XEC)</h3>
 
             <div class="definition">
                 <p class="definition-title">Definition 27.12 (eCash)</p>
@@ -630,7 +630,7 @@ if (timeSince6Blocks > 12 hours):
         </section>
 
         <section>
-            <h2>27.7 The 2017 SegWit2x Attempt</h2>
+            <h2 id="s27-7">27.7 The 2017 SegWit2x Attempt</h2>
 
             <p>
                 The most consequential fork attempt is one that <em>did not</em> happen: SegWit2x.
@@ -682,7 +682,7 @@ if (timeSince6Blocks > 12 hours):
         </section>
 
         <section>
-            <h2>27.8 Comparative Analysis</h2>
+            <h2 id="s27-8">27.8 Comparative Analysis</h2>
 
             <p>
                 A systematic comparison reveals patterns in fork outcomes.
@@ -764,7 +764,7 @@ if (timeSince6Blocks > 12 hours):
         </section>
 
         <section>
-            <h2>27.9 Lessons and Principles</h2>
+            <h2 id="s27-9">27.9 Lessons and Principles</h2>
 
             <div class="remark">
                 <p class="remark-title">Remark 27.12 (Fork Success Factors)</p>

--- a/chapters/28-segwit-deep-dive.html
+++ b/chapters/28-segwit-deep-dive.html
@@ -33,7 +33,7 @@
         </section>
 
         <section>
-            <h2>28.1 The Malleability Problem</h2>
+            <h2 id="s28-1">28.1 The Malleability Problem</h2>
 
             <p>
                 To understand SegWit, we must first understand the problem it solved:
@@ -142,7 +142,7 @@ Since R'.x = R.x (negation preserves x), both pass.</pre>
         </section>
 
         <section>
-            <h2>28.2 The SegWit Solution</h2>
+            <h2 id="s28-2">28.2 The SegWit Solution</h2>
 
             <p>
                 SegWit's key insight is to remove signature data from the txid computation by
@@ -268,7 +268,7 @@ Since R'.x = R.x (negation preserves x), both pass.</pre>
         </section>
 
         <section>
-            <h2>28.3 Witness Programs and Script Versioning</h2>
+            <h2 id="s28-3">28.3 Witness Programs and Script Versioning</h2>
 
             <p>
                 SegWit introduced a new output type identified by a specific pattern.
@@ -352,7 +352,7 @@ where:
         </section>
 
         <section>
-            <h2>28.4 Block Weight and Capacity</h2>
+            <h2 id="s28-4">28.4 Block Weight and Capacity</h2>
 
             <p>
                 SegWit replaced the block size limit with a more nuanced "weight" system.
@@ -487,7 +487,7 @@ where:
         </section>
 
         <section>
-            <h2>28.5 The Witness Commitment</h2>
+            <h2 id="s28-5">28.5 The Witness Commitment</h2>
 
             <p>
                 Witness data must be committed to in blocks for validation, but the existing
@@ -576,7 +576,7 @@ commitment = SHA256(SHA256(witness_root || witness_nonce))
         </section>
 
         <section>
-            <h2>28.6 The Soft Fork Mechanism</h2>
+            <h2 id="s28-6">28.6 The Soft Fork Mechanism</h2>
 
             <p>
                 SegWit was deployed as a soft fork through careful design that made
@@ -658,7 +658,7 @@ commitment = SHA256(SHA256(witness_root || witness_nonce))
         </section>
 
         <section>
-            <h2>28.7 Sighash Changes (BIP-143)</h2>
+            <h2 id="s28-7">28.7 Sighash Changes (BIP-143)</h2>
 
             <p>
                 SegWit introduced an improved signature hash algorithm addressing
@@ -714,7 +714,7 @@ SHA256d(
         </section>
 
         <section>
-            <h2>28.8 Wrapped SegWit (P2SH-P2WPKH/WSH)</h2>
+            <h2 id="s28-8">28.8 Wrapped SegWit (P2SH-P2WPKH/WSH)</h2>
 
             <p>
                 For backward compatibility with wallets that could not generate bech32
@@ -775,7 +775,7 @@ witness:      &lt;sig&gt; &lt;pubkey&gt;</pre>
         </section>
 
         <section>
-            <h2>28.9 SegWit Adoption</h2>
+            <h2 id="s28-9">28.9 SegWit Adoption</h2>
 
             <p>
                 SegWit adoption has been gradual but substantial.
@@ -832,7 +832,7 @@ witness:      &lt;sig&gt; &lt;pubkey&gt;</pre>
         </section>
 
         <section>
-            <h2>28.10 Enabling Layer 2</h2>
+            <h2 id="s28-10">28.10 Enabling Layer 2</h2>
 
             <p>
                 Beyond malleability fixes, SegWit was essential for second-layer protocols.

--- a/chapters/29-taproot-architecture.html
+++ b/chapters/29-taproot-architecture.html
@@ -33,7 +33,7 @@
         </section>
 
         <section>
-            <h2>29.1 Schnorr Signatures (BIP-340)</h2>
+            <h2 id="s29-1">29.1 Schnorr Signatures (BIP-340)</h2>
 
             <p>
                 Taproot begins with a new signature scheme: Schnorr signatures, which improve
@@ -109,7 +109,7 @@
                 <figcaption>Figure 29.1: ECDSA vs Schnorr signature comparison.</figcaption>
             </figure>
 
-            <h3>29.1.1 X-Only Public Keys</h3>
+            <h3 id="s29-1-1">29.1.1 X-Only Public Keys</h3>
 
             <div class="definition">
                 <p class="definition-title">Definition 29.3 (X-Only Public Key)</p>
@@ -134,7 +134,7 @@
                 </ul>
             </div>
 
-            <h3>29.1.2 Batch Verification</h3>
+            <h3 id="s29-1-2">29.1.2 Batch Verification</h3>
 
             <div class="theorem">
                 <p class="theorem-title">Theorem 29.1 (Schnorr Batch Verification)</p>
@@ -161,7 +161,7 @@
         </section>
 
         <section>
-            <h2>29.2 Key Tweaking and Taproot Outputs</h2>
+            <h2 id="s29-2">29.2 Key Tweaking and Taproot Outputs</h2>
 
             <p>
                 Taproot's central mechanism is <em>key tweaking</em>: encoding spending conditions
@@ -253,7 +253,7 @@
         </section>
 
         <section>
-            <h2>29.3 Script Trees (MAST)</h2>
+            <h2 id="s29-3">29.3 Script Trees (MAST)</h2>
 
             <p>
                 Taproot implements Merkleized Alternative Script Trees, allowing multiple
@@ -370,7 +370,7 @@ where:
         </section>
 
         <section>
-            <h2>29.4 Tapscript (BIP-342)</h2>
+            <h2 id="s29-4">29.4 Tapscript (BIP-342)</h2>
 
             <p>
                 Tapscript is the script system for Taproot script path spends, with
@@ -457,7 +457,7 @@ Stack after:  [n] (or [n+1] if valid)
         </section>
 
         <section>
-            <h2>29.5 Key Aggregation: MuSig2</h2>
+            <h2 id="s29-5">29.5 Key Aggregation: MuSig2</h2>
 
             <p>
                 Schnorr's linearity enables multi-party signatures in which the
@@ -545,7 +545,7 @@ Stack after:  [n] (or [n+1] if valid)
         </section>
 
         <section>
-            <h2>29.6 Adaptor Signatures</h2>
+            <h2 id="s29-6">29.6 Adaptor Signatures</h2>
 
             <p>
                 Schnorr enables a powerful primitive for atomic protocols: adaptor signatures.
@@ -615,7 +615,7 @@ Stack after:  [n] (or [n+1] if valid)
         </section>
 
         <section>
-            <h2>29.7 Taproot Adoption and Use Cases</h2>
+            <h2 id="s29-7">29.7 Taproot Adoption and Use Cases</h2>
 
             <div class="example">
                 <p class="example-title">Example 29.2 (Adoption Metrics)</p>

--- a/chapters/30-covenants.html
+++ b/chapters/30-covenants.html
@@ -32,7 +32,7 @@
         </section>
 
         <section>
-            <h2>30.1 What Are Covenants?</h2>
+            <h2 id="s30-1">30.1 What Are Covenants?</h2>
 
             <div class="definition">
                 <p class="definition-title">Definition 30.1 (Covenant)</p>
@@ -108,7 +108,7 @@
         </section>
 
         <section>
-            <h2>30.2 OP_CHECKTEMPLATEVERIFY (CTV)</h2>
+            <h2 id="s30-2">30.2 OP_CHECKTEMPLATEVERIFY (CTV)</h2>
 
             <p>
                 CTV (BIP-119) is the simplest and most conservative covenant proposal.
@@ -198,7 +198,7 @@ DefaultCheckTemplateVerifyHash(tx, input_index):
                 <figcaption>Figure 30.2: CTV commits to most transaction fields except which inputs fund it.</figcaption>
             </figure>
 
-            <h3>30.2.1 CTV Use Cases</h3>
+            <h3 id="s30-2-1">30.2.1 CTV Use Cases</h3>
 
             <div class="example">
                 <p class="example-title">Example 30.1 (Congestion Control / Payment Batching)</p>
@@ -277,7 +277,7 @@ A thief who steals the hot key must wait out the CSV delay,
 during which the owner claws the funds back to cold storage.</pre>
             </div>
 
-            <h3>30.2.2 CTV Controversy</h3>
+            <h3 id="s30-2-2">30.2.2 CTV Controversy</h3>
 
             <div class="remark">
                 <p class="remark-title">Remark 30.2 (CTV Debate)</p>
@@ -294,7 +294,7 @@ during which the owner claws the funds back to cold storage.</pre>
         </section>
 
         <section>
-            <h2>30.3 OP_CAT</h2>
+            <h2 id="s30-3">30.3 OP_CAT</h2>
 
             <p>
                 OP_CAT (concatenation) was disabled in 2010, but proposals to re-enable it
@@ -368,7 +368,7 @@ OP_CHECKSIG</pre>
         </section>
 
         <section>
-            <h2>30.4 OP_VAULT (BIP-345)</h2>
+            <h2 id="s30-4">30.4 OP_VAULT (BIP-345)</h2>
 
             <p>
                 OP_VAULT is a purpose-built opcode for secure custody.
@@ -470,9 +470,9 @@ OP_CHECKSIG</pre>
         </section>
 
         <section>
-            <h2>30.5 Other Covenant Proposals</h2>
+            <h2 id="s30-5">30.5 Other Covenant Proposals</h2>
 
-            <h3>30.5.1 SIGHASH_ANYPREVOUT (BIP-118)</h3>
+            <h3 id="s30-5-1">30.5.1 SIGHASH_ANYPREVOUT (BIP-118)</h3>
 
             <div class="definition">
                 <p class="definition-title">Definition 30.8 (ANYPREVOUT)</p>
@@ -487,7 +487,7 @@ OP_CHECKSIG</pre>
                 </ul>
             </div>
 
-            <h3>30.5.2 OP_TXHASH / OP_CHECKTXHASHVERIFY</h3>
+            <h3 id="s30-5-2">30.5.2 OP_TXHASH / OP_CHECKTXHASHVERIFY</h3>
 
             <div class="definition">
                 <p class="definition-title">Definition 30.9 (TXHASH)</p>
@@ -501,7 +501,7 @@ OP_CHECKSIG</pre>
                 </ul>
             </div>
 
-            <h3>30.5.3 OP_CHECKSIGFROMSTACK</h3>
+            <h3 id="s30-5-3">30.5.3 OP_CHECKSIGFROMSTACK</h3>
 
             <div class="definition">
                 <p class="definition-title">Definition 30.10 (CSFS)</p>
@@ -518,7 +518,7 @@ Stack: [1 if valid]</pre>
                 </p>
             </div>
 
-            <h3>30.5.4 Comparison Table</h3>
+            <h3 id="s30-5-4">30.5.4 Comparison Table</h3>
 
             <table class="data-table">
                 <thead>
@@ -571,7 +571,7 @@ Stack: [1 if valid]</pre>
         </section>
 
         <section>
-            <h2>30.6 Recursive Covenants and Concerns</h2>
+            <h2 id="s30-6">30.6 Recursive Covenants and Concerns</h2>
 
             <div class="definition">
                 <p class="definition-title">Definition 30.11 (Recursive Covenant)</p>
@@ -620,7 +620,7 @@ Stack: [1 if valid]</pre>
         </section>
 
         <section>
-            <h2>30.7 Covenant Applications</h2>
+            <h2 id="s30-7">30.7 Covenant Applications</h2>
 
             <div class="example">
                 <p class="example-title">Example 30.4 (Summary of Applications)</p>

--- a/chapters/31-sidechains.html
+++ b/chapters/31-sidechains.html
@@ -31,7 +31,7 @@
         </section>
 
         <section>
-            <h2>31.1 Two-Way Peg Fundamentals</h2>
+            <h2 id="s31-1">31.1 Two-Way Peg Fundamentals</h2>
 
             <div class="definition">
                 <p class="definition-title">Definition 31.1 (Sidechain)</p>
@@ -114,7 +114,7 @@
         </section>
 
         <section>
-            <h2>31.2 Federated Sidechains</h2>
+            <h2 id="s31-2">31.2 Federated Sidechains</h2>
 
             <p>
                 The most practical current approach is to trust a federation to manage the peg.
@@ -145,7 +145,7 @@
                 </ul>
             </div>
 
-            <h3>31.2.1 Liquid Network</h3>
+            <h3 id="s31-2-1">31.2.1 Liquid Network</h3>
 
             <div class="definition">
                 <p class="definition-title">Definition 31.5 (Liquid)</p>
@@ -205,7 +205,7 @@
                 </table>
             </div>
 
-            <h3>31.2.2 RSK (Rootstock)</h3>
+            <h3 id="s31-2-2">31.2.2 RSK (Rootstock)</h3>
 
             <div class="definition">
                 <p class="definition-title">Definition 31.6 (RSK)</p>
@@ -231,7 +231,7 @@
         </section>
 
         <section>
-            <h2>31.3 SPV Sidechains (Theoretical)</h2>
+            <h2 id="s31-3">31.3 SPV Sidechains (Theoretical)</h2>
 
             <p>
                 The original sidechain proposal (Blockstream, 2014) envisioned SPV proofs.
@@ -264,7 +264,7 @@
         </section>
 
         <section>
-            <h2>31.4 Validity Rollups and ZK Sidechains</h2>
+            <h2 id="s31-4">31.4 Validity Rollups and ZK Sidechains</h2>
 
             <p>
                 Emerging designs use validity proofs for trust-minimized pegs.
@@ -305,7 +305,7 @@
         </section>
 
         <section>
-            <h2>31.5 Stacks and Proof of Transfer</h2>
+            <h2 id="s31-5">31.5 Stacks and Proof of Transfer</h2>
 
             <div class="definition">
                 <p class="definition-title">Definition 31.11 (Stacks / PoX)</p>
@@ -334,7 +334,7 @@
         </section>
 
         <section>
-            <h2>31.6 Comparison of Approaches</h2>
+            <h2 id="s31-6">31.6 Comparison of Approaches</h2>
 
             <table class="data-table">
                 <thead>
@@ -390,7 +390,7 @@
         </section>
 
         <section>
-            <h2>31.7 Sidechain Economics</h2>
+            <h2 id="s31-7">31.7 Sidechain Economics</h2>
 
             <div class="remark">
                 <p class="remark-title">Remark 31.5 (Sidechain Fee Market)</p>

--- a/chapters/32-beyond-lightning.html
+++ b/chapters/32-beyond-lightning.html
@@ -32,7 +32,7 @@
         </section>
 
         <section>
-            <h2>32.1 Lightning's Limitations</h2>
+            <h2 id="s32-1">32.1 Lightning's Limitations</h2>
 
             <p>
                 Understanding new L2 proposals requires understanding Lightning's constraints.
@@ -81,7 +81,7 @@
         </section>
 
         <section>
-            <h2>32.2 Ark Protocol</h2>
+            <h2 id="s32-2">32.2 Ark Protocol</h2>
 
             <p>
                 Ark is a new L2 design that trades interactivity for simplicity.
@@ -216,7 +216,7 @@
         </section>
 
         <section>
-            <h2>32.3 Statechains</h2>
+            <h2 id="s32-3">32.3 Statechains</h2>
 
             <p>
                 Statechains enable off-chain UTXO transfer without channels.
@@ -298,7 +298,7 @@
         </section>
 
         <section>
-            <h2>32.4 Channel Factories</h2>
+            <h2 id="s32-4">32.4 Channel Factories</h2>
 
             <p>
                 Channel factories amortize on-chain costs across multiple channels.
@@ -373,7 +373,7 @@
         </section>
 
         <section>
-            <h2>32.5 LN-Symmetry (Eltoo)</h2>
+            <h2 id="s32-5">32.5 LN-Symmetry (Eltoo)</h2>
 
             <p>
                 LN-Symmetry is a cleaner channel design that requires SIGHASH_ANYPREVOUT.
@@ -407,7 +407,7 @@
         </section>
 
         <section>
-            <h2>32.6 Comparison Summary</h2>
+            <h2 id="s32-6">32.6 Comparison Summary</h2>
 
             <table class="data-table">
                 <thead>

--- a/chapters/33-governance.html
+++ b/chapters/33-governance.html
@@ -33,7 +33,7 @@
         </section>
 
         <section>
-            <h2>33.1 The Stakeholders</h2>
+            <h2 id="s33-1">33.1 The Stakeholders</h2>
 
             <div class="definition">
                 <p class="definition-title">Definition 33.1 (Bitcoin Stakeholder Groups)</p>
@@ -100,7 +100,7 @@
         </section>
 
         <section>
-            <h2>33.2 The BIP Process</h2>
+            <h2 id="s33-2">33.2 The BIP Process</h2>
 
             <div class="definition">
                 <p class="definition-title">Definition 33.2 (Bitcoin Improvement Proposal)</p>
@@ -228,7 +228,7 @@
         </section>
 
         <section>
-            <h2>33.3 Consensus Formation</h2>
+            <h2 id="s33-3">33.3 Consensus Formation</h2>
 
             <p>
                 Beyond technical specification, controversial changes require social consensus.
@@ -280,7 +280,7 @@
         </section>
 
         <section>
-            <h2>33.4 Soft Fork Activation</h2>
+            <h2 id="s33-4">33.4 Soft Fork Activation</h2>
 
             <p>
                 Technical consensus (a working BIP) requires an activation mechanism.
@@ -335,7 +335,7 @@
         </section>
 
         <section>
-            <h2>33.5 Bitcoin Core's Role</h2>
+            <h2 id="s33-5">33.5 Bitcoin Core's Role</h2>
 
             <div class="definition">
                 <p class="definition-title">Definition 33.6 (Bitcoin Core)</p>
@@ -382,7 +382,7 @@
         </section>
 
         <section>
-            <h2>33.6 Philosophical Foundations</h2>
+            <h2 id="s33-6">33.6 Philosophical Foundations</h2>
 
             <div class="definition">
                 <p class="definition-title">Definition 33.7 (Bitcoin Maximalism)</p>
@@ -428,9 +428,9 @@
         </section>
 
         <section>
-            <h2>33.7 Case Studies in Governance</h2>
+            <h2 id="s33-7">33.7 Case Studies in Governance</h2>
 
-            <h3>33.7.1 The Block Size War (2015-2017)</h3>
+            <h3 id="s33-7-1">33.7.1 The Block Size War (2015-2017)</h3>
 
             <div class="example">
                 <p class="example-title">Example 33.3 (Block Size Debate)</p>
@@ -445,7 +445,7 @@
                 </ul>
             </div>
 
-            <h3>33.7.2 Taproot Activation (2020-2021)</h3>
+            <h3 id="s33-7-2">33.7.2 Taproot Activation (2020-2021)</h3>
 
             <div class="example">
                 <p class="example-title">Example 33.4 (Taproot)</p>
@@ -460,7 +460,7 @@
                 </ul>
             </div>
 
-            <h3>33.7.3 Ordinals/Inscriptions (2023)</h3>
+            <h3 id="s33-7-3">33.7.3 Ordinals/Inscriptions (2023)</h3>
 
             <div class="example">
                 <p class="example-title">Example 33.5 (Ordinals Controversy)</p>
@@ -477,7 +477,7 @@
         </section>
 
         <section>
-            <h2>33.8 Future Governance Challenges</h2>
+            <h2 id="s33-8">33.8 Future Governance Challenges</h2>
 
             <div class="remark">
                 <p class="remark-title">Remark 33.8 (Open Questions)</p>

--- a/chapters/34-drivechains.html
+++ b/chapters/34-drivechains.html
@@ -34,7 +34,7 @@
         </section>
 
         <section>
-            <h2>34.1 The Drivechain Vision</h2>
+            <h2 id="s34-1">34.1 The Drivechain Vision</h2>
 
             <div class="definition">
                 <p class="definition-title">Definition 34.1 (Drivechain)</p>
@@ -106,7 +106,7 @@
         </section>
 
         <section>
-            <h2>34.2 BIP-300: Hashrate Escrow</h2>
+            <h2 id="s34-2">34.2 BIP-300: Hashrate Escrow</h2>
 
             <div class="definition">
                 <p class="definition-title">Definition 34.3 (BIP-300 Mechanism)</p>
@@ -189,7 +189,7 @@ Withdrawal process:
         </section>
 
         <section>
-            <h2>34.3 BIP-301: Blind Merged Mining</h2>
+            <h2 id="s34-3">34.3 BIP-301: Blind Merged Mining</h2>
 
             <div class="definition">
                 <p class="definition-title">Definition 34.5 (Blind Merged Mining)</p>
@@ -237,7 +237,7 @@ OP_RETURN &lt;BMM_TAG&gt; &lt;sidechain_id&gt; &lt;block_hash&gt;
         </section>
 
         <section>
-            <h2>34.4 Security Analysis</h2>
+            <h2 id="s34-4">34.4 Security Analysis</h2>
 
             <div class="remark">
                 <p class="remark-title">Remark 34.3 (Drivechain Trust Model)</p>
@@ -317,13 +317,13 @@ OP_RETURN &lt;BMM_TAG&gt; &lt;sidechain_id&gt; &lt;block_hash&gt;
         </section>
 
         <section>
-            <h2>34.5 The Drivechain Controversy</h2>
+            <h2 id="s34-5">34.5 The Drivechain Controversy</h2>
 
             <p>
                 Drivechains are among the most contentious Bitcoin proposals.
             </p>
 
-            <h3>34.5.1 Arguments For</h3>
+            <h3 id="s34-5-1">34.5.1 Arguments For</h3>
 
             <div class="remark">
                 <p class="remark-title">Remark 34.5 (Pro-Drivechain Arguments)</p>
@@ -336,7 +336,7 @@ OP_RETURN &lt;BMM_TAG&gt; &lt;sidechain_id&gt; &lt;block_hash&gt;
                 </ul>
             </div>
 
-            <h3>34.5.2 Arguments Against</h3>
+            <h3 id="s34-5-2">34.5.2 Arguments Against</h3>
 
             <div class="remark">
                 <p class="remark-title">Remark 34.6 (Anti-Drivechain Arguments)</p>
@@ -364,7 +364,7 @@ OP_RETURN &lt;BMM_TAG&gt; &lt;sidechain_id&gt; &lt;block_hash&gt;
                 </p>
             </div>
 
-            <h3>34.5.3 Technical Criticisms</h3>
+            <h3 id="s34-5-3">34.5.3 Technical Criticisms</h3>
 
             <div class="remark">
                 <p class="remark-title">Remark 34.8 (Specific Concerns)</p>
@@ -378,7 +378,7 @@ OP_RETURN &lt;BMM_TAG&gt; &lt;sidechain_id&gt; &lt;block_hash&gt;
         </section>
 
         <section>
-            <h2>34.6 Proposed Sidechains</h2>
+            <h2 id="s34-6">34.6 Proposed Sidechains</h2>
 
             <div class="example">
                 <p class="example-title">Example 34.2 (Potential Drivechains)</p>
@@ -420,7 +420,7 @@ OP_RETURN &lt;BMM_TAG&gt; &lt;sidechain_id&gt; &lt;block_hash&gt;
         </section>
 
         <section>
-            <h2>34.7 Current Status</h2>
+            <h2 id="s34-7">34.7 Current Status</h2>
 
             <div class="remark">
                 <p class="remark-title">Remark 34.9 (Activation Status)</p>

--- a/chapters/35-consensus-cleanup.html
+++ b/chapters/35-consensus-cleanup.html
@@ -32,7 +32,7 @@
         </section>
 
         <section>
-            <h2>35.1 Overview of Consensus Bugs</h2>
+            <h2 id="s35-1">35.1 Overview of Consensus Bugs</h2>
 
             <div class="definition">
                 <p class="definition-title">Definition 35.1 (Consensus Bug)</p>
@@ -98,7 +98,7 @@
         </section>
 
         <section>
-            <h2>35.2 The Timewarp Attack</h2>
+            <h2 id="s35-2">35.2 The Timewarp Attack</h2>
 
             <p>
                 The timewarp attack is the most serious unfixed vulnerability in Bitcoin's consensus rules.
@@ -203,7 +203,7 @@ timestamp(block[h]) >= timestamp(block[h-1]) - 2 hours</pre>
         </section>
 
         <section>
-            <h2>35.3 The 64-Byte Transaction Vulnerability</h2>
+            <h2 id="s35-3">35.3 The 64-Byte Transaction Vulnerability</h2>
 
             <div class="definition">
                 <p class="definition-title">Definition 35.5 (64-Byte Transaction)</p>
@@ -282,7 +282,7 @@ if (tx.GetSerializeSize() == 64)
         </section>
 
         <section>
-            <h2>35.4 Merkle Tree CVE-2012-2459</h2>
+            <h2 id="s35-4">35.4 Merkle Tree CVE-2012-2459</h2>
 
             <div class="definition">
                 <p class="definition-title">Definition 35.7 (Duplicate Txid Vulnerability)</p>
@@ -331,7 +331,7 @@ Different blocks, same merkle root → attack vector</pre>
         </section>
 
         <section>
-            <h2>35.5 Legacy Script Validation Issues</h2>
+            <h2 id="s35-5">35.5 Legacy Script Validation Issues</h2>
 
             <div class="definition">
                 <p class="definition-title">Definition 35.9 (FindAndDelete)</p>
@@ -372,7 +372,7 @@ Different blocks, same merkle root → attack vector</pre>
         </section>
 
         <section>
-            <h2>35.6 Validation Time Limits</h2>
+            <h2 id="s35-6">35.6 Validation Time Limits</h2>
 
             <div class="definition">
                 <p class="definition-title">Definition 35.11 (Quadratic Hashing)</p>
@@ -413,7 +413,7 @@ Different blocks, same merkle root → attack vector</pre>
         </section>
 
         <section>
-            <h2>35.7 Activation and Status</h2>
+            <h2 id="s35-7">35.7 Activation and Status</h2>
 
             <div class="remark">
                 <p class="remark-title">Remark 35.3 (Current Status)</p>

--- a/chapters/36-security-threats.html
+++ b/chapters/36-security-threats.html
@@ -32,7 +32,7 @@
         </section>
 
         <section>
-            <h2>36.1 The 51% Attack</h2>
+            <h2 id="s36-1">36.1 The 51% Attack</h2>
 
             <div class="definition">
                 <p class="definition-title">Definition 36.1 (51% Attack)</p>
@@ -194,7 +194,7 @@
         </section>
 
         <section>
-            <h2>36.2 Chain Reorganizations</h2>
+            <h2 id="s36-2">36.2 Chain Reorganizations</h2>
 
             <div class="definition">
                 <p class="definition-title">Definition 36.3 (Chain Reorganization)</p>
@@ -257,7 +257,7 @@
         </section>
 
         <section>
-            <h2>36.3 Selfish Mining</h2>
+            <h2 id="s36-3">36.3 Selfish Mining</h2>
 
             <div class="definition">
                 <p class="definition-title">Definition 36.4 (Selfish Mining)</p>
@@ -333,7 +333,7 @@
         </section>
 
         <section>
-            <h2>36.4 Eclipse Attacks</h2>
+            <h2 id="s36-4">36.4 Eclipse Attacks</h2>
 
             <div class="definition">
                 <p class="definition-title">Definition 36.5 (Eclipse Attack)</p>
@@ -376,9 +376,9 @@
         </section>
 
         <section>
-            <h2>36.5 Other Attack Vectors</h2>
+            <h2 id="s36-5">36.5 Other Attack Vectors</h2>
 
-            <h3>36.5.1 Transaction Censorship</h3>
+            <h3 id="s36-5-1">36.5.1 Transaction Censorship</h3>
 
             <div class="definition">
                 <p class="definition-title">Definition 36.6 (Transaction Censorship)</p>
@@ -391,7 +391,7 @@
                 </ul>
             </div>
 
-            <h3>36.5.2 Block Withholding</h3>
+            <h3 id="s36-5-2">36.5.2 Block Withholding</h3>
 
             <div class="definition">
                 <p class="definition-title">Definition 36.7 (Block Withholding Attack)</p>
@@ -406,7 +406,7 @@
                 </ul>
             </div>
 
-            <h3>36.5.3 Time-Dilation Attack</h3>
+            <h3 id="s36-5-3">36.5.3 Time-Dilation Attack</h3>
 
             <div class="definition">
                 <p class="definition-title">Definition 36.8 (Time-Dilation Attack)</p>
@@ -423,7 +423,7 @@
         </section>
 
         <section>
-            <h2>36.6 Attack Economics</h2>
+            <h2 id="s36-6">36.6 Attack Economics</h2>
 
             <div class="remark">
                 <p class="remark-title">Remark 36.4 (51% Attack Cost)</p>

--- a/chapters/37-defense-mechanisms.html
+++ b/chapters/37-defense-mechanisms.html
@@ -31,7 +31,7 @@
         </section>
 
         <section>
-            <h2>37.1 Confirmation-Based Security</h2>
+            <h2 id="s37-1">37.1 Confirmation-Based Security</h2>
 
             <div class="definition">
                 <p class="definition-title">Definition 37.1 (Confirmation)</p>
@@ -127,7 +127,7 @@
         </section>
 
         <section>
-            <h2>37.2 Checkpoints</h2>
+            <h2 id="s37-2">37.2 Checkpoints</h2>
 
             <div class="definition">
                 <p class="definition-title">Definition 37.2 (Checkpoint)</p>
@@ -191,7 +191,7 @@ checkpointData = {
         </section>
 
         <section>
-            <h2>37.3 Minimum Chain Work</h2>
+            <h2 id="s37-3">37.3 Minimum Chain Work</h2>
 
             <div class="definition">
                 <p class="definition-title">Definition 37.4 (Minimum Chain Work)</p>
@@ -225,7 +225,7 @@ nMinimumChainWork = 0x0000000000000000000000000000000000000000
         </section>
 
         <section>
-            <h2>37.4 AssumeValid and AssumeUTXO</h2>
+            <h2 id="s37-4">37.4 AssumeValid and AssumeUTXO</h2>
 
             <div class="definition">
                 <p class="definition-title">Definition 37.5 (AssumeValid)</p>
@@ -293,7 +293,7 @@ nMinimumChainWork = 0x0000000000000000000000000000000000000000
         </section>
 
         <section>
-            <h2>37.5 Node Hardening</h2>
+            <h2 id="s37-5">37.5 Node Hardening</h2>
 
             <div class="definition">
                 <p class="definition-title">Definition 37.7 (Eclipse Attack Mitigations)</p>
@@ -326,7 +326,7 @@ nMinimumChainWork = 0x0000000000000000000000000000000000000000
         </section>
 
         <section>
-            <h2>37.6 Economic Security</h2>
+            <h2 id="s37-6">37.6 Economic Security</h2>
 
             <div class="remark">
                 <p class="remark-title">Remark 37.5 (Security Budget)</p>
@@ -391,7 +391,7 @@ nMinimumChainWork = 0x0000000000000000000000000000000000000000
         </section>
 
         <section>
-            <h2>37.7 Social Layer Defenses</h2>
+            <h2 id="s37-7">37.7 Social Layer Defenses</h2>
 
             <div class="definition">
                 <p class="definition-title">Definition 37.10 (Social Consensus)</p>
@@ -421,7 +421,7 @@ nMinimumChainWork = 0x0000000000000000000000000000000000000000
         </section>
 
         <section>
-            <h2>37.8 Finality Considerations</h2>
+            <h2 id="s37-8">37.8 Finality Considerations</h2>
 
             <div class="definition">
                 <p class="definition-title">Definition 37.11 (Probabilistic vs Deterministic Finality)</p>

--- a/chapters/38-security-budget.html
+++ b/chapters/38-security-budget.html
@@ -51,7 +51,7 @@
         </section>
 
         <section>
-            <h2>38.1 The Subsidy Decline</h2>
+            <h2 id="s38-1">38.1 The Subsidy Decline</h2>
 
             <div class="definition">
                 <p class="definition-title">Definition 38.1 (Block Subsidy Schedule)</p>
@@ -168,7 +168,7 @@
         </section>
 
         <section>
-            <h2>38.2 Defining the Security Budget</h2>
+            <h2 id="s38-2">38.2 Defining the Security Budget</h2>
 
             <div class="definition">
                 <p class="definition-title">Definition 38.2 (Security Budget)</p>
@@ -215,7 +215,7 @@
         </section>
 
         <section>
-            <h2>38.3 Historical Fee Analysis</h2>
+            <h2 id="s38-3">38.3 Historical Fee Analysis</h2>
 
             <div class="remark">
                 <p class="remark-title">Remark 38.3 (Historical Fee Revenue)</p>
@@ -290,7 +290,7 @@
         </section>
 
         <section>
-            <h2>38.4 Fee Market Dynamics</h2>
+            <h2 id="s38-4">38.4 Fee Market Dynamics</h2>
 
             <div class="definition">
                 <p class="definition-title">Definition 38.3 (Fee Market)</p>
@@ -342,7 +342,7 @@ Fee Determination:
         </section>
 
         <section>
-            <h2>38.5 Economic Models and Projections</h2>
+            <h2 id="s38-5">38.5 Economic Models and Projections</h2>
 
             <div class="definition">
                 <p class="definition-title">Definition 38.4 (Model 1: Linear Fee Growth)</p>
@@ -444,7 +444,7 @@ Fee Determination:
         </section>
 
         <section>
-            <h2>38.6 Game-Theoretic Considerations</h2>
+            <h2 id="s38-6">38.6 Game-Theoretic Considerations</h2>
 
             <p>In a low-subsidy environment, miners face new incentive challenges:</p>
 
@@ -510,9 +510,9 @@ if (GetRandInt(10) == 0)
         </section>
 
         <section>
-            <h2>38.7 Proposed Solutions</h2>
+            <h2 id="s38-7">38.7 Proposed Solutions</h2>
 
-            <h3>38.7.1 Do Nothing (Market Will Provide)</h3>
+            <h3 id="s38-7-1">38.7.1 Do Nothing (Market Will Provide)</h3>
 
             <p>The dominant view among Bitcoin maximalists:</p>
 
@@ -533,7 +533,7 @@ if (GetRandInt(10) == 0)
                 </p>
             </div>
 
-            <h3>38.7.2 Increase Block Size</h3>
+            <h3 id="s38-7-2">38.7.2 Increase Block Size</h3>
 
             <p>Increase transaction throughput to compensate for lower per-transaction fees:</p>
 
@@ -550,7 +550,7 @@ if (GetRandInt(10) == 0)
                 <li>May not solve problem&mdash;fees might drop proportionally</li>
             </ul>
 
-            <h3>38.7.3 Tail Emission (Perpetual Inflation)</h3>
+            <h3 id="s38-7-3">38.7.3 Tail Emission (Perpetual Inflation)</h3>
 
             <p>The most controversial proposal is to modify Bitcoin to have permanent low-level issuance.</p>
 
@@ -580,7 +580,7 @@ if (GetRandInt(10) == 0)
                 <li>Would require extremely contentious hard fork</li>
             </ul>
 
-            <h3>38.7.4 Merged Mining</h3>
+            <h3 id="s38-7-4">38.7.4 Merged Mining</h3>
 
             <p>Miners earn revenue from multiple chains simultaneously:</p>
 
@@ -595,7 +595,7 @@ Merged Mining Revenue Model:
 
             <p>This supplements miner revenue without changing Bitcoin's protocol.</p>
 
-            <h3>38.7.5 Fee Smoothing Mechanisms</h3>
+            <h3 id="s38-7-5">38.7.5 Fee Smoothing Mechanisms</h3>
 
             <p>Protocol changes to reduce fee variance:</p>
 
@@ -607,7 +607,7 @@ Merged Mining Revenue Model:
 
             <p>These reduce miner incentive problems but require consensus changes.</p>
 
-            <h3>38.7.6 Layer 2 Dependency</h3>
+            <h3 id="s38-7-6">38.7.6 Layer 2 Dependency</h3>
 
             <p>Accept that most transactions occur off-chain:</p>
 
@@ -634,7 +634,7 @@ Layer 2 Fee Model:
         </section>
 
         <section>
-            <h2>38.8 How Much Security Is Enough?</h2>
+            <h2 id="s38-8">38.8 How Much Security Is Enough?</h2>
 
             <div class="remark">
                 <p class="remark-title">Remark 38.11 (Threat Models)</p>
@@ -709,7 +709,7 @@ Layer 2 Fee Model:
         </section>
 
         <section>
-            <h2>38.9 Ordinals and the Fee Market</h2>
+            <h2 id="s38-9">38.9 Ordinals and the Fee Market</h2>
 
             <p>
                 The emergence of Ordinals, BRC-20 tokens, and Runes has substantially
@@ -760,7 +760,7 @@ Layer 2 Fee Model:
         </section>
 
         <section>
-            <h2>38.10 The Transition Timeline</h2>
+            <h2 id="s38-10">38.10 The Transition Timeline</h2>
 
             <p>When does this become critical?</p>
 
@@ -808,9 +808,9 @@ Security Budget Timeline:
         </section>
 
         <section>
-            <h2>38.11 Future Scenarios</h2>
+            <h2 id="s38-11">38.11 Future Scenarios</h2>
 
-            <h3>38.11.1 Scenario 1: Fee Market Success</h3>
+            <h3 id="s38-11-1">38.11.1 Scenario 1: Fee Market Success</h3>
 
             <p>The optimistic path:</p>
             <ul>
@@ -821,7 +821,7 @@ Security Budget Timeline:
                 <li>Security budget maintains nation-state resistance</li>
             </ul>
 
-            <h3>38.11.2 Scenario 2: Gradual Decline</h3>
+            <h3 id="s38-11-2">38.11.2 Scenario 2: Gradual Decline</h3>
 
             <p>The concerning path:</p>
             <ul>
@@ -832,7 +832,7 @@ Security Budget Timeline:
                 <li>Users accept longer confirmation times, higher confirmation requirements</li>
             </ul>
 
-            <h3>38.11.3 Scenario 3: Crisis and Adaptation</h3>
+            <h3 id="s38-11-3">38.11.3 Scenario 3: Crisis and Adaptation</h3>
 
             <p>The transformative path:</p>
             <ul>
@@ -845,9 +845,9 @@ Security Budget Timeline:
         </section>
 
         <section>
-            <h2>38.12 Active Research</h2>
+            <h2 id="s38-12">38.12 Active Research</h2>
 
-            <h3>38.12.1 Fee Market Design</h3>
+            <h3 id="s38-12-1">38.12.1 Fee Market Design</h3>
 
             <p>Researchers are studying improved fee mechanisms:</p>
 
@@ -857,7 +857,7 @@ Security Budget Timeline:
                 <li><strong>Batch auctions:</strong> More efficient price discovery</li>
             </ul>
 
-            <h3>38.12.2 Alternative Security Models</h3>
+            <h3 id="s38-12-2">38.12.2 Alternative Security Models</h3>
 
             <ul>
                 <li><strong>Proof of Stake:</strong> Different security economics (not for Bitcoin)</li>
@@ -865,7 +865,7 @@ Security Budget Timeline:
                 <li><strong>Checkpointing:</strong> Social consensus as security layer</li>
             </ul>
 
-            <h3>38.12.3 Layer 2 Economic Integration</h3>
+            <h3 id="s38-12-3">38.12.3 Layer 2 Economic Integration</h3>
 
             <ul>
                 <li>How do Layer 2 fees contribute to Layer 1 security?</li>
@@ -875,7 +875,7 @@ Security Budget Timeline:
         </section>
 
         <section>
-            <h2>38.13 Summary</h2>
+            <h2 id="s38-13">38.13 Summary</h2>
 
             <ul>
                 <li>Bitcoin's block subsidy will effectively end within 20-30 years</li>

--- a/chapters/39-quantum-resistance.html
+++ b/chapters/39-quantum-resistance.html
@@ -40,7 +40,7 @@
         </section>
 
         <section>
-            <h2>39.1 The Two Quantum Threats</h2>
+            <h2 id="s39-1">39.1 The Two Quantum Threats</h2>
 
             <div class="remark">
                 <p class="remark-title">Remark 39.1 (The Two Quantum Threats)</p>
@@ -59,7 +59,7 @@
         </section>
 
         <section>
-            <h2>39.2 Quantum Computing Fundamentals</h2>
+            <h2 id="s39-2">39.2 Quantum Computing Fundamentals</h2>
 
             <div class="definition">
                 <p class="definition-title">Definition 39.1 (Qubit)</p>
@@ -151,7 +151,7 @@ Common Quantum Gates:
         </section>
 
         <section>
-            <h2>39.3 Shor's Algorithm: The ECDSA Threat</h2>
+            <h2 id="s39-3">39.3 Shor's Algorithm: The ECDSA Threat</h2>
 
             <div class="definition">
                 <p class="definition-title">Definition 39.3 (Shor's Algorithm)</p>
@@ -296,7 +296,7 @@ Critical timing:
         </section>
 
         <section>
-            <h2>39.4 Grover's Algorithm: The Mining Threat</h2>
+            <h2 id="s39-4">39.4 Grover's Algorithm: The Mining Threat</h2>
 
             <div class="definition">
                 <p class="definition-title">Definition 39.6 (Grover's Algorithm)</p>
@@ -378,7 +378,7 @@ Practical Reality:
         </section>
 
         <section>
-            <h2>39.5 The Current State of Quantum Computing</h2>
+            <h2 id="s39-5">39.5 The Current State of Quantum Computing</h2>
 
             <div class="example">
                 <p class="example-title">Example 39.2 (2024 Quantum Landscape)</p>
@@ -529,7 +529,7 @@ For Breaking 256-bit ECDSA (Roetteler et al., 2017):
         </section>
 
         <section>
-            <h2>39.6 Post-Quantum Cryptography</h2>
+            <h2 id="s39-6">39.6 Post-Quantum Cryptography</h2>
 
             <div class="definition">
                 <p class="definition-title">Definition 39.9 (NIST Post-Quantum Standards)</p>
@@ -673,7 +673,7 @@ Lamport Signatures (simpler):
         </section>
 
         <section>
-            <h2>39.7 Bitcoin Migration Strategies</h2>
+            <h2 id="s39-7">39.7 Bitcoin Migration Strategies</h2>
 
             <div class="definition">
                 <p class="definition-title">Definition 39.12 (Post-Quantum SegWit, P2QRH)</p>
@@ -778,7 +778,7 @@ Security:
         </section>
 
         <section>
-            <h2>39.8 Scalability Implications</h2>
+            <h2 id="s39-8">39.8 Scalability Implications</h2>
 
             <div class="example">
                 <p class="example-title">Example 39.5 (Transaction Size Explosion)</p>
@@ -830,7 +830,7 @@ Dealing with Larger Signatures:
         </section>
 
         <section>
-            <h2>39.9 The Lost Coins Problem</h2>
+            <h2 id="s39-9">39.9 The Lost Coins Problem</h2>
 
             <div class="remark">
                 <p class="remark-title">Remark 39.9 (Coins That Cannot Migrate)</p>
@@ -880,7 +880,7 @@ Controversial Question:
         </section>
 
         <section>
-            <h2>39.10 Preparing Today</h2>
+            <h2 id="s39-10">39.10 Preparing Today</h2>
 
             <div class="remark">
                 <p class="remark-title">Remark 39.11 (Best Practices for Users)</p>
@@ -974,7 +974,7 @@ Recommended Preparation Timeline:
         </section>
 
         <section>
-            <h2>39.11 Summary</h2>
+            <h2 id="s39-11">39.11 Summary</h2>
 
             <ul>
                 <li><strong>Shor's algorithm</strong> will eventually break ECDSA&mdash;migration is inevitable</li>

--- a/chapters/40-monetary-future.html
+++ b/chapters/40-monetary-future.html
@@ -43,7 +43,7 @@
         </section>
 
         <section>
-            <h2>40.1 The Evolution of Money</h2>
+            <h2 id="s40-1">40.1 The Evolution of Money</h2>
 
             <div class="definition">
                 <p class="definition-title">Definition 40.1 (Monetary Eras)</p>
@@ -118,7 +118,7 @@
         </section>
 
         <section>
-            <h2>40.2 Stages of Adoption</h2>
+            <h2 id="s40-2">40.2 Stages of Adoption</h2>
 
             <div class="definition">
                 <p class="definition-title">Definition 40.2 (Adoption S-Curve)</p>
@@ -200,7 +200,7 @@
         </section>
 
         <section>
-            <h2>40.3 Nation-State Game Theory</h2>
+            <h2 id="s40-3">40.3 Nation-State Game Theory</h2>
 
             <div class="definition">
                 <p class="definition-title">Definition 40.3 (Nation-State Adoption Game)</p>
@@ -290,7 +290,7 @@
         </section>
 
         <section>
-            <h2>40.4 Future Scenarios</h2>
+            <h2 id="s40-4">40.4 Future Scenarios</h2>
 
             <p>
                 Where a scenario states a price range, the arithmetic is the simple identity
@@ -423,7 +423,7 @@
         </section>
 
         <section>
-            <h2>40.5 Hyperbitcoinization</h2>
+            <h2 id="s40-5">40.5 Hyperbitcoinization</h2>
 
             <div class="definition">
                 <p class="definition-title">Definition 40.8 (Hyperbitcoinization)</p>
@@ -468,7 +468,7 @@
         </section>
 
         <section>
-            <h2>40.6 Economic Implications</h2>
+            <h2 id="s40-6">40.6 Economic Implications</h2>
 
             <div class="definition">
                 <p class="definition-title">Definition 40.10 (Deflationary Standard)</p>
@@ -563,7 +563,7 @@
         </section>
 
         <section>
-            <h2>40.7 Social and Political Implications</h2>
+            <h2 id="s40-7">40.7 Social and Political Implications</h2>
 
             <div class="remark">
                 <p class="remark-title">Remark 40.7 (The Monetary Reformation)</p>
@@ -637,7 +637,7 @@
         </section>
 
         <section>
-            <h2>40.8 Obstacles to Widespread Adoption</h2>
+            <h2 id="s40-8">40.8 Obstacles to Widespread Adoption</h2>
 
             <div class="remark">
                 <p class="remark-title">Remark 40.9 (Technical and Economic Obstacles)</p>
@@ -685,7 +685,7 @@
         </section>
 
         <section>
-            <h2>40.9 The Coexistence Model</h2>
+            <h2 id="s40-9">40.9 The Coexistence Model</h2>
 
             <div class="definition">
                 <p class="definition-title">Definition 40.12 (Multi-Money Coexistence)</p>
@@ -728,7 +728,7 @@
         </section>
 
         <section>
-            <h2>40.10 A Speculative Timeline</h2>
+            <h2 id="s40-10">40.10 A Speculative Timeline</h2>
 
             <div class="remark">
                 <p class="remark-title">Remark 40.11 (Speculative Adoption Timeline)</p>
@@ -760,7 +760,7 @@
         </section>
 
         <section>
-            <h2>40.11 The Money of the Future</h2>
+            <h2 id="s40-11">40.11 The Money of the Future</h2>
 
             <p>
                 Beyond technology or investment, Bitcoin represents an idea: that money can be
@@ -812,7 +812,7 @@
         </section>
 
         <section>
-            <h2>40.12 Summary: Volume V Key Points</h2>
+            <h2 id="s40-12">40.12 Summary: Volume V Key Points</h2>
 
             <ul>
                 <li><strong>Security threats</strong> like 51% attacks are real but expensive</li>

--- a/chapters/appendix-a-notation.html
+++ b/chapters/appendix-a-notation.html
@@ -670,6 +670,7 @@
 
         <nav class="chapter-nav">
             <a href="../index.html">← Table of Contents</a>
+            <a href="appendix-b-references.html">Appendix B: References →</a>
         </nav>
     </main>
 

--- a/chapters/appendix-b-references.html
+++ b/chapters/appendix-b-references.html
@@ -1,0 +1,280 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Appendix B: References | Elementary Bitcoin</title>
+    <meta name="description" content="Appendix B: References - Bibliography, standards, BIPs, BOLTs, and CVEs cited throughout Elementary Bitcoin">
+
+    <!-- Open Graph -->
+    <meta property="og:type" content="article">
+    <meta property="og:site_name" content="Elementary Bitcoin">
+    <meta property="og:title" content="Appendix B: References | Elementary Bitcoin">
+    <meta property="og:description" content="Bibliography, standards, BIPs, BOLTs, and CVEs cited throughout Elementary Bitcoin">
+    <meta property="og:url" content="https://elementarybitcoin.org/chapters/appendix-b-references.html">
+    <meta property="og:image" content="https://elementarybitcoin.org/og-image.png">
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Appendix B: References | Elementary Bitcoin">
+    <meta name="twitter:description" content="Bibliography, standards, BIPs, BOLTs, and CVEs cited throughout Elementary Bitcoin">
+    <meta name="twitter:image" content="https://elementarybitcoin.org/og-image.png">
+
+    <link rel="stylesheet" href="../style.css">
+    <style>
+        .ref-list p { margin: 0.9rem 0; padding-left: 2rem; text-indent: -2rem; }
+        .ref-list .cited { color: #666; font-size: 0.9rem; }
+    </style>
+</head>
+<body>
+    <header class="chapter-header">
+        <span class="chapter-number">Appendix B</span>
+        <h1 class="chapter-title">References</h1>
+    </header>
+
+    <main>
+        <section>
+            <p>
+                This appendix collects the works, standards, and protocol documents cited or
+                discussed in the text. Citations in the chapters are informal (author and year,
+                or protocol name); the full records appear here. Entries marked
+                <em>"discussed in"</em> are constructions the text presents without a formal
+                inline citation.
+            </p>
+        </section>
+
+        <section>
+            <h2>B.1 Primary Sources</h2>
+            <div class="ref-list">
+                <p>Nakamoto, S. (2008). "Bitcoin: A Peer-to-Peer Electronic Cash System."
+                   <a href="https://bitcoin.org/bitcoin.pdf">bitcoin.org/bitcoin.pdf</a>.
+                   <span class="cited">Section 8 is quoted in full in Chapter 17; the double-spend
+                   analysis of Section 11 underlies Theorems 14.4, 17.6, and 36.1.</span></p>
+                <p>Nakamoto, S. (17 January 2009). "Bitcoin v0.1 released." Post to the Cryptography
+                   Mailing List.
+                   <span class="cited">Quoted as the Chapter 40 epigraph.</span></p>
+                <p><em>The Times</em> (London), 3 January 2009, front page: "Chancellor on brink of
+                   second bailout for banks."
+                   <span class="cited">Embedded in the genesis block coinbase; quoted in Chapters 10 and 13.</span></p>
+            </div>
+        </section>
+
+        <section>
+            <h2>B.2 Academic Works and Technical Reports</h2>
+            <div class="ref-list">
+                <p>Aumasson, J.-P., &amp; Bernstein, D. J. (2012). "SipHash: A Fast Short-Input PRF."
+                   INDOCRYPT 2012, LNCS 7668. Springer.
+                   <span class="cited">SipHash-2-4 is used by BIP-158 filters; discussed in Chapter 19.</span></p>
+                <p>Back, A. (2002). "Hashcash &mdash; A Denial of Service Counter-Measure." Technical
+                   report, hashcash.org. First announced on the cypherpunks mailing list, 1997.
+                   <span class="cited">Cited in Chapter 14.</span></p>
+                <p>Back, A., Corallo, M., Dashjr, L., Friedenbach, M., Maxwell, G., Miller, A.,
+                   Poelstra, A., Tim&oacute;n, J., &amp; Wuille, P. (2014). "Enabling Blockchain Innovations
+                   with Pegged Sidechains." Blockstream whitepaper.
+                   <span class="cited">Cited in Chapter 31 as the original sidechain proposal.</span></p>
+                <p>Bose, P., Guo, H., Kranakis, E., Maheshwari, A., Morin, P., Morrison, J.,
+                   Smid, M., &amp; Tang, Y. (2008). "On the false-positive rate of Bloom filters."
+                   <em>Information Processing Letters</em> 108(4), 210&ndash;213.
+                   <span class="cited">Cited in Chapter 18.</span></p>
+                <p>Danezis, G., &amp; Goldberg, I. (2009). "Sphinx: A Compact and Provably Secure Mix
+                   Format." IEEE Symposium on Security and Privacy.
+                   <span class="cited">Lightning's onion routing is Sphinx-style; discussed in Chapter 24.</span></p>
+                <p>Decker, C., &amp; Wattenhofer, R. (2013). "Information Propagation in the Bitcoin
+                   Network." 13th IEEE International Conference on Peer-to-Peer Computing.
+                   <span class="cited">Source of the 2013 stale-rate measurement cited in Chapter 26.</span></p>
+                <p>Dobbertin, H., Bosselaers, A., &amp; Preneel, B. (1996). "RIPEMD-160: A Strengthened
+                   Version of RIPEMD." Fast Software Encryption (FSE 1996), LNCS 1039. Springer.
+                   <span class="cited">RIPEMD-160 is discussed in Chapters 6 and 9.</span></p>
+                <p>Dwork, C., &amp; Naor, M. (1993). "Pricing via Processing or Combatting Junk Mail."
+                   Advances in Cryptology &mdash; CRYPTO '92, LNCS 740. Springer.
+                   <span class="cited">Cited in Chapter 14 as an independent invention of proof of work.</span></p>
+                <p>Eyal, I., &amp; Sirer, E. G. (2014). "Majority Is Not Enough: Bitcoin Mining Is
+                   Vulnerable." Financial Cryptography and Data Security (FC 2014), LNCS 8437. Springer.
+                   <span class="cited">Cited in Chapter 14; the selfish-mining threshold of Theorem 36.3
+                   is this paper's result.</span></p>
+                <p>Fiat, A., &amp; Shamir, A. (1987). "How to Prove Yourself: Practical Solutions to
+                   Identification and Signature Problems." Advances in Cryptology &mdash; CRYPTO '86,
+                   LNCS 263. Springer.
+                   <span class="cited">The Fiat&ndash;Shamir transform is presented in Chapter 8.</span></p>
+                <p>Gallager, R. G., &amp; Van Voorhis, D. C. (1975). "Optimal Source Codes for
+                   Geometrically Distributed Integer Alphabets." <em>IEEE Transactions on Information
+                   Theory</em> 21(2), 228&ndash;230.
+                   <span class="cited">Optimality of Golomb coding; underlies Theorem 19.2.</span></p>
+                <p>Gervais, A., Karame, G. O., Gruber, D., &amp; Capkun, S. (2014). "On the Privacy
+                   Provisions of Bloom Filters in Lightweight Bitcoin Clients." 30th Annual Computer
+                   Security Applications Conference (ACSAC 2014). ACM.
+                   <span class="cited">Cited in Chapter 18.</span></p>
+                <p>Golomb, S. W. (1966). "Run-Length Encodings." <em>IEEE Transactions on Information
+                   Theory</em> 12(3), 399&ndash;401.
+                   <span class="cited">Golomb coding is developed in Chapter 19.</span></p>
+                <p>Grover, L. K. (1996). "A Fast Quantum Mechanical Algorithm for Database Search."
+                   28th ACM Symposium on Theory of Computing (STOC), 212&ndash;219.
+                   <span class="cited">Cited in Chapter 39.</span></p>
+                <p>Hankerson, D., Menezes, A. J., &amp; Vanstone, S. (2004). <em>Guide to Elliptic Curve
+                   Cryptography.</em> Springer.
+                   <span class="cited">Cited in Chapter 5 for the formal definition of Koblitz curves.</span></p>
+                <p>Koblitz, N. (1992). "CM-Curves with Good Cryptographic Properties." Advances in
+                   Cryptology &mdash; CRYPTO '91, LNCS 576. Springer.
+                   <span class="cited">Cited in Chapters 4 and 5 (as "Koblitz, 1991", the conference year).</span></p>
+                <p>Lamport, L. (1979). "Constructing Digital Signatures from a One-Way Function."
+                   Technical Report CSL-98, SRI International.
+                   <span class="cited">Lamport signatures are discussed in Chapters 30 and 39.</span></p>
+                <p>Lovejoy, J. (2020). "Bitcoin Gold (BTG) 51% attack reports." MIT Digital Currency
+                   Initiative.
+                   <span class="cited">Source for the BTG attack figures in Chapter 27.</span></p>
+                <p>Maxwell, G., Poelstra, A., Seurin, Y., &amp; Wuille, P. (2019). "Simple Schnorr
+                   Multi-Signatures with Applications to Bitcoin." <em>Designs, Codes and
+                   Cryptography</em> 87(9), 2139&ndash;2164.
+                   <span class="cited">MuSig is presented in Chapter 8.</span></p>
+                <p>Merkle, R. C. (1979). <em>Secrecy, Authentication, and Public Key Systems.</em>
+                   Ph.D. thesis, Stanford University.
+                   <span class="cited">Origin of the hash tree; Chapter 12.</span></p>
+                <p>Mosca, M. (2018). "Cybersecurity in an Era with Quantum Computers: Will We Be
+                   Ready?" <em>IEEE Security &amp; Privacy</em> 16(5), 38&ndash;41.
+                   <span class="cited">Mosca's inequality is Definition 39.8.</span></p>
+                <p>Nick, J., Ruffing, T., &amp; Seurin, Y. (2021). "MuSig2: Simple Two-Round Schnorr
+                   Multi-Signatures." Advances in Cryptology &mdash; CRYPTO 2021, LNCS 12825. Springer.
+                   <span class="cited">MuSig2 is presented in Chapters 8 and 29.</span></p>
+                <p>Poelstra, A. (2021). "CAT and Schnorr Tricks I&ndash;II." wpsoftware.net blog.
+                   <span class="cited">The on-stack sighash construction of Proposition 30.1.</span></p>
+                <p>Roetteler, M., Naehrig, M., Svore, K. M., &amp; Lauter, K. (2017). "Quantum Resource
+                   Estimates for Computing Elliptic Curve Discrete Logarithms." Advances in
+                   Cryptology &mdash; ASIACRYPT 2017, LNCS 10625. Springer.
+                   <span class="cited">Cited in Chapter 39 for the ~2,330 logical-qubit estimate.</span></p>
+                <p>Schnorr, C. P. (1991). "Efficient Signature Generation by Smart Cards."
+                   <em>Journal of Cryptology</em> 4(3), 161&ndash;174.
+                   <span class="cited">The signature scheme of Chapter 8.</span></p>
+                <p>Shor, P. W. (1994). "Algorithms for Quantum Computation: Discrete Logarithms and
+                   Factoring." 35th IEEE Symposium on Foundations of Computer Science (FOCS), 124&ndash;134.
+                   <span class="cited">Cited in Chapter 39.</span></p>
+                <p>Silverman, J. H. (2009). <em>The Arithmetic of Elliptic Curves</em>, 2nd ed.
+                   Graduate Texts in Mathematics 106. Springer.
+                   <span class="cited">Cited in Chapter 3 for the associativity proof (Ch. III, Prop. 2.2).</span></p>
+                <p>Sompolinsky, Y., &amp; Zohar, A. (2015). "Secure High-Rate Transaction Processing in
+                   Bitcoin." Financial Cryptography and Data Security (FC 2015), LNCS 8975. Springer.
+                   <span class="cited">The GHOST fork-choice rule mentioned in Chapter 26.</span></p>
+                <p>Todd, P. (2016). "Building Blocks of the State Machine Approach to Consensus."
+                   petertodd.org.
+                   <span class="cited">Origin of single-use seals; cited in Chapter 22.</span></p>
+            </div>
+        </section>
+
+        <section>
+            <h2>B.3 Standards</h2>
+            <div class="ref-list">
+                <p>Certicom Research / SECG (2010). "SEC 2: Recommended Elliptic Curve Domain
+                   Parameters," Version 2.0. Standards for Efficient Cryptography Group.
+                   <span class="cited">Defines secp256k1; Chapter 5.</span></p>
+                <p>NIST (2015). FIPS PUB 180-4, <em>Secure Hash Standard</em>.
+                   <span class="cited">SHA-256; Chapter 6 (first published 2001&ndash;2002).</span></p>
+                <p>NIST (2024). FIPS PUB 203, <em>Module-Lattice-Based Key-Encapsulation Mechanism
+                   Standard</em> (ML-KEM / Kyber).
+                   <span class="cited">Chapter 39.</span></p>
+                <p>NIST (2024). FIPS PUB 204, <em>Module-Lattice-Based Digital Signature Standard</em>
+                   (ML-DSA / Dilithium).
+                   <span class="cited">Chapter 39.</span></p>
+                <p>NIST (2024). FIPS PUB 205, <em>Stateless Hash-Based Digital Signature Standard</em>
+                   (SLH-DSA / SPHINCS+).
+                   <span class="cited">Chapter 39.</span></p>
+                <p>Pornin, T. (2013). RFC 6979, "Deterministic Usage of the Digital Signature
+                   Algorithm (DSA) and Elliptic Curve Digital Signature Algorithm (ECDSA)." IETF.
+                   <span class="cited">Deterministic nonces; Chapter 7.</span></p>
+            </div>
+        </section>
+
+        <section>
+            <h2>B.4 Bitcoin Improvement Proposals</h2>
+            <p>
+                BIPs are published in the
+                <a href="https://github.com/bitcoin/bips">bitcoin/bips</a> repository.
+                The chapters listed are where each BIP is cited or treated substantively.
+            </p>
+            <table>
+                <tr><th>BIP</th><th>Title</th><th>Chapters</th></tr>
+                <tr><td>2</td><td>BIP process, revised</td><td>33</td></tr>
+                <tr><td>3</td><td>Updated BIP Process</td><td>33</td></tr>
+                <tr><td>8</td><td>Version bits with lock-in by height</td><td>16, 33</td></tr>
+                <tr><td>9</td><td>Version bits with timeout and delay</td><td>13, 16, 28, 33</td></tr>
+                <tr><td>16</td><td>Pay to Script Hash</td><td>9, 15, 16</td></tr>
+                <tr><td>30</td><td>Duplicate transactions</td><td>16, 35</td></tr>
+                <tr><td>32</td><td>Hierarchical Deterministic Wallets</td><td>20</td></tr>
+                <tr><td>34</td><td>Block v2, Height in Coinbase</td><td>10, 13, 16, 20, 35</td></tr>
+                <tr><td>37</td><td>Connection Bloom filtering</td><td>17, 18, 19</td></tr>
+                <tr><td>65</td><td>OP_CHECKLOCKTIMEVERIFY</td><td>11, 16</td></tr>
+                <tr><td>66</td><td>Strict DER signatures</td><td>16, 26</td></tr>
+                <tr><td>68</td><td>Relative lock-time using consensus-enforced sequence numbers</td><td>10, 16</td></tr>
+                <tr><td>101</td><td>Increase maximum block size</td><td>27</td></tr>
+                <tr><td>112</td><td>CHECKSEQUENCEVERIFY</td><td>11, 16</td></tr>
+                <tr><td>113</td><td>Median time-past as endpoint for lock-time calculations</td><td>16</td></tr>
+                <tr><td>118</td><td>SIGHASH_ANYPREVOUT for Taproot Scripts</td><td>16, 24, 30, 32</td></tr>
+                <tr><td>119</td><td>CHECKTEMPLATEVERIFY</td><td>16, 30</td></tr>
+                <tr><td>125</td><td>Opt-in Full Replace-by-Fee Signaling</td><td>10</td></tr>
+                <tr><td>141</td><td>Segregated Witness (Consensus layer)</td><td>16, 20, 28</td></tr>
+                <tr><td>143</td><td>Transaction Signature Verification for Version 0 Witness Program</td><td>16, 28</td></tr>
+                <tr><td>144</td><td>Segregated Witness (Peer Services)</td><td>16, 28</td></tr>
+                <tr><td>146</td><td>Dealing with signature encoding malleability</td><td>28</td></tr>
+                <tr><td>148</td><td>Mandatory activation of segwit deployment (UASF)</td><td>16, 25, 28, 33</td></tr>
+                <tr><td>152</td><td>Compact Block Relay</td><td>13</td></tr>
+                <tr><td>157</td><td>Client Side Block Filtering</td><td>17, 18, 19, 20</td></tr>
+                <tr><td>158</td><td>Compact Block Filters for Light Clients</td><td>18, 19, 20, A</td></tr>
+                <tr><td>173</td><td>Base32 address format for native v0&ndash;16 witness outputs (Bech32)</td><td>9</td></tr>
+                <tr><td>180</td><td>Block size/weight fraud proof</td><td>20</td></tr>
+                <tr><td>300</td><td>Hashrate Escrows (Consensus layer)</td><td>34</td></tr>
+                <tr><td>301</td><td>Blind Merged Mining (Consensus layer)</td><td>34</td></tr>
+                <tr><td>340</td><td>Schnorr Signatures for secp256k1</td><td>4, 6, 8, 9, 11, 16, 29, A</td></tr>
+                <tr><td>341</td><td>Taproot: SegWit version 1 spending rules</td><td>8, 11, 16, 28, 29</td></tr>
+                <tr><td>342</td><td>Validation of Taproot Scripts (Tapscript)</td><td>11, 16, 29</td></tr>
+                <tr><td>345</td><td>OP_VAULT</td><td>30</td></tr>
+                <tr><td>346</td><td>OP_TXHASH</td><td>30</td></tr>
+                <tr><td>347</td><td>OP_CAT in Tapscript</td><td>30</td></tr>
+                <tr><td>348</td><td>OP_CHECKSIGFROMSTACK</td><td>30</td></tr>
+                <tr><td>350</td><td>Bech32m format for v1+ witness addresses</td><td>9</td></tr>
+                <tr><td>360</td><td>QuBit &mdash; Pay to Quantum Resistant Hash (draft)</td><td>39</td></tr>
+            </table>
+        </section>
+
+        <section>
+            <h2>B.5 Lightning Network Specifications (BOLTs)</h2>
+            <p>
+                The Basis of Lightning Technology specifications are published in the
+                <a href="https://github.com/lightning/bolts">lightning/bolts</a> repository.
+                All are treated in Chapter 24 (channel mechanics in Chapter 23).
+            </p>
+            <table>
+                <tr><th>BOLT</th><th>Title</th></tr>
+                <tr><td>1</td><td>Base Protocol</td></tr>
+                <tr><td>2</td><td>Peer Protocol for Channel Management</td></tr>
+                <tr><td>3</td><td>Bitcoin Transaction and Script Formats</td></tr>
+                <tr><td>4</td><td>Onion Routing Protocol</td></tr>
+                <tr><td>5</td><td>Recommendations for On-chain Transaction Handling</td></tr>
+                <tr><td>7</td><td>P2P Node and Channel Discovery</td></tr>
+                <tr><td>8</td><td>Encrypted and Authenticated Transport</td></tr>
+                <tr><td>9</td><td>Assigned Feature Flags</td></tr>
+                <tr><td>10</td><td>DNS Bootstrap and Assisted Node Location</td></tr>
+                <tr><td>11</td><td>Invoice Protocol for Lightning Payments</td></tr>
+                <tr><td>12</td><td>Offers (draft)</td></tr>
+            </table>
+        </section>
+
+        <section>
+            <h2>B.6 Security Advisories</h2>
+            <table>
+                <tr><th>Identifier</th><th>Subject</th><th>Chapters</th></tr>
+                <tr><td>CVE-2012-1909</td><td>Duplicate transaction IDs overwriting transactions (addressed by BIP-30/BIP-34)</td><td>35</td></tr>
+                <tr><td>CVE-2012-2459</td><td>Merkle-tree duplicate-subtree block mutation</td><td>12, 35</td></tr>
+                <tr><td>CVE-2013-5700</td><td>BIP-37 Bloom-filter remote denial of service</td><td>18</td></tr>
+                <tr><td>CVE-2017-12842</td><td>64-byte-transaction Merkle leaf/interior ambiguity (motivates the policy minimum transaction size and part of the Great Consensus Cleanup)</td><td>15, 35</td></tr>
+            </table>
+        </section>
+
+        <nav class="chapter-nav">
+            <a href="appendix-a-notation.html">← Appendix A: Mathematical Notation</a>
+            <a href="appendix-c-index.html">Appendix C: Subject Index →</a>
+        </nav>
+    </main>
+
+    <footer>
+        <p><a href="../index.html">Elementary Bitcoin</a> · A Mathematical Introduction</p>
+    </footer>
+</body>
+</html>

--- a/chapters/appendix-c-index.html
+++ b/chapters/appendix-c-index.html
@@ -1,0 +1,424 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Appendix C: Subject Index | Elementary Bitcoin</title>
+    <meta name="description" content="Appendix C: Subject Index - Alphabetical index of concepts with links to the sections where they are defined and developed">
+
+    <!-- Open Graph -->
+    <meta property="og:type" content="article">
+    <meta property="og:site_name" content="Elementary Bitcoin">
+    <meta property="og:title" content="Appendix C: Subject Index | Elementary Bitcoin">
+    <meta property="og:description" content="Alphabetical index of concepts with links to the sections where they are defined and developed">
+    <meta property="og:url" content="https://elementarybitcoin.org/chapters/appendix-c-index.html">
+    <meta property="og:image" content="https://elementarybitcoin.org/og-image.png">
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Appendix C: Subject Index | Elementary Bitcoin">
+    <meta name="twitter:description" content="Alphabetical index of concepts with links to the sections where they are defined and developed">
+    <meta name="twitter:image" content="https://elementarybitcoin.org/og-image.png">
+
+    <link rel="stylesheet" href="../style.css">
+    <style>
+        .index-list { list-style: none; padding: 0; columns: 2; column-gap: 3rem; }
+        .index-list li { padding: 0.25rem 0; break-inside: avoid; font-size: 0.95rem; }
+        .index-list a { color: #8b4513; text-decoration: none; }
+        .index-list a:hover { text-decoration: underline; }
+        main h2 { border-bottom: 1px solid #ddd; margin-top: 2rem; }
+        @media (max-width: 600px) { .index-list { columns: 1; } }
+    </style>
+</head>
+<body>
+    <header class="chapter-header">
+        <span class="chapter-number">Appendix C</span>
+        <h1 class="chapter-title">Subject Index</h1>
+    </header>
+
+    <main>
+        <section>
+            <p>
+                Each entry links to the section where the concept is defined or receives its
+                primary treatment (listed first), followed by other sections that develop it.
+            </p>
+            <h2>0-9</h2>
+            <ul class="index-list">
+                <li>21 million cap &middot; <a href="15-consensus-parameters.html#s15-1">&sect;15.1</a></li>
+                <li>51% attack &middot; <a href="14-proof-of-work.html#s14-8-2">&sect;14.8.2</a>, <a href="25-debunking-myths.html#s25-4">&sect;25.4</a>, <a href="36-security-threats.html#s36-1">&sect;36.1</a>, <a href="38-security-budget.html#s38-8">&sect;38.8</a></li>
+                <li>64-byte transaction vulnerability &middot; <a href="35-consensus-cleanup.html#s35-3">&sect;35.3</a>, <a href="12-merkle-trees.html#s12-8-2">&sect;12.8.2</a></li>
+            </ul>
+            <h2>A</h2>
+            <ul class="index-list">
+                <li>abelian group &middot; <a href="01-groups.html#s1-3">&sect;1.3</a>, <a href="03-elliptic-curves-real.html#s3-5">&sect;3.5</a></li>
+                <li>adaptor signature &middot; <a href="29-taproot-architecture.html#s29-6">&sect;29.6</a></li>
+                <li>anyone-can-spend output &middot; <a href="28-segwit-deep-dive.html#s28-3">&sect;28.3</a></li>
+                <li>Ark protocol &middot; <a href="32-beyond-lightning.html#s32-2">&sect;32.2</a></li>
+                <li>ASIC mining hardware &middot; <a href="14-proof-of-work.html#s14-10">&sect;14.10</a></li>
+                <li>AssumeUTXO &middot; <a href="21-node-optimizations.html#s21-3">&sect;21.3</a>, <a href="37-defense-mechanisms.html#s37-4">&sect;37.4</a></li>
+                <li>AssumeValid &middot; <a href="21-node-optimizations.html#s21-2">&sect;21.2</a>, <a href="37-defense-mechanisms.html#s37-4">&sect;37.4</a></li>
+                <li>avalanche effect &middot; <a href="06-hash-functions.html#s6-2">&sect;6.2</a></li>
+            </ul>
+            <h2>B</h2>
+            <ul class="index-list">
+                <li>baby-step giant-step algorithm &middot; <a href="04-elliptic-curves-finite.html#s4-5">&sect;4.5</a></li>
+                <li>Base58Check &middot; <a href="09-keys-addresses.html#s9-4">&sect;9.4</a>, <a href="09-keys-addresses.html#s9-9">&sect;9.9</a></li>
+                <li>batch verification &middot; <a href="08-schnorr.html#s8-9">&sect;8.9</a>, <a href="29-taproot-architecture.html#s29-1-2">&sect;29.1.2</a></li>
+                <li>Bech32 &middot; <a href="09-keys-addresses.html#s9-7">&sect;9.7</a></li>
+                <li>Bech32m &middot; <a href="09-keys-addresses.html#s9-8-1">&sect;9.8.1</a></li>
+                <li>bilateral fork &middot; <a href="26-fork-theory.html#s26-3">&sect;26.3</a></li>
+                <li>binary operation &middot; <a href="01-groups.html#s1-1">&sect;1.1</a></li>
+                <li>BIP-143 sighash &middot; <a href="28-segwit-deep-dive.html#s28-7">&sect;28.7</a></li>
+                <li>BIP-157 / BIP-158 &middot; <a href="19-compact-filters.html#s19-3">&sect;19.3</a>, <a href="19-compact-filters.html#s19-4">&sect;19.4</a></li>
+                <li>BIP-340 &middot; <a href="08-schnorr.html#s8-4">&sect;8.4</a>, <a href="29-taproot-architecture.html#s29-1">&sect;29.1</a></li>
+                <li>BIP-37 Bloom filtering &middot; <a href="18-bloom-filters.html#s18-2">&sect;18.2</a>, <a href="18-bloom-filters.html#s18-7">&sect;18.7</a></li>
+                <li>BIP-8 activation &middot; <a href="16-soft-forks.html#s16-3-3">&sect;16.3.3</a>, <a href="33-governance.html#s33-4">&sect;33.4</a></li>
+                <li>BIP-9 version bits &middot; <a href="16-soft-forks.html#s16-3-2">&sect;16.3.2</a>, <a href="13-blocks.html#s13-2-1">&sect;13.2.1</a>, <a href="33-governance.html#s33-4">&sect;33.4</a></li>
+                <li>BIP process &middot; <a href="33-governance.html#s33-2">&sect;33.2</a></li>
+                <li>birthday bound &middot; <a href="09-keys-addresses.html#s9-1-1">&sect;9.1.1</a>, <a href="06-hash-functions.html#s6-7">&sect;6.7</a></li>
+                <li>Bitcoin Cash &middot; <a href="27-historical-forks.html#s27-3">&sect;27.3</a></li>
+                <li>Bitcoin Gold &middot; <a href="27-historical-forks.html#s27-5">&sect;27.5</a></li>
+                <li>Bitcoin SV &middot; <a href="27-historical-forks.html#s27-4">&sect;27.4</a></li>
+                <li>Bitcoin Unlimited &middot; <a href="27-historical-forks.html#s27-2-3">&sect;27.2.3</a></li>
+                <li>Bitcoin XT &middot; <a href="27-historical-forks.html#s27-2-1">&sect;27.2.1</a></li>
+                <li>bits field (compact target) &middot; <a href="13-blocks.html#s13-2-5">&sect;13.2.5</a></li>
+                <li>blind merged mining &middot; <a href="34-drivechains.html#s34-3">&sect;34.3</a></li>
+                <li>block &middot; <a href="13-blocks.html#s13-1">&sect;13.1</a></li>
+                <li>block hash &middot; <a href="13-blocks.html#s13-2-2">&sect;13.2.2</a></li>
+                <li>block header &middot; <a href="13-blocks.html#s13-2">&sect;13.2</a></li>
+                <li>block height &middot; <a href="13-blocks.html#s13-7">&sect;13.7</a></li>
+                <li>block propagation &middot; <a href="13-blocks.html#s13-9">&sect;13.9</a></li>
+                <li>block size debate &middot; <a href="27-historical-forks.html#s27-1">&sect;27.1</a>, <a href="33-governance.html#s33-7-1">&sect;33.7.1</a></li>
+                <li>block subsidy &middot; <a href="15-consensus-parameters.html#s15-2">&sect;15.2</a>, <a href="10-transactions.html#s10-10">&sect;10.10</a>, <a href="38-security-budget.html#s38-1">&sect;38.1</a></li>
+                <li>block validation rules &middot; <a href="13-blocks.html#s13-5">&sect;13.5</a></li>
+                <li>block weight &middot; <a href="13-blocks.html#s13-4-2">&sect;13.4.2</a>, <a href="10-transactions.html#s10-8-1">&sect;10.8.1</a>, <a href="28-segwit-deep-dive.html#s28-4">&sect;28.4</a></li>
+                <li>block withholding &middot; <a href="36-security-threats.html#s36-5-2">&sect;36.5.2</a></li>
+                <li>Bloom filter &middot; <a href="18-bloom-filters.html#s18-1">&sect;18.1</a></li>
+                <li>BOLT specifications &middot; <a href="24-lightning.html#s24-5">&sect;24.5</a></li>
+                <li>breach remedy transaction &middot; <a href="23-payment-channels.html#s23-4">&sect;23.4</a></li>
+                <li>Bézout's identity &middot; <a href="02-finite-fields.html#s2-4">&sect;2.4</a></li>
+            </ul>
+            <h2>C</h2>
+            <ul class="index-list">
+                <li>CBDC &middot; <a href="40-monetary-future.html#s40-9">&sect;40.9</a></li>
+                <li>censorship resistance &middot; <a href="25-debunking-myths.html#s25-6">&sect;25.6</a>, <a href="36-security-threats.html#s36-5-1">&sect;36.5.1</a></li>
+                <li>chain reorganization &middot; <a href="36-security-threats.html#s36-2">&sect;36.2</a>, <a href="26-fork-theory.html#s26-7">&sect;26.7</a></li>
+                <li>chain split &middot; <a href="16-soft-forks.html#s16-7-1">&sect;16.7.1</a></li>
+                <li>chainwork (most-work rule) &middot; <a href="26-fork-theory.html#s26-6">&sect;26.6</a>, <a href="14-proof-of-work.html#s14-6">&sect;14.6</a>, <a href="37-defense-mechanisms.html#s37-3">&sect;37.3</a></li>
+                <li>channel factory &middot; <a href="32-beyond-lightning.html#s32-4">&sect;32.4</a></li>
+                <li>checkpoint &middot; <a href="37-defense-mechanisms.html#s37-2">&sect;37.2</a></li>
+                <li>chord-and-tangent method &middot; <a href="03-elliptic-curves-real.html#s3-3">&sect;3.3</a></li>
+                <li>client-side validation &middot; <a href="22-client-side-validation.html#s22-1">&sect;22.1</a></li>
+                <li>CLTV delta &middot; <a href="24-lightning.html#s24-1">&sect;24.1</a></li>
+                <li>coexistence model (monetary) &middot; <a href="40-monetary-future.html#s40-9">&sect;40.9</a></li>
+                <li>cofactor &middot; <a href="04-elliptic-curves-finite.html#s4-4">&sect;4.4</a>, <a href="05-secp256k1.html#s5-5">&sect;5.5</a></li>
+                <li>coinbase maturity &middot; <a href="15-consensus-parameters.html#s15-5">&sect;15.5</a></li>
+                <li>coinbase transaction &middot; <a href="10-transactions.html#s10-10">&sect;10.10</a>, <a href="13-blocks.html#s13-6">&sect;13.6</a></li>
+                <li>collision resistance &middot; <a href="06-hash-functions.html#s6-1">&sect;6.1</a>, <a href="12-merkle-trees.html#s12-4">&sect;12.4</a></li>
+                <li>commitment transaction &middot; <a href="23-payment-channels.html#s23-4">&sect;23.4</a></li>
+                <li>compact block filter &middot; <a href="19-compact-filters.html#s19-3">&sect;19.3</a></li>
+                <li>compact block relay &middot; <a href="13-blocks.html#s13-9">&sect;13.9</a></li>
+                <li>compressed public key &middot; <a href="05-secp256k1.html#s5-8">&sect;5.8</a>, <a href="09-keys-addresses.html#s9-2-1">&sect;9.2.1</a></li>
+                <li>confirmation security &middot; <a href="17-spv-theory.html#s17-6">&sect;17.6</a>, <a href="13-blocks.html#s13-7">&sect;13.7</a>, <a href="37-defense-mechanisms.html#s37-1">&sect;37.1</a></li>
+                <li>congruence &middot; <a href="02-finite-fields.html#s2-1">&sect;2.1</a></li>
+                <li>consensus rule &middot; <a href="16-soft-forks.html#s16-1">&sect;16.1</a></li>
+                <li>contentious fork &middot; <a href="26-fork-theory.html#s26-9">&sect;26.9</a></li>
+                <li>control block (Taproot) &middot; <a href="29-taproot-architecture.html#s29-3">&sect;29.3</a></li>
+                <li>cooperative close &middot; <a href="23-payment-channels.html#s23-5">&sect;23.5</a></li>
+                <li>coordination game &middot; <a href="26-fork-theory.html#s26-4">&sect;26.4</a>, <a href="33-governance.html#s33-6">&sect;33.6</a>, <a href="40-monetary-future.html#s40-3">&sect;40.3</a></li>
+                <li>coset &middot; <a href="01-groups.html#s1-5">&sect;1.5</a></li>
+                <li>covenant &middot; <a href="30-covenants.html#s30-1">&sect;30.1</a></li>
+                <li>cryptographic accumulator &middot; <a href="21-node-optimizations.html#s21-5">&sect;21.5</a></li>
+                <li>cryptographic hash function &middot; <a href="06-hash-functions.html#s6-1">&sect;6.1</a></li>
+                <li>CVE-2012-2459 &middot; <a href="12-merkle-trees.html#s12-8-1">&sect;12.8.1</a>, <a href="35-consensus-cleanup.html#s35-4">&sect;35.4</a></li>
+                <li>cyclic group &middot; <a href="01-groups.html#s1-4">&sect;1.4</a>, <a href="04-elliptic-curves-finite.html#s4-4">&sect;4.4</a></li>
+            </ul>
+            <h2>D</h2>
+            <ul class="index-list">
+                <li>DER encoding &middot; <a href="07-ecdsa.html#s7-9">&sect;7.9</a></li>
+                <li>difficulty &middot; <a href="14-proof-of-work.html#s14-3">&sect;14.3</a></li>
+                <li>difficulty adjustment &middot; <a href="14-proof-of-work.html#s14-4">&sect;14.4</a>, <a href="15-consensus-parameters.html#s15-3">&sect;15.3</a></li>
+                <li>difficulty death spiral &middot; <a href="26-fork-theory.html#s26-8">&sect;26.8</a>, <a href="27-historical-forks.html#s27-9">&sect;27.9</a></li>
+                <li>digital signature &middot; <a href="07-ecdsa.html#s7-1">&sect;7.1</a></li>
+                <li>discrete logarithm &middot; <a href="01-groups.html#s1-6">&sect;1.6</a></li>
+                <li>discrete logarithm problem &middot; <a href="01-groups.html#s1-6">&sect;1.6</a>, <a href="04-elliptic-curves-finite.html#s4-5">&sect;4.5</a></li>
+                <li>discriminant &middot; <a href="03-elliptic-curves-real.html#s3-1">&sect;3.1</a></li>
+                <li>domain separation &middot; <a href="06-hash-functions.html#s6-7">&sect;6.7</a></li>
+                <li>double-and-add algorithm &middot; <a href="03-elliptic-curves-real.html#s3-6">&sect;3.6</a></li>
+                <li>double SHA-256 (HASH256) &middot; <a href="06-hash-functions.html#s6-3">&sect;6.3</a></li>
+                <li>double-spend attack &middot; <a href="14-proof-of-work.html#s14-8-1">&sect;14.8.1</a>, <a href="17-spv-theory.html#s17-6">&sect;17.6</a>, <a href="36-security-threats.html#s36-1">&sect;36.1</a></li>
+                <li>drivechain &middot; <a href="34-drivechains.html#s34-1">&sect;34.1</a></li>
+            </ul>
+            <h2>E</h2>
+            <ul class="index-list">
+                <li>ECDSA &middot; <a href="07-ecdsa.html#s7-2">&sect;7.2</a></li>
+                <li>eclipse attack &middot; <a href="17-spv-theory.html#s17-5-2">&sect;17.5.2</a>, <a href="36-security-threats.html#s36-4">&sect;36.4</a></li>
+                <li>Electrum protocol &middot; <a href="20-light-clients.html#s20-2">&sect;20.2</a></li>
+                <li>elliptic curve &middot; <a href="03-elliptic-curves-real.html#s3-1">&sect;3.1</a>, <a href="04-elliptic-curves-finite.html#s4-1">&sect;4.1</a></li>
+                <li>elliptic curve discrete logarithm problem (ECDLP) &middot; <a href="04-elliptic-curves-finite.html#s4-5">&sect;4.5</a>, <a href="05-secp256k1.html#s5-10">&sect;5.10</a></li>
+                <li>elliptic curve group law &middot; <a href="03-elliptic-curves-real.html#s3-5">&sect;3.5</a></li>
+                <li>eltoo / LN-Symmetry &middot; <a href="32-beyond-lightning.html#s32-5">&sect;32.5</a>, <a href="24-lightning.html#s24-7">&sect;24.7</a></li>
+                <li>emergency difficulty adjustment &middot; <a href="27-historical-forks.html#s27-3-1">&sect;27.3.1</a></li>
+                <li>energy consumption &middot; <a href="14-proof-of-work.html#s14-9">&sect;14.9</a>, <a href="25-debunking-myths.html#s25-5">&sect;25.5</a></li>
+                <li>Euler's totient function &middot; <a href="02-finite-fields.html#s2-6">&sect;2.6</a></li>
+                <li>extended Euclidean algorithm &middot; <a href="02-finite-fields.html#s2-4">&sect;2.4</a></li>
+                <li>extra nonce &middot; <a href="13-blocks.html#s13-2-6">&sect;13.2.6</a></li>
+            </ul>
+            <h2>F</h2>
+            <ul class="index-list">
+                <li>false positive rate &middot; <a href="18-bloom-filters.html#s18-1">&sect;18.1</a>, <a href="19-compact-filters.html#s19-5">&sect;19.5</a></li>
+                <li>federated peg &middot; <a href="31-sidechains.html#s31-2">&sect;31.2</a></li>
+                <li>fee market &middot; <a href="38-security-budget.html#s38-4">&sect;38.4</a>, <a href="10-transactions.html#s10-8">&sect;10.8</a></li>
+                <li>fee sniping &middot; <a href="38-security-budget.html#s38-6">&sect;38.6</a></li>
+                <li>Fermat's little theorem &middot; <a href="02-finite-fields.html#s2-5">&sect;2.5</a></li>
+                <li>Fiat-Shamir transform &middot; <a href="08-schnorr.html#s8-3">&sect;8.3</a></li>
+                <li>field &middot; <a href="02-finite-fields.html#s2-3">&sect;2.3</a></li>
+                <li>filter header &middot; <a href="19-compact-filters.html#s19-4">&sect;19.4</a></li>
+                <li>finality (probabilistic) &middot; <a href="26-fork-theory.html#s26-7">&sect;26.7</a>, <a href="37-defense-mechanisms.html#s37-8">&sect;37.8</a></li>
+                <li>flag day activation &middot; <a href="16-soft-forks.html#s16-3-1">&sect;16.3.1</a></li>
+                <li>fork &middot; <a href="26-fork-theory.html#s26-1">&sect;26.1</a></li>
+                <li>fork choice rule &middot; <a href="26-fork-theory.html#s26-6">&sect;26.6</a></li>
+                <li>fraud proof &middot; <a href="17-spv-theory.html#s17-7">&sect;17.7</a>, <a href="20-light-clients.html#s20-6">&sect;20.6</a>, <a href="25-debunking-myths.html#s25-1">&sect;25.1</a></li>
+                <li>funding transaction &middot; <a href="23-payment-channels.html#s23-2">&sect;23.2</a></li>
+            </ul>
+            <h2>G</h2>
+            <ul class="index-list">
+                <li>generator (of a group) &middot; <a href="01-groups.html#s1-4">&sect;1.4</a>, <a href="02-finite-fields.html#s2-6">&sect;2.6</a></li>
+                <li>generator point G &middot; <a href="05-secp256k1.html#s5-4">&sect;5.4</a>, <a href="04-elliptic-curves-finite.html#s4-4">&sect;4.4</a></li>
+                <li>genesis block &middot; <a href="13-blocks.html#s13-6">&sect;13.6</a></li>
+                <li>GLV endomorphism &middot; <a href="05-secp256k1.html#s5-9">&sect;5.9</a></li>
+                <li>Golomb-coded set (GCS) &middot; <a href="19-compact-filters.html#s19-2">&sect;19.2</a></li>
+                <li>Golomb-Rice coding &middot; <a href="19-compact-filters.html#s19-2">&sect;19.2</a></li>
+                <li>gossip protocol (Lightning) &middot; <a href="24-lightning.html#s24-4">&sect;24.4</a></li>
+                <li>Great Consensus Cleanup &middot; <a href="35-consensus-cleanup.html#s35-1">&sect;35.1</a></li>
+                <li>group &middot; <a href="01-groups.html#s1-2">&sect;1.2</a></li>
+                <li>Grover's algorithm &middot; <a href="39-quantum-resistance.html#s39-4">&sect;39.4</a></li>
+            </ul>
+            <h2>H</h2>
+            <ul class="index-list">
+                <li>halving &middot; <a href="15-consensus-parameters.html#s15-2">&sect;15.2</a>, <a href="38-security-budget.html#s38-1">&sect;38.1</a></li>
+                <li>hard fork &middot; <a href="16-soft-forks.html#s16-2">&sect;16.2</a>, <a href="26-fork-theory.html#s26-3">&sect;26.3</a>, <a href="27-historical-forks.html#s27-3">&sect;27.3</a></li>
+                <li>HASH160 &middot; <a href="06-hash-functions.html#s6-4">&sect;6.4</a>, <a href="09-keys-addresses.html#s9-3">&sect;9.3</a></li>
+                <li>hashrate &middot; <a href="14-proof-of-work.html#s14-6">&sect;14.6</a></li>
+                <li>hashrate escrow &middot; <a href="34-drivechains.html#s34-2">&sect;34.2</a></li>
+                <li>Hasse's theorem &middot; <a href="04-elliptic-curves-finite.html#s4-3">&sect;4.3</a></li>
+                <li>header chain &middot; <a href="17-spv-theory.html#s17-2">&sect;17.2</a></li>
+                <li>headers-first sync &middot; <a href="21-node-optimizations.html#s21-1">&sect;21.1</a></li>
+                <li>HTLC &middot; <a href="23-payment-channels.html#s23-6">&sect;23.6</a>, <a href="24-lightning.html#s24-1">&sect;24.1</a></li>
+                <li>hyperbitcoinization &middot; <a href="40-monetary-future.html#s40-5">&sect;40.5</a></li>
+            </ul>
+            <h2>I</h2>
+            <ul class="index-list">
+                <li>initial block download (IBD) &middot; <a href="21-node-optimizations.html#s21-1">&sect;21.1</a></li>
+                <li>invoice (BOLT 11) &middot; <a href="24-lightning.html#s24-3">&sect;24.3</a></li>
+            </ul>
+            <h2>K</h2>
+            <ul class="index-list">
+                <li>key aggregation &middot; <a href="08-schnorr.html#s8-8">&sect;8.8</a></li>
+                <li>Koblitz-type curve &middot; <a href="05-secp256k1.html#s5-1">&sect;5.1</a>, <a href="04-elliptic-curves-finite.html#s4-6">&sect;4.6</a></li>
+            </ul>
+            <h2>L</h2>
+            <ul class="index-list">
+                <li>Lagrange's theorem &middot; <a href="01-groups.html#s1-5">&sect;1.5</a>, <a href="04-elliptic-curves-finite.html#s4-4">&sect;4.4</a></li>
+                <li>Lamport signature &middot; <a href="39-quantum-resistance.html#s39-6">&sect;39.6</a>, <a href="39-quantum-resistance.html#s39-10">&sect;39.10</a></li>
+                <li>light client &middot; <a href="20-light-clients.html#s20-1">&sect;20.1</a>, <a href="17-spv-theory.html#s17-2">&sect;17.2</a></li>
+                <li>Lightning Network &middot; <a href="24-lightning.html#s24-1">&sect;24.1</a>, <a href="23-payment-channels.html#s23-2">&sect;23.2</a></li>
+                <li>Liquid Network &middot; <a href="31-sidechains.html#s31-2-1">&sect;31.2.1</a></li>
+                <li>LN-Penalty &middot; <a href="23-payment-channels.html#s23-4">&sect;23.4</a></li>
+                <li>locktime &middot; <a href="10-transactions.html#s10-2-2">&sect;10.2.2</a>, <a href="11-script.html#s11-7">&sect;11.7</a></li>
+                <li>low-s rule &middot; <a href="07-ecdsa.html#s7-8">&sect;7.8</a></li>
+            </ul>
+            <h2>M</h2>
+            <ul class="index-list">
+                <li>MAST &middot; <a href="29-taproot-architecture.html#s29-3">&sect;29.3</a>, <a href="12-merkle-trees.html#s12-9-2">&sect;12.9.2</a>, <a href="08-schnorr.html#s8-10">&sect;8.10</a></li>
+                <li>median time past (MTP) &middot; <a href="15-consensus-parameters.html#s15-6">&sect;15.6</a>, <a href="13-blocks.html#s13-2-4">&sect;13.2.4</a></li>
+                <li>mempool &middot; <a href="13-blocks.html#s13-9">&sect;13.9</a></li>
+                <li>merged mining &middot; <a href="38-security-budget.html#s38-7-4">&sect;38.7.4</a>, <a href="34-drivechains.html#s34-3">&sect;34.3</a></li>
+                <li>Merkle mountain range &middot; <a href="12-merkle-trees.html#s12-9-1">&sect;12.9.1</a></li>
+                <li>Merkle proof &middot; <a href="12-merkle-trees.html#s12-3">&sect;12.3</a>, <a href="12-merkle-trees.html#s12-4">&sect;12.4</a>, <a href="17-spv-theory.html#s17-3">&sect;17.3</a></li>
+                <li>Merkle root &middot; <a href="12-merkle-trees.html#s12-2">&sect;12.2</a>, <a href="13-blocks.html#s13-2-3">&sect;13.2.3</a></li>
+                <li>Merkle tree &middot; <a href="12-merkle-trees.html#s12-1">&sect;12.1</a></li>
+                <li>minimum chain work &middot; <a href="37-defense-mechanisms.html#s37-3">&sect;37.3</a></li>
+                <li>ML-DSA (Dilithium) &middot; <a href="39-quantum-resistance.html#s39-6">&sect;39.6</a>, <a href="39-quantum-resistance.html#s39-8">&sect;39.8</a></li>
+                <li>modular arithmetic &middot; <a href="02-finite-fields.html#s2-1">&sect;2.1</a></li>
+                <li>Mosca's inequality &middot; <a href="39-quantum-resistance.html#s39-5">&sect;39.5</a></li>
+                <li>multi-hop payment &middot; <a href="24-lightning.html#s24-1">&sect;24.1</a></li>
+                <li>multi-path payment &middot; <a href="24-lightning.html#s24-4">&sect;24.4</a></li>
+                <li>multiplicative inverse &middot; <a href="02-finite-fields.html#s2-3">&sect;2.3</a>, <a href="02-finite-fields.html#s2-4">&sect;2.4</a></li>
+                <li>multisignature &middot; <a href="11-script.html#s11-8-3">&sect;11.8.3</a></li>
+                <li>MurmurHash3 &middot; <a href="18-bloom-filters.html#s18-5">&sect;18.5</a></li>
+                <li>MuSig &middot; <a href="08-schnorr.html#s8-8">&sect;8.8</a></li>
+                <li>MuSig2 &middot; <a href="29-taproot-architecture.html#s29-5">&sect;29.5</a>, <a href="08-schnorr.html#s8-8">&sect;8.8</a></li>
+            </ul>
+            <h2>N</h2>
+            <ul class="index-list">
+                <li>Nakamoto double-spend formula &middot; <a href="14-proof-of-work.html#s14-8-1">&sect;14.8.1</a>, <a href="17-spv-theory.html#s17-6">&sect;17.6</a>, <a href="36-security-threats.html#s36-1">&sect;36.1</a></li>
+                <li>natural fork &middot; <a href="26-fork-theory.html#s26-2">&sect;26.2</a></li>
+                <li>Neutrino &middot; <a href="19-compact-filters.html#s19-7">&sect;19.7</a>, <a href="20-light-clients.html#s20-1">&sect;20.1</a></li>
+                <li>New York Agreement &middot; <a href="27-historical-forks.html#s27-7">&sect;27.7</a></li>
+                <li>nonce (block header) &middot; <a href="13-blocks.html#s13-2-6">&sect;13.2.6</a></li>
+                <li>nonce reuse attack &middot; <a href="07-ecdsa.html#s7-7">&sect;7.7</a></li>
+                <li>nonce (signature) &middot; <a href="07-ecdsa.html#s7-7">&sect;7.7</a></li>
+            </ul>
+            <h2>O</h2>
+            <ul class="index-list">
+                <li>onion routing &middot; <a href="24-lightning.html#s24-2">&sect;24.2</a></li>
+                <li>OP_CAT &middot; <a href="30-covenants.html#s30-3">&sect;30.3</a></li>
+                <li>OP_CHECKLOCKTIMEVERIFY &middot; <a href="11-script.html#s11-7">&sect;11.7</a></li>
+                <li>OP_CHECKSEQUENCEVERIFY &middot; <a href="11-script.html#s11-7">&sect;11.7</a></li>
+                <li>OP_CHECKSIG &middot; <a href="11-script.html#s11-5-2">&sect;11.5.2</a></li>
+                <li>OP_CHECKSIGADD &middot; <a href="29-taproot-architecture.html#s29-4">&sect;29.4</a></li>
+                <li>OP_CHECKSIGFROMSTACK &middot; <a href="30-covenants.html#s30-5-3">&sect;30.5.3</a></li>
+                <li>OP_CHECKTEMPLATEVERIFY (CTV) &middot; <a href="30-covenants.html#s30-2">&sect;30.2</a></li>
+                <li>OP_RETURN &middot; <a href="11-script.html#s11-9">&sect;11.9</a></li>
+                <li>OP_SUCCESS &middot; <a href="16-soft-forks.html#s16-8-2">&sect;16.8.2</a></li>
+                <li>OP_TXHASH &middot; <a href="30-covenants.html#s30-5-2">&sect;30.5.2</a></li>
+                <li>OP_VAULT &middot; <a href="30-covenants.html#s30-4">&sect;30.4</a></li>
+                <li>order of a group &middot; <a href="01-groups.html#s1-4">&sect;1.4</a></li>
+                <li>order of an element &middot; <a href="01-groups.html#s1-4">&sect;1.4</a>, <a href="04-elliptic-curves-finite.html#s4-4">&sect;4.4</a></li>
+                <li>Ordinals and inscriptions &middot; <a href="33-governance.html#s33-7-3">&sect;33.7.3</a>, <a href="38-security-budget.html#s38-9">&sect;38.9</a></li>
+                <li>orphan block &middot; <a href="13-blocks.html#s13-8">&sect;13.8</a></li>
+                <li>ossification &middot; <a href="33-governance.html#s33-3">&sect;33.3</a>, <a href="33-governance.html#s33-8">&sect;33.8</a></li>
+                <li>outpoint &middot; <a href="10-transactions.html#s10-3-1">&sect;10.3.1</a></li>
+            </ul>
+            <h2>P</h2>
+            <ul class="index-list">
+                <li>P2PKH &middot; <a href="09-keys-addresses.html#s9-5">&sect;9.5</a>, <a href="10-transactions.html#s10-5-1">&sect;10.5.1</a>, <a href="11-script.html#s11-8-1">&sect;11.8.1</a></li>
+                <li>P2QRH (BIP-360) &middot; <a href="39-quantum-resistance.html#s39-7">&sect;39.7</a></li>
+                <li>P2SH &middot; <a href="09-keys-addresses.html#s9-6">&sect;9.6</a>, <a href="10-transactions.html#s10-5-2">&sect;10.5.2</a>, <a href="11-script.html#s11-8-2">&sect;11.8.2</a></li>
+                <li>P2TR &middot; <a href="09-keys-addresses.html#s9-8">&sect;9.8</a>, <a href="10-transactions.html#s10-5-4">&sect;10.5.4</a></li>
+                <li>P2WPKH &middot; <a href="09-keys-addresses.html#s9-7-2">&sect;9.7.2</a>, <a href="10-transactions.html#s10-5-3">&sect;10.5.3</a></li>
+                <li>pathfinding (Lightning) &middot; <a href="24-lightning.html#s24-4">&sect;24.4</a></li>
+                <li>payment channel &middot; <a href="23-payment-channels.html#s23-2">&sect;23.2</a></li>
+                <li>payment preimage &middot; <a href="23-payment-channels.html#s23-6">&sect;23.6</a></li>
+                <li>pay-to-contract &middot; <a href="22-client-side-validation.html#s22-2">&sect;22.2</a></li>
+                <li>point addition &middot; <a href="03-elliptic-curves-real.html#s3-3">&sect;3.3</a>, <a href="04-elliptic-curves-finite.html#s4-2">&sect;4.2</a></li>
+                <li>point at infinity &middot; <a href="03-elliptic-curves-real.html#s3-2">&sect;3.2</a>, <a href="04-elliptic-curves-finite.html#s4-1">&sect;4.1</a></li>
+                <li>point doubling &middot; <a href="03-elliptic-curves-real.html#s3-4">&sect;3.4</a></li>
+                <li>policy rule (standardness) &middot; <a href="16-soft-forks.html#s16-1">&sect;16.1</a>, <a href="16-soft-forks.html#s16-6">&sect;16.6</a></li>
+                <li>Pollard's rho algorithm &middot; <a href="04-elliptic-curves-finite.html#s4-5">&sect;4.5</a></li>
+                <li>post-quantum cryptography &middot; <a href="39-quantum-resistance.html#s39-6">&sect;39.6</a></li>
+                <li>preimage resistance &middot; <a href="06-hash-functions.html#s6-1">&sect;6.1</a></li>
+                <li>prime field &middot; <a href="02-finite-fields.html#s2-3">&sect;2.3</a></li>
+                <li>primitive root &middot; <a href="02-finite-fields.html#s2-6">&sect;2.6</a></li>
+                <li>private key &middot; <a href="05-secp256k1.html#s5-7">&sect;5.7</a>, <a href="09-keys-addresses.html#s9-1">&sect;9.1</a></li>
+                <li>proof of work &middot; <a href="14-proof-of-work.html#s14-1">&sect;14.1</a></li>
+                <li>pruning &middot; <a href="21-node-optimizations.html#s21-4">&sect;21.4</a></li>
+                <li>public key &middot; <a href="05-secp256k1.html#s5-7">&sect;5.7</a>, <a href="09-keys-addresses.html#s9-2">&sect;9.2</a></li>
+            </ul>
+            <h2>Q</h2>
+            <ul class="index-list">
+                <li>quantum threat model &middot; <a href="39-quantum-resistance.html#s39-1">&sect;39.1</a>, <a href="25-debunking-myths.html#s25-3">&sect;25.3</a></li>
+            </ul>
+            <h2>R</h2>
+            <ul class="index-list">
+                <li>random oracle model &middot; <a href="06-hash-functions.html#s6-6">&sect;6.6</a></li>
+                <li>recursive covenant &middot; <a href="30-covenants.html#s30-6">&sect;30.6</a></li>
+                <li>repeated squaring &middot; <a href="02-finite-fields.html#s2-5">&sect;2.5</a></li>
+                <li>replay protection &middot; <a href="26-fork-theory.html#s26-5">&sect;26.5</a>, <a href="27-historical-forks.html#s27-3">&sect;27.3</a></li>
+                <li>revocation key &middot; <a href="23-payment-channels.html#s23-4">&sect;23.4</a></li>
+                <li>RFC 6979 (deterministic nonce) &middot; <a href="07-ecdsa.html#s7-7">&sect;7.7</a></li>
+                <li>RGB protocol &middot; <a href="22-client-side-validation.html#s22-3">&sect;22.3</a></li>
+                <li>ring &middot; <a href="02-finite-fields.html#s2-2">&sect;2.2</a></li>
+                <li>RIPEMD-160 &middot; <a href="06-hash-functions.html#s6-4">&sect;6.4</a></li>
+                <li>rogue key attack &middot; <a href="08-schnorr.html#s8-8">&sect;8.8</a></li>
+                <li>RSK (Rootstock) &middot; <a href="31-sidechains.html#s31-2-2">&sect;31.2.2</a></li>
+            </ul>
+            <h2>S</h2>
+            <ul class="index-list">
+                <li>satoshi (unit) &middot; <a href="10-transactions.html#s10-4">&sect;10.4</a></li>
+                <li>scalar multiplication &middot; <a href="03-elliptic-curves-real.html#s3-6">&sect;3.6</a></li>
+                <li>Schelling point &middot; <a href="26-fork-theory.html#s26-4">&sect;26.4</a>, <a href="33-governance.html#s33-6">&sect;33.6</a></li>
+                <li>Schnorr identification protocol &middot; <a href="08-schnorr.html#s8-2">&sect;8.2</a></li>
+                <li>Schnorr signature &middot; <a href="08-schnorr.html#s8-5">&sect;8.5</a>, <a href="29-taproot-architecture.html#s29-1">&sect;29.1</a></li>
+                <li>script execution &middot; <a href="11-script.html#s11-1">&sect;11.1</a></li>
+                <li>scriptPubKey &middot; <a href="10-transactions.html#s10-4">&sect;10.4</a></li>
+                <li>scriptSig &middot; <a href="10-transactions.html#s10-3">&sect;10.3</a></li>
+                <li>script versioning &middot; <a href="28-segwit-deep-dive.html#s28-3">&sect;28.3</a>, <a href="16-soft-forks.html#s16-8-1">&sect;16.8.1</a></li>
+                <li>secp256k1 &middot; <a href="05-secp256k1.html#s5-2">&sect;5.2</a></li>
+                <li>security budget &middot; <a href="38-security-budget.html#s38-2">&sect;38.2</a>, <a href="15-consensus-parameters.html#s15-9-3">&sect;15.9.3</a>, <a href="25-debunking-myths.html#s25-5">&sect;25.5</a></li>
+                <li>SegWit &middot; <a href="10-transactions.html#s10-6">&sect;10.6</a>, <a href="16-soft-forks.html#s16-4-2">&sect;16.4.2</a>, <a href="28-segwit-deep-dive.html#s28-1">&sect;28.1</a></li>
+                <li>SegWit2x &middot; <a href="27-historical-forks.html#s27-7">&sect;27.7</a></li>
+                <li>selfish mining &middot; <a href="36-security-threats.html#s36-3">&sect;36.3</a>, <a href="14-proof-of-work.html#s14-8-3">&sect;14.8.3</a></li>
+                <li>sequence number &middot; <a href="10-transactions.html#s10-3-2">&sect;10.3.2</a></li>
+                <li>SHA-256 &middot; <a href="06-hash-functions.html#s6-2">&sect;6.2</a></li>
+                <li>Shor's algorithm &middot; <a href="39-quantum-resistance.html#s39-3">&sect;39.3</a></li>
+                <li>sidechain &middot; <a href="31-sidechains.html#s31-1">&sect;31.1</a></li>
+                <li>SIGHASH_ANYPREVOUT &middot; <a href="30-covenants.html#s30-5-1">&sect;30.5.1</a>, <a href="32-beyond-lightning.html#s32-5">&sect;32.5</a></li>
+                <li>SIGHASH_FORKID &middot; <a href="27-historical-forks.html#s27-3">&sect;27.3</a></li>
+                <li>sighash type &middot; <a href="10-transactions.html#s10-7">&sect;10.7</a></li>
+                <li>signature malleability &middot; <a href="07-ecdsa.html#s7-8">&sect;7.8</a>, <a href="28-segwit-deep-dive.html#s28-1">&sect;28.1</a></li>
+                <li>single-use seal &middot; <a href="22-client-side-validation.html#s22-2">&sect;22.2</a></li>
+                <li>SipHash &middot; <a href="19-compact-filters.html#s19-3">&sect;19.3</a></li>
+                <li>SLH-DSA (SPHINCS+) &middot; <a href="39-quantum-resistance.html#s39-6">&sect;39.6</a></li>
+                <li>soft fork &middot; <a href="16-soft-forks.html#s16-2">&sect;16.2</a>, <a href="26-fork-theory.html#s26-3">&sect;26.3</a>, <a href="28-segwit-deep-dive.html#s28-6">&sect;28.6</a></li>
+                <li>Speedy Trial &middot; <a href="16-soft-forks.html#s16-3-4">&sect;16.3.4</a>, <a href="33-governance.html#s33-4">&sect;33.4</a></li>
+                <li>Sphinx onion packet &middot; <a href="24-lightning.html#s24-2">&sect;24.2</a></li>
+                <li>SPV peg &middot; <a href="31-sidechains.html#s31-3">&sect;31.3</a></li>
+                <li>SPV (simplified payment verification) &middot; <a href="17-spv-theory.html#s17-2">&sect;17.2</a>, <a href="12-merkle-trees.html#s12-7">&sect;12.7</a></li>
+                <li>Stacks &middot; <a href="31-sidechains.html#s31-5">&sect;31.5</a></li>
+                <li>stale block &middot; <a href="13-blocks.html#s13-8">&sect;13.8</a>, <a href="26-fork-theory.html#s26-2">&sect;26.2</a></li>
+                <li>statechain &middot; <a href="32-beyond-lightning.html#s32-3">&sect;32.3</a></li>
+                <li>subgroup &middot; <a href="01-groups.html#s1-5">&sect;1.5</a>, <a href="04-elliptic-curves-finite.html#s4-4">&sect;4.4</a></li>
+            </ul>
+            <h2>T</h2>
+            <ul class="index-list">
+                <li>tagged hash &middot; <a href="06-hash-functions.html#s6-7">&sect;6.7</a>, <a href="08-schnorr.html#s8-4">&sect;8.4</a></li>
+                <li>tail emission &middot; <a href="38-security-budget.html#s38-7-3">&sect;38.7.3</a></li>
+                <li>Taproot &middot; <a href="16-soft-forks.html#s16-4-3">&sect;16.4.3</a>, <a href="29-taproot-architecture.html#s29-2">&sect;29.2</a></li>
+                <li>Taproot output (tweaked key) &middot; <a href="08-schnorr.html#s8-10">&sect;8.10</a>, <a href="29-taproot-architecture.html#s29-2">&sect;29.2</a></li>
+                <li>Tapscript &middot; <a href="11-script.html#s11-11">&sect;11.11</a>, <a href="29-taproot-architecture.html#s29-4">&sect;29.4</a></li>
+                <li>target &middot; <a href="14-proof-of-work.html#s14-3">&sect;14.3</a>, <a href="13-blocks.html#s13-2-5">&sect;13.2.5</a></li>
+                <li>timewarp attack &middot; <a href="35-consensus-cleanup.html#s35-2">&sect;35.2</a></li>
+                <li>transaction &middot; <a href="10-transactions.html#s10-2">&sect;10.2</a></li>
+                <li>transaction fee &middot; <a href="10-transactions.html#s10-8">&sect;10.8</a></li>
+                <li>transaction malleability &middot; <a href="28-segwit-deep-dive.html#s28-1">&sect;28.1</a>, <a href="07-ecdsa.html#s7-8">&sect;7.8</a></li>
+                <li>two-way peg &middot; <a href="31-sidechains.html#s31-1">&sect;31.1</a></li>
+                <li>txid &middot; <a href="10-transactions.html#s10-6-2">&sect;10.6.2</a></li>
+            </ul>
+            <h2>U</h2>
+            <ul class="index-list">
+                <li>UASF &middot; <a href="16-soft-forks.html#s16-3-3">&sect;16.3.3</a>, <a href="33-governance.html#s33-4">&sect;33.4</a>, <a href="27-historical-forks.html#s27-7">&sect;27.7</a></li>
+                <li>unforgeability &middot; <a href="07-ecdsa.html#s7-1">&sect;7.1</a></li>
+                <li>Utreexo &middot; <a href="21-node-optimizations.html#s21-5">&sect;21.5</a></li>
+                <li>UTXO &middot; <a href="10-transactions.html#s10-1">&sect;10.1</a></li>
+            </ul>
+            <h2>V</h2>
+            <ul class="index-list">
+                <li>validity rollup &middot; <a href="31-sidechains.html#s31-4">&sect;31.4</a></li>
+                <li>vault &middot; <a href="30-covenants.html#s30-4">&sect;30.4</a>, <a href="30-covenants.html#s30-2-1">&sect;30.2.1</a></li>
+                <li>virtual size (vbyte) &middot; <a href="10-transactions.html#s10-8-1">&sect;10.8.1</a></li>
+                <li>vTXO &middot; <a href="32-beyond-lightning.html#s32-2">&sect;32.2</a></li>
+            </ul>
+            <h2>W</h2>
+            <ul class="index-list">
+                <li>watchtower &middot; <a href="23-payment-channels.html#s23-7">&sect;23.7</a></li>
+                <li>Weierstrass equation &middot; <a href="03-elliptic-curves-real.html#s3-1">&sect;3.1</a></li>
+                <li>WIF (wallet import format) &middot; <a href="09-keys-addresses.html#s9-9">&sect;9.9</a></li>
+                <li>witness &middot; <a href="10-transactions.html#s10-6">&sect;10.6</a></li>
+                <li>witness commitment &middot; <a href="12-merkle-trees.html#s12-6">&sect;12.6</a>, <a href="28-segwit-deep-dive.html#s28-5">&sect;28.5</a></li>
+                <li>witness discount &middot; <a href="28-segwit-deep-dive.html#s28-4">&sect;28.4</a></li>
+                <li>witness program &middot; <a href="10-transactions.html#s10-5-3">&sect;10.5.3</a>, <a href="11-script.html#s11-10">&sect;11.10</a>, <a href="28-segwit-deep-dive.html#s28-3">&sect;28.3</a></li>
+                <li>wtxid &middot; <a href="10-transactions.html#s10-6-2">&sect;10.6.2</a>, <a href="28-segwit-deep-dive.html#s28-2">&sect;28.2</a></li>
+            </ul>
+            <h2>X</h2>
+            <ul class="index-list">
+                <li>x-only public key &middot; <a href="08-schnorr.html#s8-4">&sect;8.4</a>, <a href="29-taproot-architecture.html#s29-1-1">&sect;29.1.1</a></li>
+            </ul>
+            <h2>Z</h2>
+            <ul class="index-list">
+                <li>zero-knowledge proof &middot; <a href="08-schnorr.html#s8-2">&sect;8.2</a></li>
+            </ul>
+        </section>
+
+        <nav class="chapter-nav">
+            <a href="appendix-b-references.html">&larr; Appendix B: References</a>
+            <a href="../index.html">Table of Contents</a>
+        </nav>
+    </main>
+
+    <footer>
+        <p><a href="../index.html">Elementary Bitcoin</a> &middot; A Mathematical Introduction</p>
+    </footer>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -602,6 +602,18 @@
                 <span class="ch-title"><a href="chapters/appendix-a-notation.html">Mathematical Notation</a></span>
             </div>
             <p class="toc-desc">Symbols and conventions by topic · The secp256k1 constants · Overloaded-symbol disambiguation · House conventions</p>
+
+            <div class="toc-chapter">
+                <span class="ch-num">B.</span>
+                <span class="ch-title"><a href="chapters/appendix-b-references.html">References</a></span>
+            </div>
+            <p class="toc-desc">Bibliography · Standards · Bitcoin Improvement Proposals · Lightning BOLTs · Security advisories</p>
+
+            <div class="toc-chapter">
+                <span class="ch-num">C.</span>
+                <span class="ch-title"><a href="chapters/appendix-c-index.html">Subject Index</a></span>
+            </div>
+            <p class="toc-desc">Alphabetical index of nearly 300 concepts, each linked to its defining section</p>
         </section>
 
     </main>


### PR DESCRIPTION
## Summary
Completes the book's scholarly apparatus: notation (Appendix A) is now joined by a references list and a subject index.

**Prerequisite**: all 435 numbered section headings across the 40 chapters now carry `id="sNN-M"` anchors (verified duplicate-free), enabling section-level deep links book-wide.

**Appendix B — References**, compiled from three citation sweeps (each verifying bibliographic details via web search):
- Primary sources: the whitepaper (Section 8 is quoted in full in Ch 17), Nakamoto's January 2009 mailing-list post (the Ch 40 epigraph), and The Times genesis headline
- 29 academic works with full records — including canonical citations for constructions the text presents without formal attribution (Fiat–Shamir, Schnorr 1991, MuSig/MuSig2, Sphinx, Golomb 1966, SipHash, Lamport 1979, GHOST, the Eyal–Sirer threshold behind Theorem 36.3, Poelstra's Schnorr trick behind Proposition 30.1, Lovejoy's BTG attack reports)
- Standards (SEC 2, RFC 6979, FIPS 180-4 and the 2024 post-quantum FIPS 203/204/205), a 39-row BIP table and 11-row BOLT table with official titles and citing chapters, and the four CVEs the book discusses

**Appendix C — Subject Index**: 292 terms, 414 links, merged from three per-volume term maps with collision disambiguation (signature nonce vs block nonce, group order vs curve order); every entry deep-links to the section where the concept is defined, with secondary treatments listed after. Every anchor is programmatically validated at generation time; the build script is reusable (.task/build_index.py).

**Wiring**: Appendices A → B → C → contents nav chain; both new appendices on the homepage with descriptions. All links and anchors verified resolving; tag balance clean; Appendix C visually render-checked.

Fixes #141