### PR TITLE
Figure pass batch 1: 13 diagrams for Ch 25, 34, 38, 39, 40

### DIFF
--- a/chapters/25-debunking-myths.html
+++ b/chapters/25-debunking-myths.html
@@ -129,6 +129,60 @@
                 </ul>
             </div>
 
+            <figure>
+                <svg class="diagram" width="520" height="240" viewBox="0 0 520 240">
+                    <!-- SPV panel -->
+                    <rect x="30" y="34" width="190" height="194" rx="6" fill="#f0f5f8" stroke="#4a90d9" stroke-width="1.5"/>
+                    <text x="125" y="56" text-anchor="middle" font-family="Georgia" font-size="11" font-weight="bold">SPV Client</text>
+
+                    <text x="46" y="80" text-anchor="middle" font-family="Georgia" font-size="10" fill="#5a8f5a">&#10003;</text>
+                    <text x="58" y="80" font-family="Georgia" font-size="10">Merkle inclusion proof</text>
+                    <text x="46" y="100" text-anchor="middle" font-family="Georgia" font-size="10" fill="#5a8f5a">&#10003;</text>
+                    <text x="58" y="100" font-family="Georgia" font-size="10">Valid proof-of-work</text>
+                    <text x="46" y="120" text-anchor="middle" font-family="Georgia" font-size="10" fill="#5a8f5a">&#10003;</text>
+                    <text x="58" y="120" font-family="Georgia" font-size="10">Most-work chain</text>
+
+                    <line x1="42" y1="130" x2="208" y2="130" stroke="#666" stroke-width="1" stroke-dasharray="3,3"/>
+
+                    <text x="46" y="148" text-anchor="middle" font-family="Georgia" font-size="10" fill="#c44">&#10007;</text>
+                    <text x="58" y="148" font-family="Georgia" font-size="10" fill="#666">Valid signatures</text>
+                    <text x="46" y="168" text-anchor="middle" font-family="Georgia" font-size="10" fill="#c44">&#10007;</text>
+                    <text x="58" y="168" font-family="Georgia" font-size="10" fill="#666">No double-spends</text>
+                    <text x="46" y="188" text-anchor="middle" font-family="Georgia" font-size="10" fill="#c44">&#10007;</text>
+                    <text x="58" y="188" font-family="Georgia" font-size="10" fill="#666">Correct subsidy</text>
+                    <text x="46" y="208" text-anchor="middle" font-family="Georgia" font-size="10" fill="#c44">&#10007;</text>
+                    <text x="58" y="208" font-family="Georgia" font-size="10" fill="#666">Consensus rules</text>
+
+                    <text x="125" y="222" text-anchor="middle" font-family="Georgia" font-size="9" fill="#666">&#10007; = trusted, not verified</text>
+
+                    <!-- Subset relation -->
+                    <text x="260" y="136" text-anchor="middle" font-family="Georgia" font-size="20">&#8834;</text>
+                    <text x="260" y="154" text-anchor="middle" font-family="Georgia" font-size="9" fill="#666">strict subset</text>
+
+                    <!-- Full node panel -->
+                    <rect x="300" y="34" width="190" height="194" rx="6" fill="#f5f8f0" stroke="#5a8f5a" stroke-width="1.5"/>
+                    <text x="395" y="56" text-anchor="middle" font-family="Georgia" font-size="11" font-weight="bold">Full Node</text>
+
+                    <text x="316" y="80" text-anchor="middle" font-family="Georgia" font-size="10" fill="#5a8f5a">&#10003;</text>
+                    <text x="328" y="80" font-family="Georgia" font-size="10">Merkle inclusion proof</text>
+                    <text x="316" y="100" text-anchor="middle" font-family="Georgia" font-size="10" fill="#5a8f5a">&#10003;</text>
+                    <text x="328" y="100" font-family="Georgia" font-size="10">Valid proof-of-work</text>
+                    <text x="316" y="120" text-anchor="middle" font-family="Georgia" font-size="10" fill="#5a8f5a">&#10003;</text>
+                    <text x="328" y="120" font-family="Georgia" font-size="10">Most-work chain</text>
+                    <text x="316" y="148" text-anchor="middle" font-family="Georgia" font-size="10" fill="#5a8f5a">&#10003;</text>
+                    <text x="328" y="148" font-family="Georgia" font-size="10">Valid signatures</text>
+                    <text x="316" y="168" text-anchor="middle" font-family="Georgia" font-size="10" fill="#5a8f5a">&#10003;</text>
+                    <text x="328" y="168" font-family="Georgia" font-size="10">No double-spends</text>
+                    <text x="316" y="188" text-anchor="middle" font-family="Georgia" font-size="10" fill="#5a8f5a">&#10003;</text>
+                    <text x="328" y="188" font-family="Georgia" font-size="10">Correct subsidy</text>
+                    <text x="316" y="208" text-anchor="middle" font-family="Georgia" font-size="10" fill="#5a8f5a">&#10003;</text>
+                    <text x="328" y="208" font-family="Georgia" font-size="10">Consensus rules</text>
+
+                    <text x="395" y="222" text-anchor="middle" font-family="Georgia" font-size="9" fill="#666">&#10003; = independently verified</text>
+                </svg>
+                <figcaption>Figure 25.1: SPV verification is a strict subset of full-node verification&mdash;SPV checks inclusion and work but trusts miners for everything below the line.</figcaption>
+            </figure>
+
             <div class="proof">
                 <p><strong>Analysis.</strong></p>
                 <p>
@@ -263,6 +317,61 @@
                     Layer 2 achieves the same throughput with ~150,000x less on-chain footprint.
                 </p>
             </div>
+
+            <figure>
+                <svg class="diagram" width="520" height="232" viewBox="0 0 520 232">
+                    <!-- Left: pure on-chain -->
+                    <text x="130" y="24" text-anchor="middle" font-family="Georgia" font-size="11" font-weight="bold">Pure on-chain</text>
+                    <text x="130" y="40" text-anchor="middle" font-family="Georgia" font-size="9" fill="#666">target: 1 million TPS</text>
+
+                    <rect x="80" y="56" width="100" height="84" rx="4" fill="#ffe8e8" stroke="#c44" stroke-width="1.5"/>
+                    <text x="130" y="84" text-anchor="middle" font-family="Georgia" font-size="10">one block</text>
+                    <text x="130" y="104" text-anchor="middle" font-family="Georgia" font-size="13" font-weight="bold">~144 GB</text>
+                    <text x="130" y="124" text-anchor="middle" font-family="Georgia" font-size="9" fill="#666">every 10 minutes</text>
+
+                    <text x="130" y="166" text-anchor="middle" font-family="Georgia" font-size="10" fill="#666">every node: ~150 GB</text>
+                    <text x="130" y="182" text-anchor="middle" font-family="Georgia" font-size="10" fill="#666">bandwidth per 10 min</text>
+
+                    <!-- Divider -->
+                    <line x1="260" y1="14" x2="260" y2="190" stroke="#666" stroke-width="1" stroke-dasharray="4,4"/>
+
+                    <!-- Right: Lightning -->
+                    <text x="390" y="24" text-anchor="middle" font-family="Georgia" font-size="11" font-weight="bold">Lightning channels</text>
+                    <text x="390" y="40" text-anchor="middle" font-family="Georgia" font-size="9" fill="#666">target: 1 million TPS</text>
+
+                    <rect x="302" y="52" width="176" height="64" rx="8" fill="#f0f5f8" stroke="#4a90d9" stroke-width="1.5"/>
+                    <text x="390" y="70" text-anchor="middle" font-family="Georgia" font-size="10" font-weight="bold">off-chain payments</text>
+                    <circle cx="326" cy="84" r="3" fill="#4a90d9"/>
+                    <circle cx="342" cy="84" r="3" fill="#4a90d9"/>
+                    <circle cx="358" cy="84" r="3" fill="#4a90d9"/>
+                    <circle cx="374" cy="84" r="3" fill="#4a90d9"/>
+                    <circle cx="390" cy="84" r="3" fill="#4a90d9"/>
+                    <circle cx="406" cy="84" r="3" fill="#4a90d9"/>
+                    <circle cx="422" cy="84" r="3" fill="#4a90d9"/>
+                    <circle cx="438" cy="84" r="3" fill="#4a90d9"/>
+                    <circle cx="454" cy="84" r="3" fill="#4a90d9"/>
+                    <text x="390" y="107" text-anchor="middle" font-family="Georgia" font-size="9" fill="#666">1000 tx per channel</text>
+
+                    <line x1="390" y1="118" x2="390" y2="138" stroke="#4a90d9" stroke-width="1.5" marker-end="url(#arrow25a)"/>
+                    <text x="398" y="132" font-family="Georgia" font-size="9" fill="#666">anchored by</text>
+
+                    <rect x="366" y="142" width="48" height="26" rx="3" fill="#f5f8f0" stroke="#5a8f5a" stroke-width="1.5"/>
+                    <text x="390" y="159" text-anchor="middle" font-family="Georgia" font-size="9" font-weight="bold">~1 MB</text>
+
+                    <text x="390" y="186" text-anchor="middle" font-family="Georgia" font-size="10" fill="#666">node requirements:</text>
+                    <text x="390" y="202" text-anchor="middle" font-family="Georgia" font-size="10" fill="#666">unchanged</text>
+
+                    <!-- Bottom annotation -->
+                    <text x="260" y="224" text-anchor="middle" font-family="Georgia" font-size="10">Same throughput with ~150,000x less on-chain footprint</text>
+
+                    <defs>
+                        <marker id="arrow25a" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+                            <polygon points="0 0, 8 3, 0 6" fill="#4a90d9"/>
+                        </marker>
+                    </defs>
+                </svg>
+                <figcaption>Figure 25.2: On-chain scaling grows node costs linearly with throughput; layer 2 anchors many off-chain transactions with one small on-chain block.</figcaption>
+            </figure>
 
             <div class="nuance-box">
                 <h4>Nuance: Layer 2 has costs of its own</h4>
