### PR TITLE
Apply external review feedback (Somsen)

### DIFF
--- a/chapters/17-spv-theory.html
+++ b/chapters/17-spv-theory.html
@@ -563,6 +563,9 @@
                 </ul>
                 <p>
                     Proposals like Utreexo (Chapter 21) may eventually enable fraud proofs.
+                    Even then, a deeper obstacle remains: alerts about <em>withheld data</em>
+                    are unattributable and free to fake, so an alert system invites denial of
+                    service (Section 20.6 develops this point).
                 </p>
             </div>
         </section>

--- a/chapters/20-light-clients.html
+++ b/chapters/20-light-clients.html
@@ -916,10 +916,28 @@ Response:
             </ul>
 
             <p>
-                This is the <em>data availability problem</em>. Solutions proposed in
-                other systems include data availability sampling, where light clients
-                request random fragments of the block and use erasure coding to detect
-                withholding. Bitcoin does not currently implement such a mechanism.
+                This is the <em>data availability problem</em>, and its sting is sharper
+                than the withholding scenario alone suggests. Suppose an honest node raises
+                the alarm: "the data for block <span class="math">B</span> is unavailable."
+                That claim is <em>unattributable</em>. Unavailability is not a property of
+                the block but of the network at a moment in time&mdash;the withholder can
+                release the data the instant anyone investigates, at which point the alarm
+                looks false and the alarmer looks dishonest. No proof of past unavailability
+                is possible, so no one can be punished: not the miner (the data is now
+                available) and not the alarmer (perhaps it really was unavailable when they
+                checked). The consequence is that unavailability alarms are a free,
+                unpunishable denial-of-service vector: an adversary can cry wolf endlessly,
+                forcing light clients either to download whole blocks (defeating the purpose)
+                or to learn to ignore alarms (defeating the alert system). This dilemma, not
+                the absence of a UTXO commitment, is the structural reason the whitepaper's
+                suggestion that full nodes could "alert" light clients (Section 17.7) has
+                never been made to work.
+            </p>
+            <p>
+                Solutions proposed in other systems include data availability sampling,
+                where light clients request random fragments of the block and use erasure
+                coding to detect withholding probabilistically (Al-Bassam, Sonnino &amp;
+                Buterin, 2018). Bitcoin does not currently implement such a mechanism.
             </p>
 
             <h3>Compact Clients: Header Distribution via Relay Networks</h3>

--- a/chapters/21-node-optimizations.html
+++ b/chapters/21-node-optimizations.html
@@ -117,7 +117,7 @@
                         </tr>
                         <tr>
                             <td>UTXO set</td>
-                            <td>~8 GB (in memory) / ~12 GB (on disk)</td>
+                            <td>~11&ndash;12 GB on disk (~175 million outputs, 2025)</td>
                         </tr>
                         <tr>
                             <td>Download bandwidth</td>
@@ -188,7 +188,7 @@
                         <rect x="0" y="0" width="110" height="80" fill="#ffe8e8" stroke="#c44" rx="5"/>
                         <text x="55" y="25" text-anchor="middle" font-size="10" font-weight="bold">Phase 4</text>
                         <text x="55" y="45" text-anchor="middle" font-size="9">UTXO Build</text>
-                        <text x="55" y="60" text-anchor="middle" font-size="9" fill="#666">~8 GB</text>
+                        <text x="55" y="60" text-anchor="middle" font-size="9" fill="#666">~12 GB</text>
                         <text x="55" y="73" text-anchor="middle" font-size="9" fill="#666">I/O-intensive</text>
                     </g>
 
@@ -402,7 +402,9 @@ bitcoind -assumevalid=00000000000000000001...</code></pre>
                 <p><strong>What it does:</strong> Start with a pre-computed UTXO set snapshot</p>
                 <p><strong>What it preserves:</strong> Background validation catches up to verify</p>
                 <p><strong>Trust assumption:</strong> Initial snapshot is correct (temporarily)</p>
