### PR TITLE
Declare the epistemic gradient; steelman the contested chapters

### DIFF
--- a/chapters/30-covenants.html
+++ b/chapters/30-covenants.html
@@ -284,12 +284,23 @@ during which the owner claws the funds back to cold storage.</pre>
                 <p>
                     CTV has been controversial despite its simplicity:
                 </p>
-                <ul>
-                    <li><strong>Proponents:</strong> Minimal, well-analyzed, enables useful patterns</li>
-                    <li><strong>Opponents:</strong> Too limited, may need replacement soon</li>
-                    <li><strong>Concerns:</strong> Could enable new MEV-like extraction</li>
-                    <li><strong>Process:</strong> Activation attempts have stalled multiple times</li>
-                </ul>
+                <p>
+                    Proponents&mdash;including BIP-119's author and, by 2025, a substantial
+                    list of developers urging activation alongside CSFS&mdash;argue that CTV
+                    is the most-reviewed covenant primitive ever proposed, that vaults address
+                    theft losses users suffer today, and that indefinite delay is itself a
+                    choice with costs. Opponents counter that no consensus change should
+                    activate without demonstrated demand from production systems, that the
+                    2022 activation attempt tried to short-circuit the consensus process of
+                    Chapter 33, and that committing to a limited primitive now may foreclose
+                    a better general design later. (Critics sometimes add that even limited
+                    covenants begin a path toward MEV-like extraction; proponents respond
+                    that CTV's fixed, non-recursive templates leave nothing to extract&mdash;the
+                    expressivity concern belongs to general introspection, Remark 30.3.)
+                    Beneath the specific proposals lies the meta-debate of Remark 33.4:
+                    whether the difficulty of activating any covenant is a failure of
+                    governance or its proper functioning.
+                </p>
             </div>
         </section>
 
@@ -363,6 +374,12 @@ OP_CHECKSIG</pre>
                     <li><strong>Recursive covenants:</strong> Potentially possible with CAT</li>
                     <li><strong>Script complexity:</strong> CAT-based covenants are complex</li>
                     <li><strong>Audit difficulty:</strong> Harder to reason about than CTV</li>
+                    <li><strong>MEV and expressivity:</strong> Critics argue that general
+                        introspection imports the miner-extractable-value dynamics of
+                        expressive chains and could be used to build transferable
+                        restrictions on coins; proponents respond that the same restrictions
+                        are already constructible off-chain and that opt-in scripts cannot
+                        encumber anyone else's coins</li>
                 </ul>
             </div>
         </section>
@@ -519,6 +536,7 @@ Stack: [1 if valid]</pre>
             </div>
 
             <h3 id="s30-5-4">30.5.4 Comparison Table</h3>
+            <p>Statuses as of mid-2026.</p>
 
             <table class="data-table">
                 <thead>

--- a/chapters/33-governance.html
+++ b/chapters/33-governance.html
@@ -302,8 +302,8 @@
                     A growing tension in Bitcoin governance:
                 </p>
                 <ul>
-                    <li><strong>Pro-change:</strong> Bitcoin needs features (covenants, etc.) to remain competitive</li>
-                    <li><strong>Pro-stability:</strong> Changes risk breaking what works; ossification protects value</li>
+                    <li><strong>Pro-change</strong> (common among application and Layer 2 developers): Bitcoin needs features (covenants, etc.) to remain competitive</li>
+                    <li><strong>Pro-stability</strong> (common among long-term holders and some senior contributors): Changes risk breaking what works; ossification protects value</li>
                     <li><strong>Middle ground:</strong> Only changes with overwhelming consensus</li>
                 </ul>
                 <p>
@@ -379,12 +379,31 @@
                     <li>Descended from Satoshi's original code</li>
                     <li>Most widely run full node software</li>
                     <li>Open source, permissively licensed</li>
-                    <li>Maintained by ~30 active contributors</li>
+                    <li>Maintained by ~30 active contributors (as of 2025)</li>
                 </ul>
             </div>
 
             <div class="remark">