@@ -498,6 +607,46 @@
                     rule applies only among <em>valid</em> chains. ∎
                 </p>
             </div>
+
+            <figure>
+                <svg class="diagram" width="500" height="252" viewBox="0 0 500 252">
+                    <text x="250" y="22" text-anchor="middle" font-family="Georgia" font-size="11" font-weight="bold">An attacker with majority (51%) hashrate</text>
+
+                    <!-- Can column -->
+                    <text x="127" y="54" text-anchor="middle" font-family="Georgia" font-size="12" font-weight="bold" fill="#c44">Can</text>
+                    <text x="127" y="68" text-anchor="middle" font-family="Georgia" font-size="9" fill="#666">ordering of valid blocks</text>
+
+                    <rect x="29" y="78" width="196" height="26" rx="4" fill="#ffe8e8" stroke="#c44" stroke-width="1"/>
+                    <text x="127" y="95" text-anchor="middle" font-family="Georgia" font-size="10">Double-spend own transactions</text>
+                    <rect x="29" y="112" width="196" height="26" rx="4" fill="#ffe8e8" stroke="#c44" stroke-width="1"/>
+                    <text x="127" y="129" text-anchor="middle" font-family="Georgia" font-size="10">Censor specific transactions</text>
+                    <rect x="29" y="146" width="196" height="26" rx="4" fill="#ffe8e8" stroke="#c44" stroke-width="1"/>
+                    <text x="127" y="163" text-anchor="middle" font-family="Georgia" font-size="10">Selfish-mine for extra reward</text>
+                    <rect x="29" y="180" width="196" height="26" rx="4" fill="#ffe8e8" stroke="#c44" stroke-width="1"/>
+                    <text x="127" y="197" text-anchor="middle" font-family="Georgia" font-size="10">Reorganize recent blocks</text>
+
+                    <!-- Boundary -->
+                    <line x1="250" y1="40" x2="250" y2="210" stroke="#2f4f4f" stroke-width="2"/>
+
+                    <!-- Cannot column -->
+                    <text x="373" y="54" text-anchor="middle" font-family="Georgia" font-size="12" font-weight="bold" fill="#5a8f5a">Cannot</text>
+                    <text x="373" y="68" text-anchor="middle" font-family="Georgia" font-size="9" fill="#666">what counts as valid</text>
+
+                    <rect x="275" y="78" width="196" height="26" rx="4" fill="#f5f8f0" stroke="#5a8f5a" stroke-width="1"/>
+                    <text x="373" y="95" text-anchor="middle" font-family="Georgia" font-size="10">Steal coins without the keys</text>
+                    <rect x="275" y="112" width="196" height="26" rx="4" fill="#f5f8f0" stroke="#5a8f5a" stroke-width="1"/>
+                    <text x="373" y="129" text-anchor="middle" font-family="Georgia" font-size="10">Create coins beyond subsidy</text>
+                    <rect x="275" y="146" width="196" height="26" rx="4" fill="#f5f8f0" stroke="#5a8f5a" stroke-width="1"/>
+                    <text x="373" y="163" text-anchor="middle" font-family="Georgia" font-size="10">Change consensus rules</text>
+                    <rect x="275" y="180" width="196" height="26" rx="4" fill="#f5f8f0" stroke="#5a8f5a" stroke-width="1"/>
+                    <text x="373" y="197" text-anchor="middle" font-family="Georgia" font-size="10">Stop a minority chain</text>
+
+                    <!-- Boundary label -->
+                    <rect x="118" y="212" width="264" height="26" rx="4" fill="#fff" stroke="#2f4f4f" stroke-width="1"/>
+                    <text x="250" y="229" text-anchor="middle" font-family="Georgia" font-size="10" font-weight="bold">Validity is decided by full nodes, not hashrate</text>
+                </svg>
+                <figcaption>Figure 25.3: Majority hashrate controls the ordering of valid blocks, not what is valid&mdash;the boundary is enforced by full nodes.</figcaption>
+            </figure>
 
             <hr>
 

--- a/chapters/34-scaling-verification.html
+++ b/chapters/34-scaling-verification.html
@@ -548,6 +548,72 @@
                 </p>
             </div>
 
