### PR TITLE
Add validation sections (13.10, 33.9) and Appendix D: Consensus Validation Rules

### DIFF
--- a/chapters/13-blocks.html
+++ b/chapters/13-blocks.html
@@ -736,6 +736,102 @@ target = 0x00ffff × 256^(29-3)
             </p>
         </section>
 
+        <section>
+            <h2 id="s13-10">13.10 The Validation Function</h2>
+
+            <p>
+                The validation rules of Section 13.5 are more than a checklist: collectively
+                they define a mathematical object that the rest of this book builds on. Every
+                statement about consensus&mdash;and, in Chapter 26, the entire theory of
+                forks&mdash;reduces to questions about a single predicate.
+            </p>
+
+            <div class="definition">
+                <p class="definition-title">Definition 13.18 (Validation Predicate)</p>
+                <p>
+                    The <strong>validation predicate</strong> is a function
+                </p>
+                <p class="math-block">
+                    V(C, B) &isin; {accept, reject}
+                </p>
+                <p>
+                    where <span class="math">B</span> is a candidate block and
+                    <span class="math">C</span> is the chain state it would extend: the header
+                    chain (which fixes the height, the expected difficulty, and the median time
+                    past), the UTXO set, and the set of rules active at that height. The
+                    <strong>set of valid blocks</strong> at state <span class="math">C</span> is
+                </p>
+                <p class="math-block">
+                    R(C) = { B : V(C, B) = accept }.
+                </p>
+                <p>
+                    <span class="math">V</span> must be a <em>pure, deterministic</em> function:
+                    identical inputs must produce identical verdicts on every node, regardless
+                    of hardware, operating system, or local configuration. Consensus is exactly
+                    the property that all participants compute the same <span class="math">V</span>.
+                </p>
+            </div>
+
+            <div class="definition">
+                <p class="definition-title">Definition 13.19 (The Validation Pipeline)</p>
+                <p>
+                    In practice <span class="math">V</span> decomposes into four phases, ordered
+                    so that cheap, context-free checks reject invalid blocks before expensive,
+                    state-dependent ones run:
+                </p>
+                <ol>
+                    <li><strong>Header validation:</strong> the proof of work meets the target
+                        encoded in <span class="math">bits</span>; that target equals the value
+                        prescribed by the difficulty adjustment; the timestamp exceeds the median
+                        time past and does not run more than two hours ahead of network-adjusted
+                        time; the version satisfies any height-gated minimum.</li>
+                    <li><strong>Transaction validation (context-free):</strong> each transaction
+                        has inputs and outputs, respects size and value bounds, and contains no
+                        duplicate inputs; checks that need no knowledge of the chain.</li>
+                    <li><strong>Block-structure validation:</strong> the Merkle root matches the
+                        transaction list, the first and only the first transaction is a coinbase,
+                        the block respects the weight and signature-operation limits, and the
+                        transaction list admits no duplicate-subtree mutation.</li>
+                    <li><strong>Contextual validation and connection:</strong> the
+                        state-dependent rules&mdash;transaction finality, the coinbase height
+                        commitment, the witness commitment, existence and maturity of every
+                        spent output, value conservation, sequence locks, and script execution
+                        under the flags active at this height.</li>
+                </ol>
+                <p>
+                    The complete rule catalog, phase by phase with activation heights, is
+                    collected in Appendix D.
+                </p>
+            </div>
+
+            <div class="remark">
+                <p class="remark-title">Remark 13.5 (Height-Gated Rules)</p>
+                <p>
+                    Each rule carries an activation condition: BIP-34's height commitment binds
+                    from height 227,931, SegWit's witness commitment from 481,824, Taproot's
+                    script rules from 709,632. The predicate <span class="math">V</span> is
+                    therefore a function of height as well as content, and the valid set
+                    <span class="math">R(C)</span> <em>shrinks</em> at every soft-fork
+                    activation&mdash;the formal content of Chapter 16's definition of a soft
+                    fork, and the foundation of the rule-set analysis in Chapter 26.
+                </p>
+            </div>
+
+            <div class="remark">
+                <p class="remark-title">Remark 13.6 (Determinism as a Consensus Requirement)</p>
+                <p>
+                    The purity requirement in Definition 13.18 is not a stylistic preference.
+                    Any input to <span class="math">V</span> beyond <span class="math">(C, B)</span>&mdash;a
+                    database resource limit, available memory, an environment-dependent code
+                    path&mdash;is a latent consensus failure: two honest nodes can disagree
+                    about <span class="math">R(C)</span> without either being modified. Exactly
+                    this happened in March 2013, when an implicit resource limit acted as an
+                    unwritten validation rule (Section 33.9 examines the episode as a
+                    specification failure).
+                </p>
+            </div>
+        </section>
+
         <section class="exercises">
             <h2>Exercises</h2>
 