-                <p><strong>Benefit:</strong> Fully functional node in ~minutes instead of hours/days</p>
+                <p><strong>Benefit:</strong> Reaches the chain tip after validating only snapshot&rarr;tip
+                   (the snapshot height is fixed in the release, so this is still weeks-to-months of
+                   blocks); history back to genesis verifies in the background</p>
             </div>
 
             <h3>Architecture</h3>
@@ -491,7 +493,7 @@ bitcoind -assumevalid=00000000000000000001...</code></pre>
                     AssumeUTXO synchronization:
                 </p>
                 <ol>
-                    <li><strong>Load snapshot:</strong> Import pre-computed UTXO set (~8 GB)</li>
+                    <li><strong>Load snapshot:</strong> Import pre-computed UTXO set (~10 GB serialized)</li>
                     <li><strong>Foreground sync:</strong> Download blocks from snapshot to tip (recent blocks)</li>
                     <li><strong>Become functional:</strong> Node can now validate new blocks, answer queries</li>
                     <li><strong>Background sync:</strong> Download and validate historical blocks (0 → snapshot)</li>
@@ -827,6 +829,27 @@ prune=550</code></pre>
             <p>
                 Utreexo is still experimental and not yet deployed on mainnet.
             </p>
+
+            <div class="remark">
+                <p><strong>Remark 21.1</strong> (SwiftSync)</p>
+                <p>
+                    A recent proposal attacks initial block download from a different angle.
+                    <em>SwiftSync</em> (Somsen, 2025) ships a compact hints file&mdash;one bit
+                    per output, marking whether it is still unspent at the snapshot
+                    height&mdash;so that validation during sync needs no UTXO-set lookups at
+                    all. Correctness is enforced by an aggregate check: each output marked
+                    spent is hashed into a running accumulator when created and subtracted
+                    when consumed; the accumulator returning to zero proves every such output
+                    was spent exactly once, with no inflation. Blocks can then be validated
+                    out of order and in parallel. Crucially, the hints are not trusted:
+                    incorrect hints make validation fail rather than succeed wrongly, so full
+                    validation is preserved. Early proof-of-concept benchmarks report roughly
+                    a 5&times; speedup before parallelization. The proposal is new and not
+                    yet deployed, but it illustrates the chapter's recurring theme: the
+                    bottleneck is not verification itself but the data structures it
+                    traverses.
+                </p>
+            </div>
         </section>
 
         <section>
@@ -886,7 +909,7 @@ prune=550</code></pre>
             <h3>Recommendations</h3>
 
             <div class="definition">
-                <p><strong>Remark 21.1</strong> (Node Configuration Recommendations)</p>
+                <p><strong>Remark 21.2</strong> (Node Configuration Recommendations)</p>
                 <table class="bitcoin-table">
                     <thead>
                         <tr>

--- a/chapters/22-client-side-validation.html
+++ b/chapters/22-client-side-validation.html
@@ -76,6 +76,25 @@
                 validation happens privately between transacting parties, with Bitcoin serving
                 only as a timestamping and anti-double-spend anchor.
             </p>
+
+            <div class="remark">
+                <p><strong>Remark 22.1</strong> (A Note on Scope)</p>
+                <p>
+                    Whether this chapter's subject belongs in a book about Bitcoin is itself
+                    contested. The protocols described here embed their consensus <em>in</em>
+                    Bitcoin rather than being part of it: Bitcoin neither validates nor is
+                    aware of their state, and arbitrarily many such protocols can anchor to
+                    any blockchain. On that view&mdash;held by serious protocol
+                    researchers&mdash;client-side validation is a separate field that merely
+                    uses Bitcoin, the way a document timestamped in the chain is not thereby
+                    part of the protocol. We include the chapter because the technique
+                    illuminates this volume's central question&mdash;what must be validated,
+                    by whom, at what cost&mdash;by exhibiting the extreme point of the
+                    spectrum: validation work pushed entirely to the parties who care about
+                    the state. Readers should weigh these designs as applications built on
+                    Bitcoin's guarantees, not extensions of them.
+                </p>
+            </div>
             <p>
                 This chapter explores the theoretical foundations of client-side validation,
                 from Peter Todd's single-use seals to modern implementations like RGB and

