### PR TITLE
SPV expansion: fabrication economics, July 2015 case study, bandwidth analysis

### DIFF
--- a/chapters/17-spv-theory.html
+++ b/chapters/17-spv-theory.html
@@ -399,6 +399,45 @@
                 </ul>
             </div>
 
+            <div class="example">
+                <p class="example-title">Example 17.1 (The Price of Six Fake Confirmations)</p>
+                <p>
+                    Suppose an attacker has eclipsed an SPV client and wants it to accept a
+                    fabricated payment with <span class="math">k = 6</span> confirmations. The
+                    six headers must satisfy real proof of work at the network's current
+                    difficulty (the client checks this&mdash;see the caveat below), so producing
+                    them costs, in expectation, the same work as honestly mining six blocks.
+                    The economic cost is therefore the forgone honest revenue:
+                </p>
+                <p class="math-block">
+                    cost &asymp; k &times; (subsidy + fees) &asymp; 6 &times; (3.125 + 0.05) &asymp; 19 BTC
+                </p>
+                <p>
+                    &mdash;on the order of millions of dollars at recent prices, spent on blocks
+                    the rest of the network will never accept. The defense is purely economic:
+                    six confirmations protect a payment <em>smaller</em> than this cost even
+                    against a fully eclipsed client, and fail to protect a larger one. This is
+                    why "wait for more confirmations" scales with payment size, and why an
+                    eclipsed SPV client is not unconditionally lost: deceiving it still costs
+                    real work.
+                </p>
+            </div>
+
+            <div class="remark">
+                <p class="remark-title">Remark 17.3 (The Difficulty Caveat)</p>
+                <p>
+                    Example 17.1's arithmetic silently assumes the client verifies that each
+                    header's difficulty target follows the adjustment rules (Phase 1 of the
+                    validation pipeline, Definition 13.19)&mdash;not merely that each header
+                    meets <em>its own stated</em> target. A client that skips this check can be
+                    fed a chain of trivial-difficulty headers fabricated for fractions of a
+                    cent. Verifying the retarget schedule forces the attacker to either pay
+                    full price per block or fork far enough back to "grind down" the
+                    difficulty across multiple retarget periods&mdash;a chain that minimum
+                    accumulated-work checks reject (Section 37.3).
+                </p>
+            </div>
+
             <h3 id="s17-5-2">17.5.2 Eclipse Attacks</h3>
 
             <div class="definition">
@@ -517,7 +556,7 @@
             </table>
 
             <div class="remark">
-                <p class="remark-title">Remark 17.3 (Same Security as Full Nodes)</p>
+                <p class="remark-title">Remark 17.4 (Same Security as Full Nodes)</p>
                 <p>
                     Importantly, these probabilities are <em>identical</em> for SPV clients and
                     full nodes. The confirmation security against double-spends depends only on
@@ -551,7 +590,7 @@
             </div>
 
             <div class="remark">