--- a/chapters/26-fork-theory.html
+++ b/chapters/26-fork-theory.html
@@ -233,7 +233,9 @@
                 <p class="definition-title">Definition 26.5 (Rule Sets)</p>
                 <p>
                     Let <span class="math">R<sub>old</sub></span> and <span class="math">R<sub>new</sub></span> be sets of blocks considered valid
-                    under old and new rules respectively:
+                    under old and new rules respectively&mdash;formally, the accept-sets
+                    <span class="math">R(C)</span> of the corresponding validation predicates
+                    (Definition 13.18):
                 </p>
                 <ul>
                     <li><strong>Soft fork:</strong> <span class="math">R<sub>new</sub> ⊂ R<sub>old</sub></span> (new rules are stricter)</li>

--- a/chapters/33-governance.html
+++ b/chapters/33-governance.html
@@ -507,6 +507,94 @@
             </div>
         </section>
 
+        <section>
+            <h2 id="s33-9">33.9 The Specification Problem</h2>
+
+            <p>
+                Every governance question in this chapter presupposes that there is a
+                well-defined thing being governed: <em>the consensus rules</em>. But where,
+                exactly, do those rules live? Bitcoin has no normative specification. There
+                is no document whose text is authoritative the way a constitution or an IETF
+                standard is. What exists is software&mdash;above all Bitcoin Core&mdash;whose
+                behavior <em>is</em>, in practice, the definition of validity.
+            </p>
+
+            <div class="remark">
+                <p class="remark-title">Remark 33.10 (Code as Specification)</p>
+                <p>
+                    Section 13.10 defined validation as a pure predicate
+                    <span class="math">V(C, B)</span>. The specification problem is that no
+                    canonical statement of <span class="math">V</span> exists apart from
+                    implementations of it. The BIPs describe individual rule changes, but no
+                    BIP&mdash;and no combination of BIPs&mdash;describes the complete predicate;
+                    large parts of it (the original rules, accumulated bug-for-bug behaviors,
+                    serialization edge cases) are documented nowhere except in code. The
+                    practical consequence: "valid" means "accepted by the software the economy
+                    runs," and a bug in that software is not a bug at all&mdash;it is a rule.
+                </p>
+            </div>
+
+            <div class="example">
+                <p class="example-title">Example 33.6 (March 2013: A Specification Failure)</p>
+                <p>
+                    Chapters 26 and 36 treat the March 2013 fork as an accidental chain split.
+                    Reread it as a statement about specification. Bitcoin Core 0.7 stored the
+                    block index in Berkeley DB, which enforces a configurable limit on
+                    simultaneously locked database pages. A sufficiently large block exceeded
+                    that limit on 0.7 nodes, which therefore rejected it&mdash;while 0.8 nodes,
+                    using LevelDB, accepted it. The network split for 24 blocks.
+                </p>
+                <p>
+                    No one had written the rule "a block must not require more than
+                    <span class="math">N</span> Berkeley DB page locks," and no one would have
+                    endorsed it&mdash;yet it was, operationally, part of
+                    <span class="math">V</span>: an unwritten, environment-dependent validation
+                    rule violating the determinism requirement of Definition 13.18. The episode
+                    shows that the consensus rules are whatever the deployed software does,
+                    including the parts nobody knows about.
+                </p>
+            </div>
+
+            <div class="remark">
+                <p class="remark-title">Remark 33.11 (The Client Diversity Dilemma)</p>
+                <p>
+                    The specification problem shapes the debate over implementation diversity.
+                    With a single dominant implementation, its bugs are uniform&mdash;everyone
+                    accepts and rejects the same blocks, so latent rule-defects do not split
+                    the network, but the project inherits a monoculture's fragility and
+                    concentrates de facto rule-setting power (Section 33.5). With many
+                    independent implementations, no single codebase defines the rules&mdash;but
+                    any disagreement between them, however obscure, is a chain split waiting
+                    for an adversary to trigger it. Without an authoritative specification to
+                    converge on, diversity trades one systemic risk for another.
+                </p>
+            </div>
+
+            <div class="remark">
+                <p class="remark-title">Remark 33.12 (Toward Executable Specifications)</p>
+                <p>
+                    The emerging response is to make the specification <em>executable</em>:
+                    a statement of <span class="math">V</span> precise enough to run, so that
+                    "spec" and "implementation" cannot drift apart. Efforts span a spectrum.
+                    Bitcoin Core's <code>libbitcoinkernel</code> project extracts the consensus
+                    engine from the rest of the node, so that one well-reviewed artifact can
+                    serve many clients. Declarative approaches&mdash;such as the Hornet DSL
+                    (Sharp, 2025)&mdash;go further, restating the validation pipeline of
+                    Definition 13.19 as pure, deterministic, height-tagged rule functions with
+                    no side effects, verified against existing implementations by large-scale
+                    differential testing rather than formal proof. Whether any such artifact
+                    ever becomes <em>normative</em> is itself a governance question: a
+                    specification only specifies if the economy treats divergence from it as
+                    a bug rather than a rule change.
+                </p>
+            </div>
+
+            <p>
+                Appendix D collects the consensus rule catalog that any such specification
+                must capture.
+            </p>
+        </section>
+
         <section class="exercises">
             <h2>Exercises</h2>
 