+            <figure>
+                <svg class="diagram" width="520" height="300" viewBox="0 0 520 300">
+                    <defs>
+                        <marker id="arrow34b" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+                            <polygon points="0 0, 8 3, 0 6" fill="#666"/>
+                        </marker>
+                    </defs>
+
+                    <text x="220" y="20" text-anchor="middle" font-family="Georgia" font-size="11" font-weight="bold">Miner payoff in the activation game</text>
+
+                    <!-- convergence region e > 1/2 -->
+                    <rect x="220" y="60" width="160" height="190" fill="#f5f8f0"/>
+                    <text x="300" y="74" text-anchor="middle" font-family="Georgia" font-size="9" fill="#5a8f5a"><tspan font-style="italic">e</tspan> &gt; 1/2: chain N wins</text>
+
+                    <!-- axes -->
+                    <line x1="60" y1="250" x2="388" y2="250" stroke="#666" stroke-width="1" marker-end="url(#arrow34b)"/>
+                    <line x1="60" y1="250" x2="60" y2="58" stroke="#666" stroke-width="1" marker-end="url(#arrow34b)"/>
+                    <text x="60" y="46" text-anchor="middle" font-family="Georgia" font-size="9" fill="#666">value of block rewards</text>
+
+                    <!-- threshold at e = 1/2 -->
+                    <line x1="220" y1="60" x2="220" y2="250" stroke="#666" stroke-width="1" stroke-dasharray="4,3"/>
+
+                    <!-- e = 0.8 example guide -->
+                    <line x1="316" y1="250" x2="316" y2="106" stroke="#666" stroke-width="0.75" stroke-dasharray="2,3"/>
+
+                    <!-- payoff lines -->
+                    <line x1="60" y1="250" x2="380" y2="70" stroke="#5a8f5a" stroke-width="2"/>
+                    <line x1="60" y1="70" x2="380" y2="250" stroke="#c44" stroke-width="2"/>
+
+                    <!-- crossing and example points -->
+                    <circle cx="220" cy="160" r="3" fill="#2f4f4f"/>
+                    <circle cx="316" cy="106" r="3.5" fill="#5a8f5a"/>
+                    <circle cx="316" cy="214" r="3.5" fill="#c44"/>
+
+                    <!-- ticks -->
+                    <line x1="60" y1="250" x2="60" y2="255" stroke="#666" stroke-width="1"/>
+                    <line x1="220" y1="250" x2="220" y2="255" stroke="#666" stroke-width="1"/>
+                    <line x1="316" y1="250" x2="316" y2="255" stroke="#666" stroke-width="1"/>
+                    <line x1="380" y1="250" x2="380" y2="255" stroke="#666" stroke-width="1"/>
+                    <text x="60" y="268" text-anchor="middle" font-family="Georgia" font-size="9" fill="#666">0</text>
+                    <text x="220" y="268" text-anchor="middle" font-family="Georgia" font-size="9" fill="#666">1/2</text>
+                    <text x="316" y="268" text-anchor="middle" font-family="Georgia" font-size="9" fill="#666">0.8</text>
+                    <text x="380" y="268" text-anchor="middle" font-family="Georgia" font-size="9" fill="#666">1</text>
+                    <text x="220" y="287" text-anchor="middle" font-family="Georgia" font-size="10" fill="#2f4f4f">enforcing economic fraction <tspan font-style="italic">e</tspan></text>
+
+                    <!-- right-margin labels -->
+                    <text x="390" y="66" font-family="Georgia" font-size="9" fill="#5a8f5a" font-weight="bold">mine chain N</text>
+                    <text x="390" y="78" font-family="Georgia" font-size="9" fill="#5a8f5a">(enforce)</text>
+
+                    <text x="390" y="112" font-family="Georgia" font-size="9" fill="#666">at <tspan font-style="italic">e</tspan> = 0.8 (dots):</text>
+                    <text x="390" y="124" font-family="Georgia" font-size="9" fill="#666">hashrate splits 4:1,</text>
+                    <text x="390" y="136" font-family="Georgia" font-size="9" fill="#666">chain O rewards 25%,</text>
+                    <text x="390" y="148" font-family="Georgia" font-size="9" fill="#666">then &rarr; 0 (orphaned)</text>
+
+                    <text x="390" y="224" font-family="Georgia" font-size="9" fill="#c44" font-weight="bold">mine chain O</text>
+                    <text x="390" y="236" font-family="Georgia" font-size="9" fill="#c44">(ignore)</text>
+                </svg>
+                <figcaption>Figure 34.2: Reward value on the two chains as a function of
+                    the enforcing fraction <span class="math">e</span>. Past the threshold
+                    <span class="math">e = 1/2</span>, chain <span class="math">N</span>
+                    out-earns chain <span class="math">O</span> and Proposition 34.1 drives
+                    all hashrate to the new rules&mdash;at <span class="math">e = 0.8</span>,
+                    chain <span class="math">O</span>'s rewards are worth 25% even before
+                    orphaning erases them.</figcaption>
+            </figure>
+
             <div class="remark">
                 <p class="remark-title">Remark 34.4 (Enforcement Requires Verification)</p>
                 <p>
@@ -682,6 +748,83 @@
                     </tr>
                 </tbody>
             </table>
+
+            <figure>
+                <svg class="diagram" width="520" height="384" viewBox="0 0 520 384">
+                    <defs>
+                        <marker id="arrow34c" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+                            <polygon points="0 0, 8 3, 0 6" fill="#666"/>
+                        </marker>
+                        <marker id="arrow34cb" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+                            <polygon points="0 0, 8 3, 0 6" fill="#8b4513"/>
+                        </marker>
+                    </defs>
+
+                    <text x="255" y="20" text-anchor="middle" font-family="Georgia" font-size="11" font-weight="bold">The trust-drift ladder</text>
+
+                    <!-- drift arrow -->
+                    <line x1="90" y1="48" x2="90" y2="356" stroke="#8b4513" stroke-width="2" marker-end="url(#arrow34cb)"/>
+                    <text x="82" y="64" text-anchor="end" font-family="Georgia" font-size="9" fill="#666">verified set</text>
+                    <text x="82" y="76" text-anchor="end" font-family="Georgia" font-size="9" fill="#666">shrinks</text>
+                    <text x="82" y="192" text-anchor="end" font-family="Georgia" font-size="9" fill="#8b4513" font-weight="bold">drift toward</text>
+                    <text x="82" y="204" text-anchor="end" font-family="Georgia" font-size="9" fill="#8b4513" font-weight="bold">convenience</text>
+                    <text x="82" y="320" text-anchor="end" font-family="Georgia" font-size="9" fill="#666">trusted set</text>
+                    <text x="82" y="332" text-anchor="end" font-family="Georgia" font-size="9" fill="#666">grows</text>
+
+                    <!-- rungs -->
+                    <rect x="150" y="40" width="210" height="34" rx="4" fill="#f5f8f0" stroke="#5a8f5a" stroke-width="1.5"/>
+                    <text x="255" y="55" text-anchor="middle" font-family="Georgia" font-size="10" font-weight="bold" fill="#2f4f4f">Full validation</text>
+                    <text x="255" y="67" text-anchor="middle" font-family="Georgia" font-size="9" fill="#666">every rule, every block, from genesis</text>
+
+                    <rect x="150" y="98" width="210" height="34" rx="4" fill="#f0f5f8" stroke="#4a90d9" stroke-width="1.5"/>
+                    <text x="255" y="113" text-anchor="middle" font-family="Georgia" font-size="10" font-weight="bold" fill="#2f4f4f">AssumeValid</text>
+                    <text x="255" y="125" text-anchor="middle" font-family="Georgia" font-size="9" fill="#666">all but historical script signatures</text>
+
+                    <rect x="150" y="156" width="210" height="34" rx="4" fill="#f0f5f8" stroke="#4a90d9" stroke-width="1.5"/>
+                    <text x="255" y="171" text-anchor="middle" font-family="Georgia" font-size="10" font-weight="bold" fill="#2f4f4f">AssumeUTXO</text>
+                    <text x="255" y="183" text-anchor="middle" font-family="Georgia" font-size="9" fill="#666">snapshot forward now, history later</text>
+
+                    <rect x="150" y="214" width="210" height="34" rx="4" fill="#fff8f0" stroke="#8b4513" stroke-width="1.5"/>
+                    <text x="255" y="229" text-anchor="middle" font-family="Georgia" font-size="10" font-weight="bold" fill="#2f4f4f">SPV / Neutrino</text>
+                    <text x="255" y="241" text-anchor="middle" font-family="Georgia" font-size="9" fill="#666">proof-of-work, headers, inclusion</text>
+
+                    <rect x="150" y="272" width="210" height="34" rx="4" fill="#fff8f0" stroke="#8b4513" stroke-width="1.5"/>
+                    <text x="255" y="287" text-anchor="middle" font-family="Georgia" font-size="10" font-weight="bold" fill="#2f4f4f">Electrum-style servers</text>
+                    <text x="255" y="299" text-anchor="middle" font-family="Georgia" font-size="9" fill="#666">headers and Merkle proofs</text>
+
+                    <rect x="150" y="330" width="210" height="34" rx="4" fill="#ffe8e8" stroke="#c44" stroke-width="1.5"/>
+                    <text x="255" y="345" text-anchor="middle" font-family="Georgia" font-size="10" font-weight="bold" fill="#c44">API / custodial</text>
+                    <text x="255" y="357" text-anchor="middle" font-family="Georgia" font-size="9" fill="#666">verifies nothing</text>
+
+                    <!-- step arrows -->
+                    <line x1="255" y1="78" x2="255" y2="93" stroke="#666" stroke-width="1" marker-end="url(#arrow34c)"/>
+                    <line x1="255" y1="136" x2="255" y2="151" stroke="#666" stroke-width="1" marker-end="url(#arrow34c)"/>
+                    <line x1="255" y1="194" x2="255" y2="209" stroke="#666" stroke-width="1" marker-end="url(#arrow34c)"/>
+                    <line x1="255" y1="252" x2="255" y2="267" stroke="#666" stroke-width="1" marker-end="url(#arrow34c)"/>
+                    <line x1="255" y1="310" x2="255" y2="325" stroke="#666" stroke-width="1" marker-end="url(#arrow34c)"/>
+
+                    <!-- what each step loses -->
+                    <text x="372" y="52" font-family="Georgia" font-size="9" font-style="italic" fill="#666">what each step down loses</text>
+
+                    <text x="372" y="84" font-family="Georgia" font-size="9" fill="#666">lost: historical script</text>
+                    <text x="372" y="95" font-family="Georgia" font-size="9" fill="#666">signature checks</text>
+
+                    <text x="372" y="142" font-family="Georgia" font-size="9" fill="#666">lost: immediate validation</text>
+                    <text x="372" y="153" font-family="Georgia" font-size="9" fill="#666">of pre-snapshot history</text>
+
+                    <text x="372" y="200" font-family="Georgia" font-size="9" fill="#666">lost: rule validation</text>
+                    <text x="372" y="211" font-family="Georgia" font-size="9" fill="#666">(trusts majority hashrate)</text>
+
+                    <text x="372" y="258" font-family="Georgia" font-size="9" fill="#666">lost: history completeness</text>
+                    <text x="372" y="269" font-family="Georgia" font-size="9" fill="#666">and query privacy</text>
+
+                    <text x="372" y="316" font-family="Georgia" font-size="9" fill="#666">lost: all verification</text>
+                    <text x="372" y="327" font-family="Georgia" font-size="9" fill="#666">(and, custodially, the keys)</text>
+                </svg>
+                <figcaption>Figure 34.3: The trust-drift ladder. Each step down sheds part
+                    of the verified set and enlarges the trusted set&mdash;and each step
+                    down is cheaper, which is why drift runs toward the bottom.</figcaption>
+            </figure>
 
             <p>
                 The ladder is a description, not a prediction. The contested question is

