### PR TITLE
Seam fixes from verification read

### DIFF
--- a/chapters/25-debunking-myths.html
+++ b/chapters/25-debunking-myths.html
@@ -371,7 +371,7 @@
                 leaving base-layer requirements unchanged (Example 25.1). Larger blocks are
                 one scaling instrument among several, with costs concentrated on verification
                 (Chapter 15); the claim that they are the only instrument does not survive the
-                comparison, and the costs of layer 2 itself are recorded in Remark 25.5.
+                comparison, even after layer 2 is charged with the costs of Remark 25.5.
             </p>
 
             <hr>
@@ -450,8 +450,8 @@
             </div>
 
             <p>
-                The risk is real but bounded. Checking more often than the negotiated
-                to_self_delay is sufficient&mdash;once per week comfortably covers a
+                The risk is real but bounded. Checking at intervals shorter than the
+                negotiated to_self_delay is sufficient&mdash;once per week comfortably covers a
                 2016-block (2 week) delay. Watchtowers (Chapter 23) delegate the task, at the
                 cost of assuming the watchtower is online and honest.
             </p>
@@ -500,7 +500,7 @@
                 <ul>
                     <li>Grover's provides only a <span class="math">√N</span> speedup (not exponential)</li>
                     <li>Difficulty adjustment compensates automatically</li>
-                    <li>Script-level uses of SHA-256 could be supplemented by soft fork; replacing the proof-of-work or transaction-identifier hash would be a hard fork requiring the coordination of Chapter 16</li>
+                    <li>Replacing SHA-256 itself, were it ever necessary, is the fork question analyzed under Claim 25.7</li>
                 </ul>
             </div>
 
@@ -589,10 +589,11 @@
                     <li>Spend coins for which it does not hold keys</li>
                     <li>Create coins beyond the subsidy schedule</li>
                     <li>Change consensus rules (full nodes reject invalid blocks)</li>
-                    <li>Prevent users from transacting on a minority chain that changes the
-                        proof-of-work function (Chapter 26), or once the attack ceases&mdash;a
-                        minority chain retaining the same proof-of-work can be reorganized at
-                        low marginal cost for as long as the attack is sustained</li>
+                    <li>Prevent users from transacting on a minority chain&mdash;immediately,
+                        if that chain changes the proof-of-work function (Chapter 26), or once
+                        the attack ceases, if it retains the same proof-of-work; while the
+                        attack is sustained, a same-proof-of-work minority chain can be
+                        reorganized at low marginal cost</li>
                 </ul>
             </div>
 
@@ -846,7 +847,7 @@
                     <li>As long as some miners include a transaction and the majority does not orphan their blocks, it eventually confirms (soft censorship, Definition 36.6): with non-censoring fraction <span class="math">q</span> of hashrate, the expected inclusion delay is <span class="math">1/q</span> blocks&mdash;and censored users can pay higher fees to non-censoring miners</li>
                 </ul>
                 <p>
-                    Two caveats sharpen the claim rather than weaken it. A majority
+                    Two caveats sharpen the analysis rather than weaken it. A majority
                     coalition willing to orphan non-compliant blocks could enforce hard
                     censorship (Definition 36.6)&mdash;at the visible cost of attacking the
                     chain itself. And a soft fork could, in principle, make specific outputs
@@ -1121,7 +1122,7 @@
             <div class="exercise">
                 <p><strong>Exercise 25.1</strong></p>
                 <p>
-                    A claim states: "Bitcoin is deflationary because 21 million coins."
+                    Consider the claim: "Bitcoin is deflationary because 21 million coins."
                     Apply the evaluation procedure (Remark 25.16). Is this technically
                     correct? What nuance is missing?
                 </p>

--- a/chapters/26-fork-theory.html
+++ b/chapters/26-fork-theory.html
@@ -785,7 +785,7 @@
                         <tr>
                             <td>Taproot (soft)</td>
                             <td>2021</td>