--- a/chapters/appendix-b-references.html
+++ b/chapters/appendix-b-references.html
@@ -144,6 +144,11 @@
                 <p>Schnorr, C. P. (1991). "Efficient Signature Generation by Smart Cards."
                    <em>Journal of Cryptology</em> 4(3), 161&ndash;174.
                    <span class="cited">The signature scheme of Chapter 8.</span></p>
+                <p>Sharp, T. (2025). "Hornet Node and the Hornet DSL: A Minimal, Executable
+                   Specification for Bitcoin Consensus," v1.2.
+                   <a href="https://hornetnode.org/paper.html">hornetnode.org</a>.
+                   <span class="cited">Declarative executable specification of the validation
+                   pipeline; discussed in Section 33.9 and Appendix D.</span></p>
                 <p>Shor, P. W. (1994). "Algorithms for Quantum Computation: Discrete Logarithms and
                    Factoring." 35th IEEE Symposium on Foundations of Computer Science (FOCS), 124&ndash;134.
                    <span class="cited">Cited in Chapter 39.</span></p>

--- a/chapters/appendix-c-index.html
+++ b/chapters/appendix-c-index.html
@@ -108,6 +108,7 @@
                 <li>channel factory &middot; <a href="32-beyond-lightning.html#s32-4">&sect;32.4</a></li>
                 <li>checkpoint &middot; <a href="37-defense-mechanisms.html#s37-2">&sect;37.2</a></li>
                 <li>chord-and-tangent method &middot; <a href="03-elliptic-curves-real.html#s3-3">&sect;3.3</a></li>