--- a/chapters/38-security-budget.html
+++ b/chapters/38-security-budget.html
@@ -166,6 +166,72 @@
                 2048, it will be negligible. The transition to a fee-based security model
                 is not a distant concern; it is already underway.
             </p>
+
+            <figure>
+                <svg class="diagram" width="500" height="280" viewBox="0 0 500 280">
+                    <!-- Halving staircase: subsidy decay vs uncertain fee growth -->
+                    <text x="250" y="20" text-anchor="middle" font-family="Georgia" font-size="10" font-weight="bold">The Halving Staircase</text>
+
+                    <!-- Axes -->
+                    <line x1="70" y1="242" x2="455" y2="242" stroke="#666" marker-end="url(#arrow38a)"/>
+                    <line x1="70" y1="242" x2="70" y2="36" stroke="#666" marker-end="url(#arrow38a)"/>
+                    <text x="24" y="139" text-anchor="middle" font-family="Georgia" font-size="9" transform="rotate(-90, 24, 139)">BTC per block (log scale)</text>
+
+                    <!-- Y ticks (one per halving step) -->
+                    <line x1="66" y1="56" x2="70" y2="56" stroke="#666"/>
+                    <line x1="66" y1="80" x2="70" y2="80" stroke="#666"/>
+                    <line x1="66" y1="104" x2="70" y2="104" stroke="#666"/>
+                    <line x1="66" y1="128" x2="70" y2="128" stroke="#666"/>
+                    <line x1="66" y1="152" x2="70" y2="152" stroke="#666"/>
+                    <line x1="66" y1="176" x2="70" y2="176" stroke="#666"/>
+                    <line x1="66" y1="200" x2="70" y2="200" stroke="#666"/>
+                    <text x="64" y="59" text-anchor="end" font-family="Georgia" font-size="9">50</text>
+                    <text x="64" y="83" text-anchor="end" font-family="Georgia" font-size="9">25</text>
+                    <text x="64" y="107" text-anchor="end" font-family="Georgia" font-size="9">12.5</text>
+                    <text x="64" y="131" text-anchor="end" font-family="Georgia" font-size="9">6.25</text>
+                    <text x="64" y="155" text-anchor="end" font-family="Georgia" font-size="9">3.125</text>
+                    <text x="64" y="179" text-anchor="end" font-family="Georgia" font-size="9">1.5625</text>
+                    <text x="64" y="203" text-anchor="end" font-family="Georgia" font-size="9">0.78</text>
+
+                    <!-- X ticks (halving years) -->
+                    <line x1="85" y1="242" x2="85" y2="246" stroke="#666"/>
+                    <line x1="124" y1="242" x2="124" y2="246" stroke="#666"/>
+                    <line x1="175" y1="242" x2="175" y2="246" stroke="#666"/>
+                    <line x1="227" y1="242" x2="227" y2="246" stroke="#666"/>
+                    <line x1="278" y1="242" x2="278" y2="246" stroke="#666"/>
+                    <line x1="330" y1="242" x2="330" y2="246" stroke="#666"/>
+                    <line x1="381" y1="242" x2="381" y2="246" stroke="#666"/>
+                    <line x1="433" y1="242" x2="433" y2="246" stroke="#666"/>
+                    <text x="85" y="258" text-anchor="middle" font-family="Georgia" font-size="9">2009</text>
+                    <text x="124" y="258" text-anchor="middle" font-family="Georgia" font-size="9">2012</text>
+                    <text x="175" y="258" text-anchor="middle" font-family="Georgia" font-size="9">2016</text>
+                    <text x="227" y="258" text-anchor="middle" font-family="Georgia" font-size="9">2020</text>
+                    <text x="278" y="258" text-anchor="middle" font-family="Georgia" font-size="9">2024</text>
+                    <text x="330" y="258" text-anchor="middle" font-family="Georgia" font-size="9">2028</text>
+                    <text x="381" y="258" text-anchor="middle" font-family="Georgia" font-size="9">2032</text>
+                    <text x="433" y="258" text-anchor="middle" font-family="Georgia" font-size="9">2036</text>
+
+                    <!-- Subsidy staircase (fixed schedule) -->
+                    <path d="M 85 56 H 124 V 80 H 175 V 104 H 227 V 128 H 278 V 152 H 330 V 176 H 381 V 200 H 433" stroke="#8b4513" stroke-width="2" fill="none"/>
+                    <text x="185" y="72" font-family="Georgia" font-size="9" fill="#8b4513">Subsidy (fixed schedule)</text>
+                    <text x="444" y="222" text-anchor="middle" font-family="Georgia" font-size="9" fill="#666">&#8594; 0 by ~2140</text>
+
+                    <!-- Fee revenue (uncertain replacement) -->
+                    <path d="M 95 236 C 180 232, 280 222, 360 204 S 430 172, 452 158" stroke="#4a90d9" stroke-width="2" stroke-dasharray="5 4" fill="none"/>
+                    <text x="230" y="202" text-anchor="middle" font-family="Georgia" font-size="9" fill="#4a90d9">Fees (uncertain)</text>
+                    <text x="460" y="153" font-family="Georgia" font-size="12" font-weight="bold" fill="#4a90d9">?</text>
+
+                    <!-- Bottom annotation -->
+                    <text x="250" y="274" text-anchor="middle" font-family="Georgia" font-size="9" fill="#666">The security budget shifts from subsidy-dominated to fee-dominated.</text>
+
+                    <defs>
+                        <marker id="arrow38a" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+                            <polygon points="0 0, 10 3.5, 0 7" fill="#666"/>
+                        </marker>
+                    </defs>
+                </svg>
+                <figcaption>Figure 38.1: The halving staircase&mdash;the block subsidy decays geometrically while uncertain fee revenue must grow to replace it.</figcaption>
+            </figure>
         </section>
 
         <section>
@@ -213,6 +279,57 @@
                     budget drops to $1 billion, attacks become 10x cheaper.
                 </p>
             </div>