-                            <td>Low (substance broadly supported; activation mechanism disputed&mdash;Section 33.7.2)</td>
+                            <td>Mild (substance broadly supported; activation mechanism disputed&mdash;Section 33.7.2)</td>
                             <td>Universal adoption</td>
                         </tr>
                     </tbody>

--- a/chapters/27-historical-forks.html
+++ b/chapters/27-historical-forks.html
@@ -163,7 +163,7 @@ if (block.GetSerializeSize() > MAX_BLOCK_SIZE)
                     <li><strong>Insufficient miner signaling:</strong> Never approached 75% threshold</li>
                     <li><strong>Community opposition:</strong> Perceived as hostile takeover</li>
                     <li><strong>Technical concerns:</strong> Exponential growth criticized as reckless</li>
-                    <li><strong>DDoS attacks:</strong> XT nodes were targeted by denial-of-service attacks whose origin was never attributed</li>
+                    <li><strong>DDoS attacks:</strong> XT nodes were targeted; the attackers were never identified</li>
                 </ol>
                 <p>
                     Peak XT node share: ~12% (late 2015), then rapid decline.
@@ -682,7 +682,7 @@ if (timeSince6Blocks > 12 hours):
                     <li>Hard forks require broader social consensus than soft forks</li>
                 </ul>
                 <p>
-                    The episode strengthened the "User Activated" model of consensus.
+                    Its failure strengthened the "User Activated" model of consensus.
                 </p>
             </div>
         </section>
@@ -819,8 +819,7 @@ if (timeSince6Blocks > 12 hours):
                 </ul>
                 <p>
                     The ability to fork, though rarely exercised successfully, serves a
-                    structural function: it bounds what any majority can impose (the exit
-                    option of Chapter 26).
+                    structural function: it bounds what any majority can impose.
                 </p>
             </div>
         </section>

--- a/chapters/29-taproot-architecture.html
+++ b/chapters/29-taproot-architecture.html
@@ -579,7 +579,7 @@ Stack after:  [n] (or [n+1] if valid)
                     <li>Alice uses <span class="math">t</span> to complete her side of the swap</li>
                 </ol>
                 <p>
-                    Given timeout branches that enable refunds after a deadline <span class="math">T</span>,
+                    Given timeout branches that enable refunds after a deadline,
                     either both transactions complete or neither does: neither party can
                     complete their side while denying the other the secret.
                 </p>

--- a/chapters/31-sidechains.html
+++ b/chapters/31-sidechains.html
@@ -541,7 +541,7 @@
                 <p class="remark-title">Remark 31.7 (Why It Did Not Activate)</p>
                 <p>
                     Critics held that the design asks users to trust two parties the base
-                    layer does not: a miner majority can vote deposits to itself&mdash;slowly
+                    layer does not ask them to trust: a miner majority can vote deposits to itself&mdash;slowly
                     and in public, which proponents argued is the defense (the theft is
                     visible and punishable, up to a user-activated soft fork) and which
                     critics judged a description of the design rather than an attack on it.

--- a/chapters/32-beyond-lightning.html
+++ b/chapters/32-beyond-lightning.html
@@ -104,9 +104,9 @@
             <div class="definition">
                 <p class="definition-title">Definition 32.2 (Ark Round)</p>
                 <p>
-                    The ASP periodically creates a <strong>round</strong>&mdash;the design
+                    The ASP periodically creates a <strong>round</strong> (the design
                     calls for rounds every few seconds; deployed implementations batch
-                    less frequently:
+                    less frequently):
                 </p>
                 <ol>
                     <li>Collects payment intents from users</li>
@@ -170,8 +170,8 @@
                     Tradeoffs:
                 </p>
                 <ul>
-                    <li><strong>ASP trust:</strong> Liveness trust, plus the obligation to refresh before expiry (after expiry, unswept funds are claimable by the ASP)</li>
-                    <li><strong>Expiring vTXOs:</strong> Must refresh before expiry</li>
+                    <li><strong>ASP trust:</strong> Liveness trust before vTXO expiry</li>
+                    <li><strong>Expiring vTXOs:</strong> Must refresh before expiry; afterwards, unswept funds are claimable by the ASP</li>
                     <li><strong>ASP capital:</strong> ASP must lock significant BTC</li>
                 </ul>
             </div>