+                <li>client diversity &middot; <a href="33-governance.html#s33-9">&sect;33.9</a></li>
                 <li>client-side validation &middot; <a href="22-client-side-validation.html#s22-1">&sect;22.1</a></li>
                 <li>CLTV delta &middot; <a href="24-lightning.html#s24-1">&sect;24.1</a></li>
                 <li>coexistence model (monetary) &middot; <a href="40-monetary-future.html#s40-9">&sect;40.9</a></li>
@@ -161,6 +162,7 @@
                 <li>emergency difficulty adjustment &middot; <a href="27-historical-forks.html#s27-3-1">&sect;27.3.1</a></li>
                 <li>energy consumption &middot; <a href="14-proof-of-work.html#s14-9">&sect;14.9</a>, <a href="25-debunking-myths.html#s25-5">&sect;25.5</a></li>
                 <li>Euler's totient function &middot; <a href="02-finite-fields.html#s2-6">&sect;2.6</a></li>
+                <li>executable specification &middot; <a href="33-governance.html#s33-9">&sect;33.9</a></li>
                 <li>extended Euclidean algorithm &middot; <a href="02-finite-fields.html#s2-4">&sect;2.4</a></li>
                 <li>extra nonce &middot; <a href="13-blocks.html#s13-2-6">&sect;13.2.6</a></li>
             </ul>
@@ -352,6 +354,7 @@
                 <li>SipHash &middot; <a href="19-compact-filters.html#s19-3">&sect;19.3</a></li>
                 <li>SLH-DSA (SPHINCS+) &middot; <a href="39-quantum-resistance.html#s39-6">&sect;39.6</a></li>
                 <li>soft fork &middot; <a href="16-soft-forks.html#s16-2">&sect;16.2</a>, <a href="26-fork-theory.html#s26-3">&sect;26.3</a>, <a href="28-segwit-deep-dive.html#s28-6">&sect;28.6</a></li>
+                <li>specification problem &middot; <a href="33-governance.html#s33-9">&sect;33.9</a>, <a href="13-blocks.html#s13-10">&sect;13.10</a></li>
                 <li>Speedy Trial &middot; <a href="16-soft-forks.html#s16-3-4">&sect;16.3.4</a>, <a href="33-governance.html#s33-4">&sect;33.4</a></li>
                 <li>Sphinx onion packet &middot; <a href="24-lightning.html#s24-2">&sect;24.2</a></li>
                 <li>SPV peg &middot; <a href="31-sidechains.html#s31-3">&sect;31.3</a></li>
@@ -385,6 +388,8 @@
             </ul>
             <h2>V</h2>
             <ul class="index-list">
+                <li>validation function (predicate) &middot; <a href="13-blocks.html#s13-10">&sect;13.10</a>, <a href="13-blocks.html#s13-5">&sect;13.5</a></li>
+                <li>validation pipeline &middot; <a href="13-blocks.html#s13-10">&sect;13.10</a></li>
                 <li>validity rollup &middot; <a href="31-sidechains.html#s31-4">&sect;31.4</a></li>
                 <li>vault &middot; <a href="30-covenants.html#s30-4">&sect;30.4</a>, <a href="30-covenants.html#s30-2-1">&sect;30.2.1</a></li>
                 <li>virtual size (vbyte) &middot; <a href="10-transactions.html#s10-8-1">&sect;10.8.1</a></li>
@@ -413,7 +418,7 @@
 
         <nav class="chapter-nav">
             <a href="appendix-b-references.html">&larr; Appendix B: References</a>
-            <a href="../index.html">Table of Contents</a>
+            <a href="appendix-d-validation-rules.html">Appendix D: Consensus Validation Rules &rarr;</a>
         </nav>
     </main>
 