+
+            <figure>
+                <svg class="diagram" width="500" height="300" viewBox="0 0 500 300">
+                    <!-- Security condition: cost of attack vs value extractable -->
+                    <text x="250" y="20" text-anchor="middle" font-family="Georgia" font-size="10" font-weight="bold">The Security Condition</text>
+
+                    <!-- Region fills -->
+                    <polygon points="70,260 420,52 70,52" fill="#f5f8f0"/>
+                    <polygon points="70,260 420,52 420,260" fill="#ffe8e8"/>
+
+                    <!-- Axes -->
+                    <line x1="70" y1="260" x2="455" y2="260" stroke="#666" marker-end="url(#arrow38b)"/>
+                    <line x1="70" y1="260" x2="70" y2="40" stroke="#666" marker-end="url(#arrow38b)"/>
+                    <text x="255" y="279" text-anchor="middle" font-family="Georgia" font-size="9">Value extractable by an attack</text>
+                    <text x="24" y="150" text-anchor="middle" font-family="Georgia" font-size="9" transform="rotate(-90, 24, 150)">Cost of attack</text>
+
+                    <!-- Break-even diagonal -->
+                    <line x1="70" y1="260" x2="420" y2="52" stroke="#2f4f4f" stroke-width="1.5"/>
+                    <text x="190" y="176" text-anchor="middle" font-family="Georgia" font-size="9" fill="#666" transform="rotate(-31, 190, 176)">Cost = Value</text>
+
+                    <!-- Region labels -->
+                    <text x="150" y="82" text-anchor="middle" font-family="Georgia" font-size="11" font-weight="bold" fill="#5a8f5a">Secure</text>
+                    <text x="150" y="97" text-anchor="middle" font-family="Georgia" font-size="9" fill="#666">cost of attack exceeds</text>
+                    <text x="150" y="110" text-anchor="middle" font-family="Georgia" font-size="9" fill="#666">extractable value</text>
+                    <text x="230" y="247" text-anchor="middle" font-family="Georgia" font-size="11" font-weight="bold" fill="#c44">Insecure &#8212; attack pays</text>
+
+                    <!-- Budget-determined attack cost levels -->
+                    <line x1="70" y1="140" x2="420" y2="140" stroke="#4a90d9" stroke-width="1.5" stroke-dasharray="6 4"/>
+                    <text x="78" y="131" font-family="Georgia" font-size="9" fill="#4a90d9">attack cost at $10B/yr budget (~$27M/day)</text>
+                    <line x1="70" y1="228" x2="420" y2="228" stroke="#8b4513" stroke-width="1.5" stroke-dasharray="6 4"/>
+                    <text x="426" y="231" font-family="Georgia" font-size="9" fill="#8b4513">$1B/yr</text>
+
+                    <!-- Declining budget arrow -->
+                    <line x1="400" y1="147" x2="400" y2="219" stroke="#c44" stroke-width="1.5" marker-end="url(#arrow38br)"/>
+                    <text x="392" y="176" text-anchor="end" font-family="Georgia" font-size="9" fill="#c44">smaller budget:</text>
+                    <text x="392" y="189" text-anchor="end" font-family="Georgia" font-size="9" fill="#c44">attack 10x cheaper</text>
+
+                    <!-- Bottom annotation -->
+                    <text x="250" y="295" text-anchor="middle" font-family="Georgia" font-size="9" fill="#666">Attack Cost &#8776; Security Budget &#215; Attack Duration / 365 (Remark 38.2)</text>
+
+                    <defs>
+                        <marker id="arrow38b" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+                            <polygon points="0 0, 10 3.5, 0 7" fill="#666"/>
+                        </marker>
+                        <marker id="arrow38br" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+                            <polygon points="0 0, 10 3.5, 0 7" fill="#c44"/>
+                        </marker>
+                    </defs>
+                </svg>
+                <figcaption>Figure 38.2: The security condition&mdash;the network is secure only while the cost of attack, set by the security budget, exceeds the value an attacker can extract.</figcaption>
+            </figure>
         </section>
 
         <section>
@@ -442,6 +559,57 @@ Fee Determination:
                     asset.
                 </p>
             </div>
+
+            <figure>
+                <svg class="diagram" width="500" height="300" viewBox="0 0 500 300">
+                    <!-- The three security-budget models of Section 38.5 -->
+                    <text x="250" y="20" text-anchor="middle" font-family="Georgia" font-size="10" font-weight="bold">Three Models of the Future Security Budget</text>
+
+                    <!-- Axes -->
+                    <line x1="70" y1="240" x2="455" y2="240" stroke="#666" marker-end="url(#arrow38c)"/>
+                    <line x1="70" y1="240" x2="70" y2="36" stroke="#666" marker-end="url(#arrow38c)"/>
+                    <text x="255" y="272" text-anchor="middle" font-family="Georgia" font-size="9">Bitcoin market capitalization</text>
+                    <text x="24" y="138" text-anchor="middle" font-family="Georgia" font-size="9" transform="rotate(-90, 24, 138)">Security budget ($B / year)</text>
+
+                    <!-- Ticks -->
+                    <line x1="66" y1="212" x2="70" y2="212" stroke="#666"/>
+                    <line x1="66" y1="55" x2="70" y2="55" stroke="#666"/>
+                    <text x="64" y="215" text-anchor="end" font-family="Georgia" font-size="9">$15B</text>
+                    <text x="64" y="58" text-anchor="end" font-family="Georgia" font-size="9">$100B</text>
+                    <line x1="117" y1="240" x2="117" y2="244" stroke="#666"/>
+                    <line x1="250" y1="240" x2="250" y2="244" stroke="#666"/>
+                    <line x1="430" y1="240" x2="430" y2="244" stroke="#666"/>
+                    <text x="117" y="256" text-anchor="middle" font-family="Georgia" font-size="9">$1.3T</text>
+                    <text x="250" y="256" text-anchor="middle" font-family="Georgia" font-size="9">$5T</text>
+                    <text x="430" y="256" text-anchor="middle" font-family="Georgia" font-size="9">$10T</text>
+
+                    <!-- Model 1: linear fee growth (~1% of market cap; $100B/yr at $10T) -->
+                    <line x1="117" y1="212" x2="430" y2="55" stroke="#4a90d9" stroke-width="2" stroke-dasharray="6 3"/>
+                    <text x="436" y="58" font-family="Georgia" font-size="9" fill="#4a90d9">Model 1</text>
+
+                    <!-- Model 3: security percentage decline (below 0.5% of cap) -->
+                    <path d="M 117 212 Q 280 204 430 160" stroke="#8b4513" stroke-width="2" stroke-dasharray="6 3" fill="none"/>
+                    <text x="436" y="163" font-family="Georgia" font-size="9" fill="#8b4513">Model 3</text>
+
+                    <!-- Model 2: constant dollar security ($15B/yr) -->
+                    <line x1="117" y1="212" x2="430" y2="212" stroke="#5a8f5a" stroke-width="2" stroke-dasharray="6 3"/>
+                    <text x="436" y="215" font-family="Georgia" font-size="9" fill="#5a8f5a">Model 2</text>
+
+                    <!-- Today's anchor point: 2024, $1.3T cap, $15B budget -->
+                    <circle cx="117" cy="212" r="3" fill="#2f4f4f"/>
+                    <text x="117" y="230" text-anchor="middle" font-family="Georgia" font-size="9" fill="#666">2024</text>
+
+                    <!-- Legend annotation -->
+                    <text x="250" y="290" text-anchor="middle" font-family="Georgia" font-size="9" fill="#666">Model 1: ~1% of market cap &#183; Model 2: constant $15B/yr &#183; Model 3: declining percentage</text>
+
+                    <defs>
+                        <marker id="arrow38c" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+                            <polygon points="0 0, 10 3.5, 0 7" fill="#666"/>
+                        </marker>
+                    </defs>
+                </svg>
+                <figcaption>Figure 38.3: The three models of Section 38.5 diverge sharply as Bitcoin's market capitalization grows, projected from the 2024 anchor point ($1.3T, $15B/yr).</figcaption>
+            </figure>
         </section>
 
         <section>