--- a/chapters/39-quantum-resistance.html
+++ b/chapters/39-quantum-resistance.html
@@ -53,7 +53,8 @@
                 </ol>
                 <p>
                     The first threat is severe and requires eventual migration. The second is
-                    less concerning and can be addressed by increasing key sizes.
+                    less concerning: difficulty adjustment compensates, and a larger hash
+                    output would restore the original margin (Remark 39.4).
                 </p>
             </div>
 
@@ -1151,7 +1152,7 @@ One Plausible Sequencing (illustrative):
 
             <ul>
                 <li><strong>Shor's algorithm:</strong> if fault-tolerant quantum computers are built, it breaks ECDSA; on prevailing expert timelines, preparation is prudent</li>
-                <li><strong>Grover's algorithm</strong> halves hash security&mdash;doubling key size fixes it</li>
+                <li><strong>Grover's algorithm</strong> halves effective hash security&mdash;doubling the hash output size would restore the margin (Remark 39.4)</li>
                 <li><strong>Timeline:</strong> Likely 15-25 years, but uncertain</li>
                 <li><strong>NIST standards</strong> (ML-DSA, SPHINCS+) provide ready alternatives</li>
                 <li><strong>Signatures will be larger</strong>&mdash;5-100x current size</li>

--- a/chapters/40-monetary-future.html
+++ b/chapters/40-monetary-future.html
@@ -936,8 +936,8 @@
                 covered the technical foundations, economic principles, and philosophical
                 implications of this technology. The preceding chapters establish
                 the foundation for understanding, using, and contributing to Bitcoin's
-                ongoing development. Whatever follows, Bitcoin has demonstrated that
-                decentralized digital money is possible; the demonstration stands.
+                ongoing development. The monetary questions of this volume remain
+                open; the mathematics on which they rest does not.
             </p>
         </section>
 


### PR DESCRIPTION
Three fresh-eyes agents read every changed hunk of PR #168 in context. 16 small fixes, all content-preserving:

- **Ch 25** (6): de-duplicated the SHA-256-replacement sentence (kept in Claim 25.7, pointer from Remark 25.8); "sharpen the claim" → "sharpen the analysis" (referent was backwards); frequency-vs-duration fix in the to_self_delay sentence; restructured the dangling "or once the attack ceases" clause in Proposition 25.2; removed a doubled Remark 25.5 pointer; exercise phrasing aligned with Example 25.4.
- **Ch 26** (1): Taproot contention table "Low" → "Mild" to match Definition 26.12's actual category names.
- **Ch 27** (3): un-doubled the DDoS label; un-doubled "The episode..." openers; removed a dangling "(the exit option of Chapter 26)" reference.
- **Ch 29** (1): dropped the inserted "deadline T" symbol that clashed with the adaptor point T = t·G defined two lines above.
- **Ch 31** (1): "trust two parties the base layer does not:" → "does not ask them to trust" (the ellipsis misparsed).
- **Ch 32** (2): colon/aside misparse in Definition 32.2; de-duplicated the refresh-before-expiry caveat across two bullets.
- **Ch 39** (2): "doubling key size fixes it" → "doubling the hash output size would restore the margin" in both the summary bullet and Remark 39.1 (Grover affects the hash, not keys).
- **Ch 40** (1): the new book-closing sentence nearly duplicated §40.11's existing "demonstration" paragraph → replaced with "The monetary questions of this volume remain open; the mathematics on which they rest does not."

Also verified clean by the read: Ch 14/24/28/30/33/34/35/36/37/38 (incl. Ch 38 threat-table arithmetic recomputed, Ch 35 log₄ arithmetic, Ch 36 probability bounds, all renumbered-environment references repo-wide).

Fixes #169