-                <p class="remark-title">Remark 33.6 (Core is Not Bitcoin)</p>
+                <p class="remark-title">Remark 33.6 (The Developer-Power Critique)</p>
+                <p>
+                    Critics&mdash;from legal scholars such as Angela Walch to veterans of the
+                    block size war&mdash;argue that the formal power map of Remark 33.1
+                    understates developer influence. Maintainers control commit access to the
+                    software the economy runs by default, and defaults are sticky: "users can
+                    reject a release" is true in principle but rarely exercised. Agenda
+                    setting&mdash;which proposals receive review at all&mdash;is itself a form
+                    of power, and contributor funding is concentrated among a handful of
+                    sponsors. On this view, Section 33.9's code-as-specification argument
+                    cuts against the customary reassurance rather than for it: if the rules
+                    are the code, those who write the code write the rules. Walch presses
+                    the point furthest, arguing that core developers function as de facto
+                    fiduciaries&mdash;exercising trusted power without accountability. The
+                    rebuttals follow.
+                </p>
+            </div>
+
+            <div class="remark">
+                <p class="remark-title">Remark 33.7 (Core is Not Bitcoin)</p>
                 <p>
                     Bitcoin Core has significant influence but not control:
                 </p>
@@ -397,7 +416,7 @@
             </div>
 
             <div class="remark">
-                <p class="remark-title">Remark 33.7 (Core Development Process)</p>
+                <p class="remark-title">Remark 33.8 (Core Development Process)</p>
                 <p>
                     Bitcoin Core changes require:
                 </p>
@@ -445,7 +464,7 @@
             </div>
 
             <div class="remark">
-                <p class="remark-title">Remark 33.8 (Schelling Point Preservation)</p>
+                <p class="remark-title">Remark 33.9 (Schelling Point Preservation)</p>
                 <p>
                     Bitcoin's value partially derives from being a Schelling point:
                 </p>
@@ -474,7 +493,7 @@
                     <li><strong>Issue:</strong> How to scale Bitcoin (blocks vs layers)</li>
                     <li><strong>Camps:</strong> Big blockers vs small blockers</li>
                     <li><strong>Resolution:</strong> SegWit activated; BCH forked away</li>
-                    <li><strong>Lesson:</strong> Users, not just miners, determine consensus</li>
+                    <li><strong>Lesson widely drawn:</strong> Users, not just miners, determine consensus&mdash;though some observers attribute the outcome more narrowly to exchanges and large economic nodes, and note that the UASF ultimatum was never carried to a contested split</li>
                 </ul>
             </div>
 
@@ -513,7 +532,7 @@
             <h2 id="s33-8">33.8 Future Governance Challenges</h2>
 
             <div class="remark">
-                <p class="remark-title">Remark 33.9 (Open Questions)</p>
+                <p class="remark-title">Remark 33.10 (Open Questions)</p>
                 <p>
                     Bitcoin governance faces unresolved challenges:
                 </p>
@@ -527,7 +546,7 @@
             </div>
 
             <div class="remark">
-                <p class="remark-title">Remark 33.10 (Governance Evolution)</p>
+                <p class="remark-title">Remark 33.11 (Governance Evolution)</p>
                 <p>
                     Bitcoin's governance has evolved:
                 </p>
@@ -553,7 +572,7 @@
             </p>
 
             <div class="remark">
-                <p class="remark-title">Remark 33.11 (Code as Specification)</p>
+                <p class="remark-title">Remark 33.12 (Code as Specification)</p>
                 <p>
                     Section 13.10 defined validation as a pure predicate
                     <span class="math">V(C, B)</span>. The specification problem is that no
@@ -589,7 +608,7 @@
             </div>
 
             <div class="remark">
-                <p class="remark-title">Remark 33.12 (The Client Diversity Dilemma)</p>
+                <p class="remark-title">Remark 33.13 (The Client Diversity Dilemma)</p>
                 <p>
                     The specification problem shapes the debate over implementation diversity.
                     With a single dominant implementation, its bugs are uniform&mdash;everyone
@@ -604,7 +623,7 @@
             </div>
 
             <div class="remark">
-                <p class="remark-title">Remark 33.13 (Toward Executable Specifications)</p>
+                <p class="remark-title">Remark 33.14 (Toward Executable Specifications)</p>
                 <p>
                     The emerging response is to make the specification <em>executable</em>:
                     a statement of <span class="math">V</span> precise enough to run, so that