--- a/chapters/39-quantum-resistance.html
+++ b/chapters/39-quantum-resistance.html
@@ -56,6 +56,45 @@
                     less concerning and can be addressed by increasing key sizes.
                 </p>
             </div>
+
+            <figure>
+                <svg class="diagram" width="500" height="248" viewBox="0 0 500 248">
+                    <!-- Quantum computer source -->
+                    <rect x="180" y="16" width="140" height="34" rx="6" fill="#f8f5f0" stroke="#2f4f4f" stroke-width="1.5"/>
+                    <text x="250" y="37" text-anchor="middle" font-family="Georgia" font-size="11" font-weight="bold">Quantum Computer</text>
+
+                    <!-- Fan-out arrows -->
+                    <path d="M 238 50 L 136 80" stroke="#2f4f4f" stroke-width="1.5" marker-end="url(#arrow39a)"/>
+                    <path d="M 262 50 L 364 80" stroke="#2f4f4f" stroke-width="1.5" marker-end="url(#arrow39a)"/>
+
+                    <!-- Shor branch -->
+                    <rect x="30" y="86" width="204" height="30" rx="6" fill="#ffe8e8" stroke="#c44" stroke-width="1.5"/>
+                    <text x="132" y="105" text-anchor="middle" font-family="Georgia" font-size="11" font-weight="bold">Shor's Algorithm</text>
+                    <text x="132" y="136" text-anchor="middle" font-family="Georgia" font-size="10">Target: ECDSA signatures (ECDLP)</text>
+                    <text x="132" y="152" text-anchor="middle" font-family="Georgia" font-size="9" fill="#666">needs fault-tolerant quantum computer</text>
+                    <text x="132" y="166" text-anchor="middle" font-family="Georgia" font-size="9" fill="#666">(~2,330 logical qubits, ~10¹² gates)</text>
+                    <rect x="30" y="182" width="204" height="48" rx="6" fill="#ffe8e8" stroke="#c44" stroke-width="1.5"/>
+                    <text x="132" y="202" text-anchor="middle" font-family="Georgia" font-size="10" font-weight="bold" fill="#c44">Severe: coins can be stolen</text>
+                    <text x="132" y="218" text-anchor="middle" font-family="Georgia" font-size="9" fill="#666">migration eventually required</text>
+
+                    <!-- Grover branch -->
+                    <rect x="266" y="86" width="204" height="30" rx="6" fill="#f0f5f8" stroke="#4a90d9" stroke-width="1.5"/>
+                    <text x="368" y="105" text-anchor="middle" font-family="Georgia" font-size="11" font-weight="bold">Grover's Algorithm</text>
+                    <text x="368" y="136" text-anchor="middle" font-family="Georgia" font-size="10">Target: SHA-256 mining</text>
+                    <text x="368" y="152" text-anchor="middle" font-family="Georgia" font-size="9" fill="#666">only quadratic speedup, O(√N)</text>
+                    <text x="368" y="166" text-anchor="middle" font-family="Georgia" font-size="9" fill="#666">(√M collective gain from M machines)</text>
+                    <rect x="266" y="182" width="204" height="48" rx="6" fill="#f5f8f0" stroke="#5a8f5a" stroke-width="1.5"/>
+                    <text x="368" y="202" text-anchor="middle" font-family="Georgia" font-size="10" font-weight="bold" fill="#5a8f5a">Manageable: 2¹²⁸ still astronomical</text>
+                    <text x="368" y="218" text-anchor="middle" font-family="Georgia" font-size="9" fill="#666">difficulty adjustment compensates</text>
+
+                    <defs>
+                        <marker id="arrow39a" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+                            <polygon points="0 0, 10 3.5, 0 7" fill="#2f4f4f"/>
+                        </marker>
+                    </defs>
+                </svg>
+                <figcaption>Figure 39.1: The two quantum threats&mdash;Shor's algorithm endangers signatures and demands migration, while Grover's quadratic speedup leaves mining intact.</figcaption>
+            </figure>
         </section>
 
         <section>
@@ -255,6 +294,55 @@ Resource Requirements (256-bit ECDSA):
                     to quantum attack regardless of address reuse practices.
                 </p>
             </div>
+
+            <figure>
+                <svg class="diagram" width="500" height="300" viewBox="0 0 500 300">
+                    <!-- Adversary -->
+                    <rect x="170" y="14" width="160" height="38" rx="6" fill="#ffe8e8" stroke="#c44" stroke-width="1.5"/>
+                    <text x="250" y="31" text-anchor="middle" font-family="Georgia" font-size="11" font-weight="bold">Shor-Capable Adversary</text>
+                    <text x="250" y="45" text-anchor="middle" font-family="Georgia" font-size="9" fill="#666">(computes <tspan font-style="italic">d</tspan> from <tspan font-style="italic">P</tspan>)</text>
+
+                    <!-- Arrows to the two classes -->
+                    <path d="M 210 52 L 138 94" stroke="#c44" stroke-width="1.5" marker-end="url(#arrow39bRed)"/>
+                    <text x="108" y="64" text-anchor="middle" font-family="Georgia" font-size="9" fill="#c44">reachable</text>
+                    <text x="108" y="76" text-anchor="middle" font-family="Georgia" font-size="9" fill="#c44">immediately</text>
+                    <path d="M 290 52 L 362 94" stroke="#666" stroke-width="1.5" stroke-dasharray="4,3" marker-end="url(#arrow39bGray)"/>
+                    <text x="392" y="64" text-anchor="middle" font-family="Georgia" font-size="9" fill="#666">only during a</text>
+                    <text x="392" y="76" text-anchor="middle" font-family="Georgia" font-size="9" fill="#666">spend-time race</text>
+
+                    <!-- Exposed panel -->
+                    <rect x="30" y="100" width="210" height="158" rx="6" fill="#ffe8e8" stroke="#c44" stroke-width="1.5"/>
+                    <text x="135" y="122" text-anchor="middle" font-family="Georgia" font-size="11" font-weight="bold" fill="#c44">Public Key Exposed</text>
+                    <text x="135" y="146" text-anchor="middle" font-family="Georgia" font-size="10">P2PK (early outputs,</text>
+                    <text x="135" y="160" text-anchor="middle" font-family="Georgia" font-size="10">~1 million BTC)</text>
+                    <text x="135" y="182" text-anchor="middle" font-family="Georgia" font-size="10">P2TR (tweaked key in output)</text>
+                    <text x="135" y="204" text-anchor="middle" font-family="Georgia" font-size="10">Reused / already-spent</text>
+                    <text x="135" y="218" text-anchor="middle" font-family="Georgia" font-size="10">addresses (key revealed)</text>
+                    <text x="135" y="242" text-anchor="middle" font-family="Georgia" font-size="9" fill="#666">no defense possible for these coins</text>
+
+                    <!-- Shielded panel -->
+                    <rect x="260" y="100" width="210" height="158" rx="6" fill="#f5f8f0" stroke="#5a8f5a" stroke-width="1.5"/>
+                    <text x="365" y="122" text-anchor="middle" font-family="Georgia" font-size="11" font-weight="bold" fill="#5a8f5a">Hash-Shielded Until Spend</text>
+                    <text x="365" y="146" text-anchor="middle" font-family="Georgia" font-size="10">P2PKH (fresh address)</text>
+                    <text x="365" y="168" text-anchor="middle" font-family="Georgia" font-size="10">P2WPKH (fresh address)</text>
+                    <text x="365" y="196" text-anchor="middle" font-family="Georgia" font-size="9" fill="#666">only a hash appears on-chain;</text>
+                    <text x="365" y="210" text-anchor="middle" font-family="Georgia" font-size="9" fill="#666">key revealed at spend time</text>
+                    <text x="365" y="242" text-anchor="middle" font-family="Georgia" font-size="9" fill="#666">migration window available</text>
+
+                    <!-- Bottom annotation -->
+                    <text x="250" y="284" text-anchor="middle" font-family="Georgia" font-size="10" fill="#666">An output is exposed exactly when its public key, not a hash, is visible on-chain.</text>
+
+                    <defs>
+                        <marker id="arrow39bRed" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+                            <polygon points="0 0, 10 3.5, 0 7" fill="#c44"/>
+                        </marker>
+                        <marker id="arrow39bGray" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+                            <polygon points="0 0, 10 3.5, 0 7" fill="#666"/>
+                        </marker>
+                    </defs>
+                </svg>
+                <figcaption>Figure 39.2: Quantum vulnerability by output type&mdash;a Shor-capable adversary can immediately reach any coin whose public key is visible on-chain.</figcaption>
+            </figure>
 
             <div class="definition">
                 <p class="definition-title">Definition 39.5 (Transaction Race Attack)</p>
