### PR TITLE
Add D.6 Standardness (Policy) Rules and define the dust threshold

### DIFF
--- a/chapters/16-soft-forks.html
+++ b/chapters/16-soft-forks.html
@@ -156,6 +156,23 @@
                     <li><strong>Future flexibility:</strong> Reserve space for future soft forks</li>
                 </ul>
             </div>
+
+            <div class="remark">
+                <p class="remark-title">Remark 16.2 (The Dust Threshold)</p>
+                <p>
+                    The policy rule most often encountered in practice is the <strong>dust
+                    threshold</strong>: an output is <em>dust</em> if its value is less than
+                    what it would cost in fees to spend it (Bitcoin Core's default deems an
+                    output dust when spending it would cost more than a third of its value at
+                    the minimum relay fee&mdash;about 546 satoshis for a P2PKH output and
+                    294 satoshis for P2WPKH). Transactions creating dust outputs are not
+                    relayed by default. Like all policy, this is a per-node default, not
+                    consensus: dust outputs are perfectly valid in a block, and the threshold
+                    exists to discourage bloating the UTXO set with entries that are
+                    uneconomical ever to spend. Appendix D.6 catalogs this and the other
+                    major standardness rules.
+                </p>
+            </div>
         </section>
 
         <section>
@@ -379,7 +396,7 @@
             <h3 id="s16-4-1">16.4.1 P2SH (BIP-16)</h3>
 
             <div class="remark">
-                <p class="remark-title">Remark 16.2 (P2SH Soft Fork)</p>
+                <p class="remark-title">Remark 16.3 (P2SH Soft Fork)</p>
                 <p>
                     Pay-to-Script-Hash (2012) made <code>OP_HASH160 &lt;hash&gt; OP_EQUAL</code>
                     outputs special. Old nodes see a simple hash check passing; new nodes
@@ -391,7 +408,7 @@
             <h3 id="s16-4-2">16.4.2 Segregated Witness (BIP-141)</h3>
 
             <div class="remark">
-                <p class="remark-title">Remark 16.3 (SegWit Soft Fork)</p>
+                <p class="remark-title">Remark 16.4 (SegWit Soft Fork)</p>
                 <p>
                     SegWit (2017) was the largest soft fork, adding:
                 </p>
@@ -410,7 +427,7 @@
             <h3 id="s16-4-3">16.4.3 Taproot (BIP-341)</h3>
 
             <div class="remark">
-                <p class="remark-title">Remark 16.4 (Taproot Soft Fork)</p>
+                <p class="remark-title">Remark 16.5 (Taproot Soft Fork)</p>
                 <p>
                     Taproot (2021) added:
                 </p>
@@ -514,7 +531,7 @@
             </div>
 
             <div class="remark">
-                <p class="remark-title">Remark 16.5 (Standardness Changes)</p>
+                <p class="remark-title">Remark 16.6 (Standardness Changes)</p>
                 <p>
                     Notable standardness changes that were <em>not</em> soft forks:
                 </p>
@@ -554,7 +571,7 @@
             <h3 id="s16-7-2">16.7.2 Coordination Challenges</h3>
 
             <div class="remark">
-                <p class="remark-title">Remark 16.6 (Upgrade Coordination)</p>
+                <p class="remark-title">Remark 16.7 (Upgrade Coordination)</p>
                 <p>
                     Soft fork deployment requires coordinating:
                 </p>
@@ -633,7 +650,7 @@
             </p>
 
             <div class="remark">
-                <p class="remark-title">Remark 16.7 (Consensus Beyond Code)</p>
+                <p class="remark-title">Remark 16.8 (Consensus Beyond Code)</p>
                 <p>
                     "Consensus" in Bitcoin has two meanings:
                 </p>

--- a/chapters/appendix-c-index.html
+++ b/chapters/appendix-c-index.html
@@ -149,6 +149,7 @@
                 <li>double SHA-256 (HASH256) &middot; <a href="06-hash-functions.html#s6-3">&sect;6.3</a></li>
                 <li>double-spend attack &middot; <a href="14-proof-of-work.html#s14-8-1">&sect;14.8.1</a>, <a href="17-spv-theory.html#s17-6">&sect;17.6</a>, <a href="36-security-threats.html#s36-1">&sect;36.1</a></li>
                 <li>drivechain &middot; <a href="34-drivechains.html#s34-1">&sect;34.1</a></li>
+                <li>dust threshold &middot; <a href="16-soft-forks.html#s16-1">&sect;16.1</a></li>
             </ul>
             <h2>E</h2>
             <ul class="index-list">

--- a/chapters/appendix-d-validation-rules.html
+++ b/chapters/appendix-d-validation-rules.html
@@ -129,6 +129,42 @@
             </p>
         </section>
 