-                <p class="remark-title">Remark 17.4 (Fraud Proofs Don't Exist Yet)</p>
+                <p class="remark-title">Remark 17.5 (Fraud Proofs Don't Exist Yet)</p>
                 <p>
                     Despite years of research, general-purpose fraud proofs for Bitcoin do not
                     exist. The problem is that proving a transaction is invalid requires proving
@@ -634,7 +673,7 @@
             </p>
 
             <div class="remark">
-                <p class="remark-title">Remark 17.5 (SPV Use Cases)</p>
+                <p class="remark-title">Remark 17.6 (SPV Use Cases)</p>
                 <p>
                     <strong>SPV is appropriate when:</strong>
                 </p>
@@ -670,7 +709,7 @@
             </p>
 
             <div class="remark">
-                <p class="remark-title">Remark 17.6 (SPV in Practice)</p>
+                <p class="remark-title">Remark 17.7 (SPV in Practice)</p>
                 <p>
                     The original SPV concept assumed:
                 </p>
@@ -687,6 +726,37 @@
                     <li>Trusted servers (Electrum model)&mdash;not SPV at all (Chapter 20)</li>
                     <li>Compact block filters (BIP-157)&mdash;improved privacy (Chapter 19)</li>
                 </ul>
+            </div>
+
+            <div class="example">
+                <p class="example-title">Example 17.2 (July 2015: The Assumption Fails Without an Attacker)</p>
+                <p>
+                    The honest-majority assumption of Theorem 17.4 failed observably once, and
+                    no adversary was needed. When the BIP-66 soft fork activated in early July
+                    2015, a substantial fraction of the network's hashrate&mdash;by
+                    contemporaneous estimates, roughly half&mdash;was engaged in
+                    <em>SPV mining</em> (also called validationless mining): building on new
+                    block headers immediately upon receipt, before downloading and validating
+                    the blocks themselves, to avoid losing seconds of mining time.
+                </p>
+                <p>
+                    On 4 July 2015, a miner produced a block invalid under the just-activated
+                    rules. The SPV-mining pools, never having validated it, extended it&mdash;to
+                    a chain six blocks long before the error was noticed and abandoned. A
+                    second, shorter invalid chain formed the next day. During those windows,
+                    an SPV client could observe a transaction with up to six confirmations on
+                    a chain that every validating node had already rejected; bitcoin.org
+                    issued an alert advising SPV users to wait roughly thirty additional
+                    confirmations for large payments.
+                </p>
+                <p>
+                    The lesson sharpens the theorem's hypothesis: SPV security rests not on a
+                    majority of hashrate being <em>honest</em>, but on a majority being honest
+                    <em>and validating</em>. Hashrate that follows headers without checking
+                    blocks counts toward proof of work but not toward the enforcement of
+                    <span class="math">V</span> (Definition 13.18)&mdash;and in July 2015 the
+                    two quantities visibly came apart.
+                </p>
             </div>
         </section>
 
@@ -732,6 +802,18 @@
                 <p>
                     Design a protocol where SPV clients share headers with each other to
                     resist eclipse attacks. What are the limitations of your design?
+                </p>
+            </div>
+
+            <div class="exercise">
+                <p class="exercise-title">Exercise 17.6</p>
+                <p>
+                    An eclipsed SPV client requires <span class="math">k</span> confirmations
+                    before treating a payment as settled. With the block subsidy at
+                    3.125 BTC and average fees of 0.05 BTC per block, what is the largest
+                    payment for which <span class="math">k = 3</span> is economically safe
+                    against fabrication? How does your answer change if the client does not
+                    verify difficulty-adjustment rules in the headers it receives?
                 </p>
             </div>
         </section>

--- a/chapters/19-compact-filters.html
+++ b/chapters/19-compact-filters.html
@@ -919,6 +919,32 @@
                 </p>
             </div>
 
+            <div class="example">
+                <p><strong>Example 19.5</strong> (A Day in the Life of a Light Client)</p>
+                <p>
+                    Consider a wallet watching <span class="math">100</span> scripts,
+                    staying synced through one day (<span class="math">144</span> blocks):
+                </p>
+                <ul>
+                    <li>Block headers: <span class="math">144 &times; 80 B &asymp; 11.5 KB</span></li>
+                    <li>Filter headers: <span class="math">144 &times; 32 B &asymp; 4.6 KB</span></li>
+                    <li>Filters: <span class="math">144 &times; ~18 KB &asymp; 2.6 MB</span></li>
+                    <li>False-positive block downloads: expected
+                        <span class="math">144 &times; 100 / 784,931 &asymp; 0.02</span>
+                        blocks per day&mdash;essentially never</li>
+                    <li>Genuine matches: one block per own transaction, ~2 MB each</li>
+                </ul>
+                <p>
+                    Total: roughly <span class="math">3&ndash;5 MB</span> per day, dominated
+                    by the filters themselves&mdash;against ~245 MB per day for downloading
+                    full blocks, and a few tens of kilobytes for BIP-37, which purchased its
+                    frugality with the privacy catastrophe of Chapter 18. The factor-of-fifty
+                    saving over full blocks, at near-zero privacy cost, is the design's whole
+                    argument; the residual 2.6 MB of filters is the price of the server
+                    learning nothing.
+                </p>
+            </div>
+
             <h3>Bandwidth Comparison</h3>
 
             <table class="bitcoin-table">

--- a/chapters/appendix-c-index.html
+++ b/chapters/appendix-c-index.html
@@ -361,6 +361,7 @@
                 <li>specification problem &middot; <a href="33-governance.html#s33-9">&sect;33.9</a>, <a href="13-blocks.html#s13-10">&sect;13.10</a></li>
                 <li>Speedy Trial &middot; <a href="16-soft-forks.html#s16-3-4">&sect;16.3.4</a>, <a href="33-governance.html#s33-4">&sect;33.4</a></li>
                 <li>Sphinx onion packet &middot; <a href="24-lightning.html#s24-2">&sect;24.2</a></li>
+                <li>SPV mining (validationless) &middot; <a href="17-spv-theory.html#s17-10">&sect;17.10</a></li>
                 <li>SPV peg &middot; <a href="31-sidechains.html#s31-3">&sect;31.3</a></li>
                 <li>SPV (simplified payment verification) &middot; <a href="17-spv-theory.html#s17-2">&sect;17.2</a>, <a href="12-merkle-trees.html#s12-7">&sect;12.7</a></li>
                 <li>Stacks &middot; <a href="31-sidechains.html#s31-5">&sect;31.5</a></li>


### PR DESCRIPTION
## Summary
The SPV treatment was correct but thin — flagged during external review. Three additions deepen it without restructuring:

**The economics of deception (§17.5.1).** Theorem 17.5 said fabricating k confirmations "costs k blocks" and stopped. Example 17.1 turns that into the number that matters: ~k × (subsidy + fees) of forgone honest revenue — about 19 BTC for six confirmations, millions of dollars spent on blocks the network will never accept. The payoff insight: an eclipsed SPV client is not unconditionally lost; confirmations are an economic dial, safe exactly for payments smaller than the fabrication cost. Remark 17.3 adds the prerequisite everyone forgets — the client must verify the difficulty-adjustment schedule in headers (Phase 1 of Definition 13.19), or trivial-difficulty fabrication costs fractions of a cent — connecting to minimum chain work (§37.3). Exercise 17.6 makes the reader compute the bound (verified: 9.5 BTC at k=3).

**July 2015 (§17.10, Example 17.2).** The canonical case study, previously absent: the honest-majority assumption failed observably with *no attacker* — roughly half the hashrate was SPV-mining through BIP-66 activation, extended an invalid block to a six-block chain (a second, shorter one the next day), SPV clients saw up to six confirmations on a chain every validating node had rejected, and bitcoin.org advised waiting ~30 extra confirmations. The lesson is stated as a sharpening of Theorem 17.4's hypothesis: SPV rests on a majority that is honest *and validating* — hashrate that follows headers without checking blocks counts toward proof of work but not toward enforcing V.

**Light-client bandwidth (Ch 19, Example 19.5).** A quantified day of syncing: 11.5 KB headers + 4.6 KB filter headers + 2.6 MB filters, with expected false-positive block downloads of 0.02/day for 100 watched scripts — ~3–5 MB total against ~245 MB of full blocks, with the closing observation that the residual filter megabytes are the price of the server learning nothing.

Remarks renumbered 17.4–17.7 (no external references); all numbering sequential; subject index regenerated (303 terms).

Fixes #153