@@ -962,6 +1050,59 @@ Recommended Preparation Timeline:
 └── Full PQ security achieved
 </pre>
             </div>
+
+            <figure>
+                <svg class="diagram" width="500" height="208" viewBox="0 0 500 208">
+                    <!-- Stage boxes -->
+                    <rect x="32" y="36" width="92" height="72" rx="6" fill="#f0f5f8" stroke="#4a90d9" stroke-width="1.5"/>
+                    <text x="78" y="56" text-anchor="middle" font-family="Georgia" font-size="10" font-weight="bold">Research</text>
+                    <text x="78" y="74" text-anchor="middle" font-family="Georgia" font-size="9" fill="#666">monitor; choose</text>
+                    <text x="78" y="88" text-anchor="middle" font-family="Georgia" font-size="9" fill="#666">PQ scheme (ML-DSA)</text>
+
+                    <rect x="136" y="36" width="92" height="72" rx="6" fill="#f5f8f0" stroke="#5a8f5a" stroke-width="1.5"/>
+                    <text x="182" y="56" text-anchor="middle" font-family="Georgia" font-size="10" font-weight="bold">Testing</text>
+                    <text x="182" y="74" text-anchor="middle" font-family="Georgia" font-size="9" fill="#666">signet, wallets,</text>
+                    <text x="182" y="88" text-anchor="middle" font-family="Georgia" font-size="9" fill="#666">audits, BIP</text>
+
+                    <rect x="240" y="36" width="92" height="72" rx="6" fill="#fff8f0" stroke="#8b4513" stroke-width="1.5"/>
+                    <text x="286" y="56" text-anchor="middle" font-family="Georgia" font-size="10" font-weight="bold">Activation</text>
+                    <text x="286" y="74" text-anchor="middle" font-family="Georgia" font-size="9" fill="#666">soft fork adds PQ</text>
+                    <text x="286" y="88" text-anchor="middle" font-family="Georgia" font-size="9" fill="#666">outputs (P2QRH)</text>
+
+                    <rect x="344" y="36" width="92" height="72" rx="6" fill="#f8f5f0" stroke="#2f4f4f" stroke-width="1.5"/>
+                    <text x="390" y="56" text-anchor="middle" font-family="Georgia" font-size="10" font-weight="bold">Migration</text>
+                    <text x="390" y="74" text-anchor="middle" font-family="Georgia" font-size="9" fill="#666">users move coins</text>
+                    <text x="390" y="88" text-anchor="middle" font-family="Georgia" font-size="9" fill="#666">to PQ addresses</text>
+
+                    <!-- Connectors to timeline -->
+                    <line x1="78" y1="108" x2="78" y2="150" stroke="#666" stroke-width="1"/>
+                    <line x1="182" y1="108" x2="182" y2="150" stroke="#666" stroke-width="1"/>
+                    <line x1="286" y1="108" x2="286" y2="150" stroke="#666" stroke-width="1"/>
+                    <line x1="390" y1="108" x2="390" y2="150" stroke="#666" stroke-width="1"/>
+
+                    <!-- Timeline axis -->
+                    <path d="M 30 150 L 484 150" stroke="#2f4f4f" stroke-width="1.5" marker-end="url(#arrow39c)"/>
+                    <text x="78" y="168" text-anchor="middle" font-family="Georgia" font-size="9" fill="#666">2024&ndash;2026</text>
+                    <text x="182" y="168" text-anchor="middle" font-family="Georgia" font-size="9" fill="#666">2026&ndash;2028</text>
+                    <text x="286" y="168" text-anchor="middle" font-family="Georgia" font-size="9" fill="#666">2028&ndash;2030</text>
+                    <text x="390" y="168" text-anchor="middle" font-family="Georgia" font-size="9" fill="#666">2030&ndash;2040</text>
+
+                    <!-- Quantum threat marker -->
+                    <line x1="460" y1="112" x2="460" y2="164" stroke="#c44" stroke-width="1.5" stroke-dasharray="4,3"/>
+                    <text x="460" y="94" text-anchor="middle" font-family="Georgia" font-size="9" fill="#c44">quantum</text>
+                    <text x="460" y="106" text-anchor="middle" font-family="Georgia" font-size="9" fill="#c44">threat (<tspan font-style="italic">Z</tspan>)</text>
+
+                    <!-- Mosca annotation -->
+                    <text x="250" y="194" text-anchor="middle" font-family="Georgia" font-size="10" fill="#666">Mosca's inequality: begin migration now whenever <tspan font-style="italic">X</tspan> + <tspan font-style="italic">Y</tspan> &gt; <tspan font-style="italic">Z</tspan>.</text>
+
+                    <defs>
+                        <marker id="arrow39c" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+                            <polygon points="0 0, 10 3.5, 0 7" fill="#2f4f4f"/>
+                        </marker>
+                    </defs>
+                </svg>
+                <figcaption>Figure 39.3: The migration path&mdash;from monitoring and standardization through a soft fork to user migration, completed before the quantum threat arrives.</figcaption>
+            </figure>
 
             <div class="remark">
                 <p class="remark-title">Remark 39.13 (The 20-Year Window)</p>

--- a/chapters/40-monetary-future.html
+++ b/chapters/40-monetary-future.html
@@ -310,6 +310,50 @@
                 evaluated at a round circulating supply of roughly 20 million BTC.
             </p>
 