--- a/chapters/appendix-b-references.html
+++ b/chapters/appendix-b-references.html
@@ -62,6 +62,11 @@
         <section>
             <h2>B.2 Academic Works and Technical Reports</h2>
             <div class="ref-list">
+                <p>Al-Bassam, M., Sonnino, A., &amp; Buterin, V. (2018). "Fraud and Data
+                   Availability Proofs: Maximising Light Client Security and Scaling Blockchains
+                   with Dishonest Majorities." arXiv:1809.09044.
+                   <span class="cited">Data availability sampling; the unattributability of
+                   unavailability is discussed in Section 20.6.</span></p>
                 <p>Aumasson, J.-P., &amp; Bernstein, D. J. (2012). "SipHash: A Fast Short-Input PRF."
                    INDOCRYPT 2012, LNCS 7668. Springer.
                    <span class="cited">SipHash-2-4 is used by BIP-158 filters; discussed in Chapter 19.</span></p>
@@ -155,6 +160,9 @@
                 <p>Silverman, J. H. (2009). <em>The Arithmetic of Elliptic Curves</em>, 2nd ed.
                    Graduate Texts in Mathematics 106. Springer.
                    <span class="cited">Cited in Chapter 3 for the associativity proof (Ch. III, Prop. 2.2).</span></p>
+                <p>Somsen, R. (2025). "SwiftSync &mdash; Smarter Synchronization with Hints."
+                   Published as a public gist and discussed on the Bitcoin development forums.
+                   <span class="cited">Hints-based initial block download; Remark 21.1.</span></p>
                 <p>Sompolinsky, Y., &amp; Zohar, A. (2015). "Secure High-Rate Transaction Processing in
                    Bitcoin." Financial Cryptography and Data Security (FC 2015), LNCS 8975. Springer.
                    <span class="cited">The GHOST fork-choice rule mentioned in Chapter 26.</span></p>

--- a/chapters/appendix-c-index.html
+++ b/chapters/appendix-c-index.html
@@ -137,6 +137,7 @@
             </ul>
             <h2>D</h2>
             <ul class="index-list">
+                <li>data availability problem &middot; <a href="20-light-clients.html#s20-6">&sect;20.6</a></li>
                 <li>DER encoding &middot; <a href="07-ecdsa.html#s7-9">&sect;7.9</a></li>
                 <li>difficulty &middot; <a href="14-proof-of-work.html#s14-3">&sect;14.3</a></li>
                 <li>difficulty adjustment &middot; <a href="14-proof-of-work.html#s14-4">&sect;14.4</a>, <a href="15-consensus-parameters.html#s15-3">&sect;15.3</a></li>
@@ -365,6 +366,7 @@
                 <li>stale block &middot; <a href="13-blocks.html#s13-8">&sect;13.8</a>, <a href="26-fork-theory.html#s26-2">&sect;26.2</a></li>
                 <li>statechain &middot; <a href="32-beyond-lightning.html#s32-3">&sect;32.3</a></li>
                 <li>subgroup &middot; <a href="01-groups.html#s1-5">&sect;1.5</a>, <a href="04-elliptic-curves-finite.html#s4-4">&sect;4.4</a></li>
+                <li>SwiftSync &middot; <a href="21-node-optimizations.html#s21-5">&sect;21.5</a></li>
             </ul>
             <h2>T</h2>
             <ul class="index-list">

--- a/index.html
+++ b/index.html
@@ -269,6 +269,43 @@
             </p>
         </section>
 