--- a/chapters/appendix-d-validation-rules.html
+++ b/chapters/appendix-d-validation-rules.html
@@ -1,0 +1,142 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Appendix D: Consensus Validation Rules | Elementary Bitcoin</title>
+    <meta name="description" content="Appendix D: Consensus Validation Rules - The block validation pipeline as a rule catalog, phase by phase with activation heights">
+
+    <!-- Open Graph -->
+    <meta property="og:type" content="article">
+    <meta property="og:site_name" content="Elementary Bitcoin">
+    <meta property="og:title" content="Appendix D: Consensus Validation Rules | Elementary Bitcoin">
+    <meta property="og:description" content="The block validation pipeline as a rule catalog, phase by phase with activation heights">
+    <meta property="og:url" content="https://elementarybitcoin.org/chapters/appendix-d-validation-rules.html">
+    <meta property="og:image" content="https://elementarybitcoin.org/og-image.png">
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Appendix D: Consensus Validation Rules | Elementary Bitcoin">
+    <meta name="twitter:description" content="The block validation pipeline as a rule catalog, phase by phase with activation heights">
+    <meta name="twitter:image" content="https://elementarybitcoin.org/og-image.png">
+
+    <link rel="stylesheet" href="../style.css">
+</head>
+<body>
+    <header class="chapter-header">
+        <span class="chapter-number">Appendix D</span>
+        <h1 class="chapter-title">Consensus Validation Rules</h1>
+    </header>
+
+    <main>
+        <section>
+            <p>
+                This appendix catalogs the consensus rules that constitute the validation
+                predicate <span class="math">V(C, B)</span> of Definition 13.18, organized by
+                the four phases of Definition 13.19. Only <em>consensus</em> rules appear:
+                violating any rule below makes a block invalid for every node. Relay-policy
+                rules (standardness, minimum fee rates, the default OP_RETURN limit) are
+                deliberately excluded; the distinction is developed in Section 16.1.
+            </p>
+            <p>
+                Two cautions. First, heights and flags describe Bitcoin mainnet. Second, this
+                catalog is a faithful description, not a normative specification&mdash;per the
+                specification problem of Section 33.9, the rules are ultimately defined by the
+                behavior of deployed implementations (Bitcoin Core's
+                <code>src/validation.cpp</code> and <code>src/consensus/</code> are the
+                de facto reference; declarative restatements such as the Hornet DSL are cited
+                in Appendix B).
+            </p>
+        </section>
+
+        <section>
+            <h2>D.1 Phase 1 &mdash; Header Validation</h2>
+            <table>
+                <tr><th>Rule</th><th>Requirement</th><th>Active since</th></tr>
+                <tr><td>Connection</td><td>The previous-block hash refers to a known, valid header</td><td>Genesis</td></tr>
+                <tr><td>Proof of work</td><td>The block hash, as a 256-bit integer, does not exceed the target encoded in the bits field</td><td>Genesis</td></tr>
+                <tr><td>Difficulty</td><td>The bits field equals the value prescribed by the difficulty adjustment algorithm for this height (Section 14.4)</td><td>Genesis</td></tr>
+                <tr><td>Timestamp, lower bound</td><td>Strictly greater than the median of the previous 11 block timestamps (MTP)</td><td>Genesis</td></tr>
+                <tr><td>Timestamp, upper bound</td><td>At most 2 hours ahead of network-adjusted time</td><td>Genesis</td></tr>
+                <tr><td>Version minimum</td><td>Version &ge; 2 (BIP-34), &ge; 3 (BIP-66), &ge; 4 (BIP-65)</td><td>Heights 227,931 / 363,725 / 388,381</td></tr>
+            </table>
+        </section>
+
+        <section>
+            <h2>D.2 Phase 2 &mdash; Transaction Validation (Context-Free)</h2>
+            <p>Applied to every transaction in the block, with no reference to chain state.</p>
+            <table>
+                <tr><th>Rule</th><th>Requirement</th><th>Active since</th></tr>
+                <tr><td>Non-empty</td><td>At least one input and at least one output</td><td>Genesis</td></tr>
+                <tr><td>Size bound</td><td>Serialized size without witness data, times 4, does not exceed 4,000,000 weight units</td><td>Genesis (in weight form since SegWit)</td></tr>
+                <tr><td>Output range</td><td>Each output value in [0, 21,000,000 &times; 10&#8312;] satoshis; the running sum stays in range</td><td>Genesis</td></tr>
+                <tr><td>No duplicate inputs</td><td>No two inputs of the transaction reference the same outpoint</td><td>Genesis</td></tr>
+                <tr><td>Coinbase script size</td><td>For a coinbase: scriptSig length between 2 and 100 bytes</td><td>Genesis</td></tr>
+                <tr><td>No null prevouts</td><td>For a non-coinbase: no input references the null (coinbase-style) outpoint</td><td>Genesis</td></tr>
+            </table>
+        </section>
+
+        <section>
+            <h2>D.3 Phase 3 &mdash; Block-Structure Validation</h2>
+            <table>
+                <tr><th>Rule</th><th>Requirement</th><th>Active since</th></tr>
+                <tr><td>Merkle root</td><td>The header's Merkle root equals the root computed from the transaction list (Chapter 12)</td><td>Genesis</td></tr>
+                <tr><td>Mutation check</td><td>The transaction list does not exhibit the duplicate-subtree malleation of CVE-2012-2459</td><td>Detection since Bitcoin Core 0.6.2 (2012)</td></tr>
+                <tr><td>Coinbase position</td><td>The first transaction is a coinbase and no other transaction is</td><td>Genesis</td></tr>
+                <tr><td>Block weight</td><td>Total weight at most 4,000,000 WU (Definition 13.9)</td><td>Genesis (1 MB size form); weight form since SegWit, height 481,824</td></tr>
+                <tr><td>Signature operations</td><td>Total signature-operation cost at most 80,000</td><td>Genesis (limit restated in cost form at SegWit)</td></tr>
+                <tr><td>Per-transaction checks</td><td>Every transaction passes Phase 2</td><td>&mdash;</td></tr>
+            </table>
+        </section>
+
+        <section>
+            <h2>D.4 Phase 4 &mdash; Contextual Validation and Connection</h2>
+            <p>State-dependent rules, evaluated against the chain state <span class="math">C</span>.</p>
+            <table>
+                <tr><th>Rule</th><th>Requirement</th><th>Active since</th></tr>
+                <tr><td>Finality</td><td>Every transaction is final: locktime satisfied relative to block height or median time past</td><td>Genesis; MTP comparison since BIP-113, height 419,328</td></tr>
+                <tr><td>Coinbase height</td><td>The coinbase scriptSig begins with the block height (BIP-34)</td><td>Height 227,931</td></tr>
+                <tr><td>Witness commitment</td><td>If any transaction has witness data, the coinbase commits to the witness Merkle root (BIP-141; Section 12.6)</td><td>Height 481,824</td></tr>
+                <tr><td>No txid overwrite</td><td>No transaction's txid duplicates that of an earlier transaction with unspent outputs (BIP-30; made unreachable for new blocks by BIP-34)</td><td>March 2012</td></tr>
+                <tr><td>Inputs exist</td><td>Every input references an existing unspent output in the UTXO set</td><td>Genesis</td></tr>
+                <tr><td>Coinbase maturity</td><td>Spent coinbase outputs have at least 100 confirmations</td><td>Genesis</td></tr>
+                <tr><td>Value conservation</td><td>For each transaction, total input value &ge; total output value; the difference is the fee</td><td>Genesis</td></tr>
+                <tr><td>Subsidy bound</td><td>Coinbase output total at most subsidy(height) + total fees (Theorem 10.2, Definition 15.2)</td><td>Genesis</td></tr>
+                <tr><td>Sequence locks</td><td>Relative lock-times encoded in sequence numbers are satisfied (BIP-68)</td><td>Height 419,328</td></tr>
+                <tr><td>Script execution</td><td>Every input's script verifies under the flags active at this height (Chapter 11)</td><td>See D.5</td></tr>
+            </table>
+        </section>
+
+        <section>
+            <h2>D.5 Height-Gated Script Verification Flags</h2>
+            <p>
+                The script-execution rule of Phase 4 is itself height-parameterized: each soft
+                fork added verification flags that apply from its activation height.
+            </p>
+            <table>
+                <tr><th>Flag / rules</th><th>Soft fork</th><th>Mainnet activation height</th></tr>
+                <tr><td>P2SH evaluation</td><td>BIP-16</td><td>173,805</td></tr>
+                <tr><td>Strict DER signatures</td><td>BIP-66</td><td>363,725</td></tr>
+                <tr><td>OP_CHECKLOCKTIMEVERIFY</td><td>BIP-65</td><td>388,381</td></tr>
+                <tr><td>OP_CHECKSEQUENCEVERIFY</td><td>BIP-112 (with 68/113)</td><td>419,328</td></tr>
+                <tr><td>Witness program evaluation (v0)</td><td>BIP-141/143</td><td>481,824</td></tr>
+                <tr><td>Taproot and Tapscript (v1)</td><td>BIP-341/342</td><td>709,632</td></tr>
+            </table>
+            <p>
+                Together, D.1&ndash;D.5 are the concrete content of Remark 13.5: the valid set
+                <span class="math">R(C)</span> contracted at each of these heights, and every
+                contraction was a soft fork in the sense of Definition 26.5.
+            </p>
+        </section>
+
+        <nav class="chapter-nav">
+            <a href="appendix-c-index.html">&larr; Appendix C: Subject Index</a>
+            <a href="../index.html">Table of Contents</a>
+        </nav>
+    </main>
+
+    <footer>
+        <p><a href="../index.html">Elementary Bitcoin</a> &middot; A Mathematical Introduction</p>
+    </footer>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -614,6 +614,12 @@
                 <span class="ch-title"><a href="chapters/appendix-c-index.html">Subject Index</a></span>
             </div>
             <p class="toc-desc">Alphabetical index of nearly 300 concepts, each linked to its defining section</p>
+
+            <div class="toc-chapter">
+                <span class="ch-num">D.</span>
+                <span class="ch-title"><a href="chapters/appendix-d-validation-rules.html">Consensus Validation Rules</a></span>
+            </div>
+            <p class="toc-desc">The validation pipeline as a rule catalog · Phase-by-phase requirements · Activation heights · Height-gated script flags</p>
         </section>
 
     </main>


### PR DESCRIPTION
## Summary
Closes the validation gap identified by reading Sharp's Hornet paper against the book: Chapter 26 built its fork theory on valid-block sets R without ever defining the predicate that generates them, and Chapter 33 governed rules whose location was never examined.

**§13.10 The Validation Function** — Definition 13.18 introduces V(C, B) as a pure, deterministic predicate over chain state and candidate block, with R(C) as its accept-set ("consensus is exactly the property that all participants compute the same V"). Definition 13.19 gives the four-phase pipeline. Remark 13.5 makes height-gated activation formal (R contracts at every soft fork — the bridge to Ch 16 and Ch 26). Remark 13.6 elevates determinism to a consensus requirement. Chapter 26's Definition 26.5 now grounds R in this predicate.

**§33.9 The Specification Problem** — code-as-specification ("a bug in that software is not a bug at all — it is a rule"); Example 33.6 rereads March 2013 as a specification failure: the Berkeley DB lock limit was an unwritten, environment-dependent validation rule violating Definition 13.18's purity requirement. Remark 33.11 frames the client-diversity dilemma; Remark 33.12 surveys executable-specification efforts (libbitcoinkernel; the Hornet DSL), ending on the governance point that a specification only specifies if the economy treats divergence as a bug.

**Appendix D — Consensus Validation Rules**: the complete consensus rule catalog, phase by phase, each rule with its requirement and activation (BIP-34 at 227,931 through Taproot at 709,632), plus the height-gated script-flag table. Policy rules explicitly excluded; framed honestly as descriptive, per §33.9.

**Wiring**: Sharp (2025) added to Appendix B; the subject index regenerated with five new terms (297 terms, 421 verified links); A→B→C→D nav chain; Appendix D on the homepage. All links/anchors verified; numbering sequential.

Fixes #143