+            <figure>
+                <svg class="diagram" width="500" height="300" viewBox="0 0 500 300">
+                    <!-- Digital Gold (top-left) -->
+                    <rect x="15" y="15" width="220" height="80" rx="6" fill="#f8f5f0" stroke="#2f4f4f" stroke-width="1.5"/>
+                    <text x="125" y="37" text-anchor="middle" font-family="Georgia" font-size="11" font-weight="bold">Digital Gold</text>
+                    <text x="125" y="54" text-anchor="middle" font-family="Georgia" font-size="10" fill="#666">10&ndash;40% of gold's market cap</text>
+                    <text x="125" y="68" text-anchor="middle" font-family="Georgia" font-size="10" fill="#666">($1.5&ndash;6 trillion)</text>
+                    <text x="125" y="82" text-anchor="middle" font-family="Georgia" font-size="10" fill="#666">price $75,000&ndash;300,000</text>
+
+                    <!-- Global Reserve Asset (top-right) -->
+                    <rect x="265" y="15" width="220" height="80" rx="6" fill="#f8f5f0" stroke="#2f4f4f" stroke-width="1.5"/>
+                    <text x="375" y="37" text-anchor="middle" font-family="Georgia" font-size="11" font-weight="bold">Global Reserve Asset</text>
+                    <text x="375" y="54" text-anchor="middle" font-family="Georgia" font-size="10" fill="#666">market cap at or above gold's</text>
+                    <text x="375" y="68" text-anchor="middle" font-family="Georgia" font-size="10" fill="#666">(~$15 trillion or more)</text>
+                    <text x="375" y="82" text-anchor="middle" font-family="Georgia" font-size="10" fill="#666">price $700,000&ndash;1,500,000</text>
+
+                    <!-- Global Base Money (bottom-left) -->
+                    <rect x="15" y="205" width="220" height="80" rx="6" fill="#f8f5f0" stroke="#2f4f4f" stroke-width="1.5"/>
+                    <text x="125" y="227" text-anchor="middle" font-family="Georgia" font-size="11" font-weight="bold">Global Base Money</text>
+                    <text x="125" y="244" text-anchor="middle" font-family="Georgia" font-size="10" fill="#666">majority of the global monetary base</text>
+                    <text x="125" y="258" text-anchor="middle" font-family="Georgia" font-size="10" fill="#666">universal unit of account</text>
+                    <text x="125" y="272" text-anchor="middle" font-family="Georgia" font-size="10" fill="#666">prices quoted in satoshis</text>
+
+                    <!-- Niche or Failure (bottom-right) -->
+                    <rect x="265" y="205" width="220" height="80" rx="6" fill="#f8f5f0" stroke="#2f4f4f" stroke-width="1.5"/>
+                    <text x="375" y="227" text-anchor="middle" font-family="Georgia" font-size="11" font-weight="bold">Niche or Failure</text>
+                    <text x="375" y="244" text-anchor="middle" font-family="Georgia" font-size="10" fill="#666">market cap below $100 billion</text>
+                    <text x="375" y="258" text-anchor="middle" font-family="Georgia" font-size="10" fill="#666">limited to ideological users</text>
+                    <text x="375" y="272" text-anchor="middle" font-family="Georgia" font-size="10" fill="#666">no mainstream adoption</text>
+
+                    <!-- Central node -->
+                    <rect x="180" y="128" width="140" height="44" rx="6" fill="#fff" stroke="#2f4f4f" stroke-width="1.5"/>
+                    <text x="250" y="147" text-anchor="middle" font-family="Georgia" font-size="11" font-weight="bold">Bitcoin's monetary</text>
+                    <text x="250" y="162" text-anchor="middle" font-family="Georgia" font-size="11" font-weight="bold">future?</text>
+
+                    <!-- Equal branches -->
+                    <line x1="210" y1="97" x2="195" y2="126" stroke="#666" stroke-width="1.5"/>
+                    <line x1="290" y1="97" x2="305" y2="126" stroke="#666" stroke-width="1.5"/>
+                    <line x1="210" y1="203" x2="195" y2="174" stroke="#666" stroke-width="1.5"/>
+                    <line x1="290" y1="203" x2="305" y2="174" stroke="#666" stroke-width="1.5"/>
+                </svg>
+                <figcaption>Figure 40.1: The four scenarios of Section 40.4 for Bitcoin's monetary future, drawn as equal branches&mdash;the chapter takes no position on which outcome obtains.</figcaption>
+            </figure>
+
             <div class="definition">
                 <p class="definition-title">Definition 40.4 (Scenario: Digital Gold)</p>
                 <p>
@@ -739,6 +783,49 @@
                     legacy system.</li>
                 </ul>
             </div>
+
+            <figure>
+                <svg class="diagram" width="500" height="290" viewBox="0 0 500 290">
+                    <!-- Layer 4 (top) -->
+                    <rect x="95" y="20" width="310" height="56" rx="6" fill="#f8f5f0" stroke="#666" stroke-width="1.5"/>
+                    <text x="250" y="39" text-anchor="middle" font-family="Georgia" font-size="11" font-weight="bold">Layer 4 &mdash; Fiat / stablecoins</text>
+                    <text x="250" y="54" text-anchor="middle" font-family="Georgia" font-size="10" fill="#666">unit of account for commerce, backed by BTC reserves</text>
+                    <text x="250" y="68" text-anchor="middle" font-family="Georgia" font-size="10" fill="#666">familiar user experience, bridge to the legacy system</text>
+
+                    <!-- Layer 3 -->
+                    <rect x="95" y="86" width="310" height="56" rx="6" fill="#f5f8f0" stroke="#5a8f5a" stroke-width="1.5"/>
+                    <text x="250" y="105" text-anchor="middle" font-family="Georgia" font-size="11" font-weight="bold">Layer 3 &mdash; Bitcoin banks / custodians</text>
+                    <text x="250" y="120" text-anchor="middle" font-family="Georgia" font-size="10" fill="#666">fractional reserve possible, regulated and insured</text>
+                    <text x="250" y="134" text-anchor="middle" font-family="Georgia" font-size="10" fill="#666">trade-off: convenience vs sovereignty</text>
+
+                    <!-- Layer 2 -->
+                    <rect x="95" y="152" width="310" height="56" rx="6" fill="#f0f5f8" stroke="#4a90d9" stroke-width="1.5"/>
+                    <text x="250" y="171" text-anchor="middle" font-family="Georgia" font-size="11" font-weight="bold">Layer 2 &mdash; Lightning / state channels</text>
+                    <text x="250" y="186" text-anchor="middle" font-family="Georgia" font-size="10" fill="#666">fast payments, low fees, BTC-denominated</text>
+                    <text x="250" y="200" text-anchor="middle" font-family="Georgia" font-size="10" fill="#666">self-custodial option</text>
+
+                    <!-- Layer 1 (base) -->
+                    <rect x="95" y="218" width="310" height="56" rx="6" fill="#fff8f0" stroke="#8b4513" stroke-width="1.5"/>
+                    <text x="250" y="237" text-anchor="middle" font-family="Georgia" font-size="11" font-weight="bold">Layer 1 &mdash; Bitcoin base layer</text>
+                    <text x="250" y="252" text-anchor="middle" font-family="Georgia" font-size="10" fill="#666">final settlement, maximum security</text>
+                    <text x="250" y="266" text-anchor="middle" font-family="Georgia" font-size="10" fill="#666">minimum throughput, reserve asset status</text>
+
+                    <!-- Convenience arrow (up) -->
+                    <line x1="55" y1="260" x2="55" y2="34" stroke="#666" stroke-width="1.5" marker-end="url(#arrowGray40b)"/>
+                    <text x="38" y="147" text-anchor="middle" font-family="Georgia" font-size="10" fill="#666" transform="rotate(-90 38 147)">convenience increases</text>
+
+                    <!-- Security arrow (down) -->
+                    <line x1="445" y1="34" x2="445" y2="260" stroke="#666" stroke-width="1.5" marker-end="url(#arrowGray40b)"/>
+                    <text x="462" y="147" text-anchor="middle" font-family="Georgia" font-size="10" fill="#666" transform="rotate(90 462 147)">security increases</text>
+
+                    <defs>
+                        <marker id="arrowGray40b" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+                            <polygon points="0 0, 10 3.5, 0 7" fill="#666"/>
+                        </marker>
+                    </defs>
+                </svg>
+                <figcaption>Figure 40.2: The layer model of Definition 40.13&mdash;each layer trades security for convenience as one moves up the stack.</figcaption>
+            </figure>
         </section>
 
         <section>


### PR DESCRIPTION
Ch 25, 38, 39, 40 had zero real diagrams (the counted SVG was the favicon data-URI); Ch 34 had one figure in 850 lines. This adds 13 house-style figures, every one depicting only facts already in its chapter's text:

- **Ch 25**: SPV vs full-node verification checklists (strict subset); on-chain vs layer-2 scaling using Example 25.1's numbers; 51% can/cannot boundary from Proposition 25.8
- **Ch 34**: activation-game payoff crossing at e = 1/2 with the e = 0.8 worked example (Prop 34.1); trust-drift ladder with the table's six rungs and per-step losses
- **Ch 38**: halving staircase (log scale, chapter's subsidy schedule) with dashed fee takeover; security condition region diagram (Remark 38.2 budget levels); three budget models from Examples 38.1-38.3
- **Ch 39**: Shor vs Grover threat split (Def 39.3/39.6 numbers); pubkey exposure by output type (Def 39.4); migration timeline with Mosca's inequality (Remark 39.12)
- **Ch 40**: neutral four-scenario map (equal weight, no preferred outcome — preserves the chapter's stated neutrality); four-layer monetary stack from Definition 40.13

QA: all 13 rendered via .task/render_svgs.py and visually inspected (by the authoring agents AND independently); tag balance OK on all five files; figure numbers sequential per chapter; palette check clean (the two grays flagged in Ch 34 are pre-existing in old Figure 34.1); diff is 688 insertions, 0 deletions.

Fixes #163