+        <section class="preface">
+            <h2>How to Read This Book</h2>
+            <p>
+                The chapters are ordered so that everything is proved before it is used: that
+                is what "elementary" means here&mdash;self-contained, not simple. But the book
+                does not have to be read front to back, and most of the later volumes stand
+                on a small set of prerequisites. Four paths:
+            </p>
+            <p>
+                <strong>The full course.</strong> Chapters 1&ndash;40 in order. Volume I is
+                the investment; everything after it is payoff, with no claim left unproved.
+            </p>
+            <p>
+                <strong>Bitcoin first.</strong> Start at Chapter 9 (keys and addresses) and
+                read through Chapter 16, taking the cryptography of Volume I on faith&mdash;the
+                forward references will tell you exactly which proofs you deferred. Return to
+                Chapters 1&ndash;8 when you want to own them.
+            </p>
+            <p>
+                <strong>Verification and scaling.</strong> Chapters 12&ndash;13 (Merkle trees
+                and blocks), then Volume III (Chapters 17&ndash;25). This is the path for
+                evaluating SPV, light clients, and layer-2 claims&mdash;and the debates of
+                Chapter 25 are its destination.
+            </p>
+            <p>
+                <strong>The debates and the future.</strong> Chapters 25&ndash;27 (myths and
+                fork history), 33 (governance), and 38&ndash;40 (security budget, quantum,
+                monetary future) are largely self-contained prose and can be read first by
+                anyone who wants to know what the arguments are about before studying the
+                machinery beneath them.
+            </p>
+            <p>
+                Wherever you start, Appendix A (notation), Appendix C (subject index), and
+                Appendix D (the rule catalog) are designed for random access.
+            </p>
+        </section>
+
         <h2 style="text-align: center; font-variant: small-caps; letter-spacing: 0.15em; margin: 3rem 0 2rem;">Contents</h2>
 
         <!-- Volume I -->


### PR DESCRIPTION
## Summary
External review feedback from Ruben Somsen, each point verified before applying:

1. **Data unavailability — the missing heart of the fraud-proof discussion.** Ch 20 covered withholding but not why alert systems fail structurally: an unavailability claim is *unattributable* (data may be released between the alarm and anyone's check, so the alarmer cannot be distinguished from a liar, nor the miner blamed), which makes alarms a free, unpunishable DoS vector — light clients must download everything or learn to ignore alerts. Now stated in §20.6 with the Al-Bassam–Sonnino–Buterin (2018) citation, with a pointer from Remark 17.4.
2. **AssumeUTXO overstated.** "Fully functional node in ~minutes" replaced by the accurate two-phase picture: the snapshot height is fixed in the release, so snapshot→tip (weeks-to-months of blocks) is still fully validated in the foreground; genesis→snapshot verifies in the background. (Definition 21.4 already had this right; the optimization card contradicted it.)
3. **UTXO set size corrected** to ~11–12 GB on disk / ~175M outputs, per the April 2025 mempool.space UTXO Set Report (was "~8 GB in memory / ~12 GB on disk" with an ~8 GB snapshot).
4. **SwiftSync added** (Remark 21.1): the hints-file + aggregate-accumulator design, the untrusted-hints security model (wrong hints fail closed), ~5× proof-of-concept speedup, clearly marked as new and undeployed. Somsen (2025) joins Appendix B.
5. **Ch 22 scope framing** (Remark 22.1): client-side-validation protocols embed their consensus *in* Bitcoin rather than being part of it; the view that this makes them a separate field is stated fairly, and the chapter's inclusion is justified by Volume III's validation-spectrum theme.
6. **"How to Read This Book"** on the homepage: four honest reading paths (full course / Bitcoin-first / verification & scaling / debates & futures) so the math-first ordering reads as a menu rather than a wall — addressing the intimidation point without renumbering anything.

Subject index regenerated (301 terms, 425 links); tag balance verified on all touched files.

Fixes #149