+        <section>
+            <h2>D.6 Standardness (Policy) Rules</h2>
+            <p>
+                For contrast with D.1&ndash;D.5, this table lists the major <em>policy</em>
+                rules&mdash;Bitcoin Core's defaults for what it will relay and admit to its
+                mempool (Definition 16.2). Three caveats distinguish every row from the
+                consensus rules above: policy is <strong>per-node</strong> (each operator may
+                configure it), <strong>version-dependent</strong> (defaults change between
+                releases without any fork), and <strong>not a security boundary</strong>&mdash;a
+                transaction violating every rule below is still consensus-valid, and miners
+                can and do include such transactions when submitted to them directly.
+            </p>
+            <table>
+                <tr><th>Rule</th><th>Default requirement</th><th>Purpose</th></tr>
+                <tr><td>Standard output types</td><td>Outputs match known templates (P2PKH, P2SH, P2WPKH, P2WSH, P2TR, bare multisig up to 3 keys, OP_RETURN data)</td><td>Predictable validation; upgrade protection</td></tr>
+                <tr><td>Dust threshold</td><td>No output worth less than the cost of spending it (&asymp;546 sats P2PKH, &asymp;294 sats P2WPKH at default rates; Remark 16.2)</td><td>UTXO-set hygiene</td></tr>
+                <tr><td>Minimum relay fee</td><td>At least 1 sat/vB</td><td>DoS protection</td></tr>
+                <tr><td>Maximum standard weight</td><td>Transaction weight at most 400,000 WU (a tenth of a block)</td><td>Keep blocks composable; DoS protection</td></tr>
+                <tr><td>Minimum size</td><td>At least 65 non-witness bytes</td><td>Forbid 64-byte transactions (CVE-2017-12842; Section 35.3)</td></tr>
+                <tr><td>Data carrier</td><td>OP_RETURN payload within the configured limit (historically 80 bytes by default; Section 11.9)</td><td>Network hygiene</td></tr>
+                <tr><td>Low-S signatures</td><td>ECDSA s &le; n/2 (Section 7.8)</td><td>Malleability hygiene</td></tr>
+                <tr><td>Clean stack</td><td>Script execution leaves exactly one stack element</td><td>Malleability hygiene; upgrade protection</td></tr>
+                <tr><td>Discouraged upgrade hooks</td><td>No spends of undefined witness versions or use of OP_SUCCESS opcodes (Section 16.8)</td><td>Soft-fork protection</td></tr>
+                <tr><td>Replacement signaling</td><td>Conflicting-transaction replacement per BIP-125 rules (fee must increase)</td><td>Mempool coherence</td></tr>
+                <tr><td>Package limits</td><td>Bounded counts and sizes of unconfirmed ancestors and descendants</td><td>DoS protection</td></tr>
+            </table>
+            <p>
+                Because these are defaults rather than rules of the system, they drift: the
+                data-carrier limit, replacement signaling, and dust rates have all changed
+                across Bitcoin Core releases, and other implementations choose differently.
+                That drift is harmless precisely because policy violations cannot split the
+                chain&mdash;which is the entire content of the policy/consensus distinction
+                of Section 16.1.
+            </p>
+        </section>
+
         <nav class="chapter-nav">
             <a href="appendix-c-index.html">&larr; Appendix C: Subject Index</a>
             <a href="../index.html">Table of Contents</a>


### PR DESCRIPTION
## Summary
Completes the standardness story. The book defined policy conceptually (Definitions 16.1/16.2, Figure 16.1's standard ⊂ valid Venn, §16.6's policy-first deployment) but never cataloged the rules themselves — and the dust threshold, the standardness rule ordinary users actually hit, appeared nowhere in 40 chapters.

- **Appendix D.6** now lists the major Bitcoin Core default policy rules in a table mirroring the consensus catalog of D.1–D.5, prefaced by the three caveats that make every row categorically different from consensus: per-node (configurable), version-dependent (defaults drift across releases without forks), and not a security boundary (miners can include violating transactions). The closing paragraph makes the conceptual point: policy drift is harmless precisely because policy violations cannot split the chain — the entire content of the §16.1 distinction.
- **Remark 16.2 (The Dust Threshold)** in §16.1: definition, the ~546/294-satoshi defaults, the UTXO-hygiene rationale, and the not-consensus caveat. Subsequent remarks renumbered 16.3–16.8 (verified: no external references).
- Subject index regenerated with the dust entry (298 terms, 422 links); the generator now permanently emits the A→B→C→D nav chain.

Verified: tag balance, link/anchor resolution, sequential remark numbering.

Fixes #145