--- a/chapters/34-drivechains.html
+++ b/chapters/34-drivechains.html
@@ -266,7 +266,10 @@ OP_RETURN &lt;BMM_TAG&gt; &lt;sidechain_id&gt; &lt;block_hash&gt;
                     Bitcoin-level criterion for distinguishing legitimate bundles from
                     illegitimate ones. Users of a drivechain therefore trust <em>two</em>
                     parties the base layer never asks them to trust: a miner majority and
-                    a software maintainer.
+                    a software maintainer. (Proponents respond that the latter is the
+                    ordinary trust any user places in opt-in software&mdash;a wallet, a
+                    Lightning node; the asymmetry critics point to is that here the
+                    maintainer sits behind a peg holding other people's deposits.)
                 </p>
             </div>
 
@@ -450,7 +453,16 @@ OP_RETURN &lt;BMM_TAG&gt; &lt;sidechain_id&gt; &lt;block_hash&gt;
                     asks users to trust a miner majority with custody (Definition 34.6) and
                     a software maintainer with the rules (Remark 34.3), and many reviewers
                     judged "miners can vote to take the deposits, slowly and in public" to
-                    be a description of the design rather than an attack on it.
+                    be a description of the design rather than an attack on it. The
+                    proposal's author, Paul Sztorc, replied that this reading inverts the
+                    design: the multi-month, fully public withdrawal process exists
+                    precisely so that an attempted theft can be seen and punished&mdash;up
+                    to a user-activated soft fork rejecting the fraudulent bundle&mdash;and
+                    that miners already hold reorg and censorship power over the base
+                    layer, so hashrate escrow adds no party users do not already trust.
+                    The objection that stuck is that this defense relies on exactly the
+                    kind of extraordinary social coordination Bitcoin's design otherwise
+                    avoids needing.
                 </p>
             </div>
 

--- a/chapters/38-security-budget.html
+++ b/chapters/38-security-budget.html
@@ -32,7 +32,8 @@
             <p class="chapter-intro">
                 Bitcoin's security model faces a fundamental challenge: the block subsidy
                 that currently funds most mining operations is designed to eventually reach
-                zero. This creates what critics call the "security budget problem"&mdash;will
+                zero. This creates what critics&mdash;most formally Eric Budish (2018) and
+                Rapha&euml;l Auer (2019)&mdash;call the "security budget problem"&mdash;will
                 transaction fees alone provide sufficient incentive for miners to secure the
                 network? This chapter examines the mathematics, economics, and game theory
                 of Bitcoin's long-term security budget, analyzing whether the network can
@@ -512,7 +513,7 @@ if (GetRandInt(10) == 0)
         <section>
             <h2 id="s38-7">38.7 Proposed Solutions</h2>
 
-            <h3 id="s38-7-1">38.7.1 Do Nothing (Market Will Provide)</h3>
+            <h3 id="s38-7-1">38.7.1 Rely on the Fee Market</h3>
 
             <p>The dominant view among Bitcoin maximalists:</p>
 
@@ -524,12 +525,22 @@ if (GetRandInt(10) == 0)
             </ul>
 
             <div class="remark">
-                <p class="remark-title">Remark 38.9 (The "It Will Work Out" Argument)</p>
+                <p class="remark-title">Remark 38.9 (The Market-Sufficiency Argument)</p>
                 <p>
                     On this view, Bitcoin has survived every challenge so far. The fee market, while
                     imperfect, has functioned for more than fifteen years. As Bitcoin
                     becomes more valuable, rational users will pay appropriate fees for the
                     security they require.
+                </p>
+                <p>
+                    A stronger version of the position disputes the premise of the models in
+                    Section 38.5 outright: what attack cost must exceed is the value an
+                    attacker can actually capture&mdash;the double-spendable <em>flow</em> of
+                    transactions&mdash;not Bitcoin's market capitalization, a <em>stock</em>.
+                    Combined with the hardware realities of Remark 38.13 (SHA-256 hashrate
+                    cannot be rented at scale, and an attacker's ASICs lose their value if
+                    the attack succeeds), the budget required for deterrence may be far
+                    smaller than any fixed percentage of market cap implies.
                 </p>
             </div>
 
@@ -558,7 +569,9 @@ if (GetRandInt(10) == 0)
                 <p class="remark-title">Remark 38.10 (The Tail Emission Debate)</p>
                 <p>
                     Monero implements tail emission (0.6 XMR per block forever). Some
-                    researchers argue that Bitcoin needs something similar. This would fundamentally change
+                    researchers&mdash;most prominently Peter Todd (2022), who argues that a
+                    fixed linear emission is asymptotically non-inflationary because coin
+                    loss offsets it&mdash;contend that Bitcoin needs something similar. This would fundamentally change
                     Bitcoin's monetary properties and is considered a non-starter by most of
                     the community.
                 </p>

--- a/chapters/40-monetary-future.html
+++ b/chapters/40-monetary-future.html
@@ -71,14 +71,17 @@
             <div class="example">
                 <p class="example-title">Example 40.1 (Monetary Problems and Bitcoin's Responses)</p>
                 <p>
-                    Bitcoin is designed to address fundamental issues with existing monetary systems:
+                    Bitcoin is designed to address what its designers and proponents identify as
+                    fundamental defects of existing monetary systems&mdash;defenders of managed
+                    money regard several of the same properties, elastic supply above all, as
+                    features rather than defects (a dispute taken up in Remark 40.6):
                 </p>
                 <table class="data-table">
                     <thead>
                         <tr>
                             <th>Problem</th>
                             <th>Fiat Status Quo</th>
-                            <th>Bitcoin Solution</th>
+                            <th>Bitcoin's Design Response</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -181,6 +184,11 @@
                         </tr>
                     </tbody>
                 </table>
+                <p>
+                    The model presupposes that diffusion runs to saturation; the skeptical
+                    position of Section 40.4 is precisely that it need not&mdash;the later
+                    stages are conjectures, not extrapolations.
+                </p>
             </div>
 
             <div class="remark">
@@ -231,7 +239,7 @@
                     <li>If neighbors might adopt &rarr; consider adopting</li>
                     <li>If Bitcoin might succeed &rarr; early adoption is advantageous</li>
                     <li>Waiting has opportunity cost</li>
-                    <li>A small allocation is a cheap hedge against the adoption equilibrium</li>
+                    <li>On this analysis, a small allocation functions as a cheap hedge against the adoption equilibrium</li>
                 </ul>
             </div>
 
@@ -305,7 +313,7 @@
             <div class="definition">
                 <p class="definition-title">Definition 40.4 (Scenario: Digital Gold)</p>
                 <p>
-                    In the <strong>digital gold scenario</strong> (high probability), Bitcoin
+                    In the <strong>digital gold scenario</strong> (most proponents' modal outcome), Bitcoin
                     becomes a widely held store of value alongside gold:
                 </p>
                 <ul>
@@ -341,7 +349,7 @@
             <div class="definition">
                 <p class="definition-title">Definition 40.5 (Scenario: Global Reserve Asset)</p>
                 <p>
-                    In the <strong>global reserve asset scenario</strong> (medium probability),
+                    In the <strong>global reserve asset scenario</strong>,
                     Bitcoin joins or replaces gold in central bank reserves:
                 </p>
                 <ul>
@@ -374,7 +382,7 @@
             <div class="definition">
                 <p class="definition-title">Definition 40.6 (Scenario: Global Base Money)</p>
                 <p>
-                    In the <strong>global base money scenario</strong> (low-medium probability),
+                    In the <strong>global base money scenario</strong>,
                     Bitcoin becomes the primary global unit of account:
                 </p>
                 <ul>
@@ -394,7 +402,7 @@
             <div class="definition">
                 <p class="definition-title">Definition 40.7 (Scenario: Niche or Failure)</p>
                 <p>
-                    In the <strong>failure scenario</strong> (low probability), Bitcoin remains
+                    In the <strong>failure scenario</strong>, Bitcoin remains
                     marginal or declines. Possible causes:
                 </p>
                 <ul>
@@ -412,12 +420,18 @@
             </div>
 
             <div class="remark">
-                <p class="remark-title">Remark 40.4 (Probability Assessment)</p>
+                <p class="remark-title">Remark 40.4 (Assessing the Failure Scenario)</p>
                 <p>
-                    Several considerations argue against the failure scenario: 15+ years of
-                    resilience, network effects that provide stability, the absence of any
-                    superior alternative, and the unlikelihood of coordinated global ban
-                    enforcement. Estimated probability: below 10%.
+                    Proponents argue the failure scenario is remote&mdash;more than fifteen
+                    years of resilience, entrenched network effects, no apparent path to an
+                    enforceable coordinated ban&mdash;and typically assess its probability
+                    below ten percent. Skeptics, including many academic economists, reply
+                    that no catastrophe is required: an asset with no cash flow has no
+                    valuation floor, volatility has not declined enough for unit-of-account
+                    use, and medium-of-exchange adoption has, if anything, retreated
+                    (Section 40.2). On the skeptical view Bitcoin need not break to fail;
+                    it need only stagnate. The book takes no position between these
+                    forecasts.
                 </p>
             </div>
         </section>

--- a/chapters/appendix-b-references.html
+++ b/chapters/appendix-b-references.html
@@ -67,6 +67,10 @@
                    with Dishonest Majorities." arXiv:1809.09044.
                    <span class="cited">Data availability sampling; the unattributability of
                    unavailability is discussed in Section 20.6.</span></p>
+                <p>Auer, R. (2019). "Beyond the Doomsday Economics of 'Proof-of-Work' in
+                   Cryptocurrencies." BIS Working Papers No. 765. Bank for International
+                   Settlements.
+                   <span class="cited">The security-budget problem; Chapter 38.</span></p>
                 <p>Aumasson, J.-P., &amp; Bernstein, D. J. (2012). "SipHash: A Fast Short-Input PRF."
                    INDOCRYPT 2012, LNCS 7668. Springer.
                    <span class="cited">SipHash-2-4 is used by BIP-158 filters; discussed in Chapter 19.</span></p>
@@ -81,6 +85,9 @@
                    Smid, M., &amp; Tang, Y. (2008). "On the false-positive rate of Bloom filters."
                    <em>Information Processing Letters</em> 108(4), 210&ndash;213.
                    <span class="cited">Cited in Chapter 18.</span></p>
+                <p>Budish, E. (2018). "The Economic Limits of Bitcoin and the Blockchain."
+                   NBER Working Paper 24717.
+                   <span class="cited">The security-budget problem; Chapter 38.</span></p>
                 <p>Danezis, G., &amp; Goldberg, I. (2009). "Sphinx: A Compact and Provably Secure Mix
                    Format." IEEE Symposium on Security and Privacy.
                    <span class="cited">Lightning's onion routing is Sphinx-style; discussed in Chapter 24.</span></p>
@@ -169,6 +176,13 @@
                 <p>Todd, P. (2016). "Building Blocks of the State Machine Approach to Consensus."
                    petertodd.org.
                    <span class="cited">Origin of single-use seals; cited in Chapter 22.</span></p>
+                <p>Todd, P. (2022). "Surprisingly, Tail Emission Is Not Inflationary."
+                   petertodd.org.
+                   <span class="cited">The tail-emission argument; Remark 38.10.</span></p>
+                <p>Walch, A. (2019). "In Code(rs) We Trust: Software Developers as Fiduciaries
+                   in Public Blockchains." In <em>Regulating Blockchain</em>, Oxford University
+                   Press.
+                   <span class="cited">The developer-power critique; Remark 33.6.</span></p>
             </div>
         </section>
 

--- a/index.html
+++ b/index.html
@@ -58,18 +58,6 @@
             line-height: 1.8;
             color: #555;
         }
-        .draft-notice {
-            background: #fff3cd;
-            border: 2px solid #8b4513;
-            padding: 1rem;
-            margin: 1rem auto;
-            max-width: 600px;
-            text-align: center;
-            border-radius: 8px;
-        }
-        .draft-notice strong {
-            color: #c87f0a;
-        }
         .epigraph {
             max-width: 450px;
             margin: 3rem auto;
@@ -209,9 +197,6 @@
             cryptographic protocols, protocol architecture, scaling technologies,
             forks, security, and monetary futures upon which Bitcoin is founded.
         </p>
-        <div class="draft-notice">
-            <strong>DRAFT:</strong> Volumes IV & V are included below as drafts undergoing revision.
-        </div>
     </div>
 
     <div class="epigraph">
@@ -228,27 +213,29 @@
                 <li class="current-volume">
                     <span class="vol-num">Volume I:</span>
                     <span class="vol-title">Mathematical Foundations</span>
-                    <span class="vol-status">— complete</span>
+                    <span class="vol-status">— complete · proved</span>
                 </li>
                 <li>
                     <span class="vol-num">Volume II:</span>
                     <span class="vol-title">Protocol Architecture</span>
-                    <span class="vol-status">— complete</span>
+                    <span class="vol-status">— complete · verifiable protocol fact</span>
                 </li>
                 <li>
                     <span class="vol-num">Volume III:</span>
                     <span class="vol-title">Scaling and Verification</span>
-                    <span class="vol-status">— complete</span>
+                    <span class="vol-status">— complete · verifiable protocol fact</span>
                 </li>
                 <li>
                     <span class="vol-num">Volume IV:</span>
                     <span class="vol-title">Forks and Futures</span>
                     <span class="vol-draft">DRAFT</span>
+                    <span class="vol-status">— the contested present, positions attributed</span>
                 </li>
                 <li>
                     <span class="vol-num">Volume V:</span>
                     <span class="vol-title">The Path to a Sustainable Future</span>
                     <span class="vol-draft">DRAFT</span>
+                    <span class="vol-status">— disciplined speculation, labeled as such</span>
                 </li>
             </ul>
         </section>
@@ -303,6 +290,30 @@
             <p>
                 Wherever you start, Appendix A (notation), Appendix C (subject index), and
                 Appendix D (the rule catalog) are designed for random access.
+            </p>
+        </section>
+
+        <section class="preface">
+            <h2>A Note on Epistemic Status</h2>
+            <p>
+                Not everything in this book is true in the same way, and the reader deserves
+                to know which kind of truth each part offers. <strong>Volume I</strong> is
+                mathematics: its theorems are proved and will be true in a century.
+                <strong>Volumes II and III</strong> are verifiable protocol fact&mdash;every
+                claim can be checked against running code and the cited specifications, and
+                changes only when the protocol does. <strong>Volume IV</strong> surveys the
+                contested present: fork histories whose narratives are still argued,
+                proposals whose statuses drift, governance questions that are contested by
+                construction. There the book reports positions, attributes them to their
+                holders, and dates every perishable claim. <strong>Volume V</strong> is
+                disciplined speculation&mdash;economic models with stated assumptions and
+                scenarios labeled as scenarios, kept in remarks and never dressed as
+                theorems.
+            </p>
+            <p>
+                The gradient is the design. The first three volumes give you the tools; the
+                last two show you the open questions those tools illuminate&mdash;and by the
+                time you reach them, you will not need this book to tell you what to think.
             </p>
         </section>
 


### PR DESCRIPTION
## Summary
The book runs proved → verifiable → contested → speculative across its five volumes; this PR makes the gradient explicit and brings the contested chapters up to steelman standard.

**Front matter** — "A Note on Epistemic Status" beside the reading guide, ending on the design thesis: *the first three volumes give you the tools; the last two show you the open questions those tools illuminate — and by then you will not need this book to tell you what to think.* Volume-overview entries gain epistemic tags; the shouty title-page DRAFT alert box is gone (the badges carry it).

**Steelman audit** (one agent pass over Ch 30/33/34/38/40, findings verified and applied):
- The two genuine imbalances were **Ch 33** — the developer-power critique (Walch's fiduciary argument, the big-block reading) existed only as the unstated target of "Core is Not Bitcoin"'s rebuttals, despite the chapter's own §33.9 supplying its strongest premise — and **Ch 40** — the book assigned scenario probabilities in its own voice and argued only one side of the failure scenario. Both fixed: the critique gets its own attributed remark before the rebuttals; the probabilities are attributed or removed, and Remark 40.4 now carries the academic-skeptic steelman (no catastrophe needed — assets without cash flow can simply stagnate) and closes "the book takes no position."
- Ch 30: both sides of the CTV debate argued at strength; the MEV concern moved to where discourse actually levels it (general introspection), with the opt-in rebuttal.
- Ch 34: within the cautionary frame, Sztorc's strongest reply now appears (the slow public withdrawal *is* the defense; miners already hold reorg power) followed by the counter that stuck.
- Ch 38: the strongest optimist argument added (deterrence scales with capturable flow, not market-cap stock); scare-quoted section titles neutralized; both poles attributed (Budish, Auer; Todd on tail emission).
- Appendix B: four new records (Auer 2019, Budish 2018, Todd 2022, Walch 2019).

Ch 33 remarks renumbered 33.6–33.14 (verified reference-clean); all tag balance and sequences check out.

Fixes #155