### PR TITLE
Remove DRAFT badges and (Draft) footers from Volumes IV-V

### DIFF
--- a/chapters/26-fork-theory.html
+++ b/chapters/26-fork-theory.html
@@ -865,7 +865,7 @@
     </main>
 
     <footer>
-        <p>Elementary Bitcoin · Volume IV: Forks and Futures (Draft)</p>
+        <p>Elementary Bitcoin · Volume IV: Forks and Futures</p>
     </footer>
 </body>
 </html>

--- a/chapters/27-historical-forks.html
+++ b/chapters/27-historical-forks.html
@@ -882,7 +882,7 @@ if (timeSince6Blocks > 12 hours):
     </main>
 
     <footer>
-        <p>Elementary Bitcoin · Volume IV: Forks and Futures (Draft)</p>
+        <p>Elementary Bitcoin · Volume IV: Forks and Futures</p>
     </footer>
 </body>
 </html>

--- a/chapters/28-segwit-deep-dive.html
+++ b/chapters/28-segwit-deep-dive.html
@@ -943,7 +943,7 @@ witness:      &lt;sig&gt; &lt;pubkey&gt;</pre>
     </main>
 
     <footer>
-        <p>Elementary Bitcoin · Volume IV: Forks and Futures (Draft)</p>
+        <p>Elementary Bitcoin · Volume IV: Forks and Futures</p>
     </footer>
 </body>
 </html>

--- a/chapters/29-taproot-architecture.html
+++ b/chapters/29-taproot-architecture.html
@@ -731,7 +731,7 @@ Stack after:  [n] (or [n+1] if valid)
     </main>
 
     <footer>
-        <p>Elementary Bitcoin · Volume IV: Forks and Futures (Draft)</p>
+        <p>Elementary Bitcoin · Volume IV: Forks and Futures</p>
     </footer>
 </body>
 </html>

--- a/chapters/30-covenants.html
+++ b/chapters/30-covenants.html
@@ -745,7 +745,7 @@ Stack: [1 if valid]</pre>
     </main>
 
     <footer>
-        <p>Elementary Bitcoin · Volume IV: Forks and Futures (Draft)</p>
+        <p>Elementary Bitcoin · Volume IV: Forks and Futures</p>
     </footer>
 </body>
 </html>

--- a/chapters/31-sidechains.html
+++ b/chapters/31-sidechains.html
@@ -607,7 +607,7 @@
     </main>
 
     <footer>
-        <p>Elementary Bitcoin · Volume IV: Forks and Futures (Draft)</p>
+        <p>Elementary Bitcoin · Volume IV: Forks and Futures</p>
     </footer>
 </body>
 </html>

--- a/chapters/32-beyond-lightning.html
+++ b/chapters/32-beyond-lightning.html
@@ -501,7 +501,7 @@
     </main>
 
     <footer>
-        <p>Elementary Bitcoin · Volume IV: Forks and Futures (Draft)</p>
+        <p>Elementary Bitcoin · Volume IV: Forks and Futures</p>
     </footer>
 </body>
 </html>

--- a/chapters/33-governance.html
+++ b/chapters/33-governance.html
@@ -858,7 +858,7 @@
     </main>
 
     <footer>
-        <p>Elementary Bitcoin · Volume IV: Forks and Futures (Draft)</p>
+        <p>Elementary Bitcoin · Volume IV: Forks and Futures</p>
     </footer>
 </body>
 </html>

--- a/chapters/34-scaling-verification.html
+++ b/chapters/34-scaling-verification.html
@@ -986,7 +986,7 @@
     </main>
 
     <footer>
-        <p>Elementary Bitcoin · Volume IV: Forks and Futures (Draft)</p>
+        <p>Elementary Bitcoin · Volume IV: Forks and Futures</p>
     </footer>
 </body>
 </html>

--- a/chapters/35-consensus-cleanup.html
+++ b/chapters/35-consensus-cleanup.html
@@ -527,7 +527,7 @@ Different blocks, same merkle root → attack vector</pre>
     </main>
 
     <footer>
-        <p>Elementary Bitcoin · Volume IV: Forks and Futures (Draft)</p>
+        <p>Elementary Bitcoin · Volume IV: Forks and Futures</p>
     </footer>
 </body>
 </html>

--- a/chapters/36-security-threats.html
+++ b/chapters/36-security-threats.html
@@ -540,7 +540,7 @@
     </main>
 
     <footer>
-        <p>Elementary Bitcoin · Volume V: The Path to a Sustainable Future (Draft)</p>
+        <p>Elementary Bitcoin · Volume V: The Path to a Sustainable Future</p>
     </footer>
 </body>
 </html>

--- a/chapters/37-defense-mechanisms.html
+++ b/chapters/37-defense-mechanisms.html
@@ -625,7 +625,7 @@ nMinimumChainWork = 0x0000000000000000000000000000000000000000
     </main>
 
     <footer>
-        <p>Elementary Bitcoin · Volume V: The Path to a Sustainable Future (Draft)</p>
+        <p>Elementary Bitcoin · Volume V: The Path to a Sustainable Future</p>
     </footer>
 </body>
 </html>

--- a/chapters/38-security-budget.html
+++ b/chapters/38-security-budget.html
@@ -1156,7 +1156,7 @@ Security Budget Timeline:
     </main>
 
     <footer>
-        <p>Elementary Bitcoin · Volume V: The Path to a Sustainable Future (Draft)</p>
+        <p>Elementary Bitcoin · Volume V: The Path to a Sustainable Future</p>
     </footer>
 </body>
 </html>

--- a/chapters/39-quantum-resistance.html
+++ b/chapters/39-quantum-resistance.html
@@ -1248,7 +1248,7 @@ One Plausible Sequencing (illustrative):
     </main>
 
     <footer>
-        <p>Elementary Bitcoin · Volume V: The Path to a Sustainable Future (Draft)</p>
+        <p>Elementary Bitcoin · Volume V: The Path to a Sustainable Future</p>
     </footer>
 </body>
 </html>

--- a/chapters/40-monetary-future.html
+++ b/chapters/40-monetary-future.html
@@ -1013,7 +1013,7 @@
     </main>
 
     <footer>
-        <p>Elementary Bitcoin · Volume V: The Path to a Sustainable Future (Draft)</p>
+        <p>Elementary Bitcoin · Volume V: The Path to a Sustainable Future</p>
         <p><em>End of Volume V</em></p>
     </footer>
 </body>

--- a/index.html
+++ b/index.html
@@ -105,14 +105,6 @@
             color: #888;
             margin-left: 1rem;
         }
-        .volume-list .vol-draft {
-            background: #fff3cd;
-            color: #c87f0a;
-            padding: 0.2rem 0.5rem;
-            border-radius: 4px;
-            font-size: 0.75rem;
-            margin-left: 0.5rem;
-        }
         .current-volume {
             background: #fff8f0;
         }
@@ -228,13 +220,11 @@
                 <li>
                     <span class="vol-num">Volume IV:</span>
                     <span class="vol-title">Forks and Futures</span>
-                    <span class="vol-draft">DRAFT</span>
                     <span class="vol-status">— the contested present, positions attributed</span>
                 </li>
                 <li>
                     <span class="vol-num">Volume V:</span>
                     <span class="vol-title">The Path to a Sustainable Future</span>
-                    <span class="vol-draft">DRAFT</span>
                     <span class="vol-status">— disciplined speculation, labeled as such</span>
                 </li>
             </ul>
@@ -516,8 +506,8 @@
             <p class="toc-desc">Claims about SPV · Scaling claims · Cryptographic concerns · Consensus claims · Economic claims · A procedure for evaluating claims</p>
         </section>
 
-        <!-- Volume IV (Draft) -->
-        <h2 style="text-align: center; font-variant: small-caps; letter-spacing: 0.15em; margin: 3rem 0 1rem; color: #8b4513;">Volume IV · Forks and Futures <span style="background: #fff3cd; color: #c87f0a; padding: 0.2rem 0.6rem; border-radius: 4px; font-size: 0.6em; vertical-align: middle;">DRAFT</span></h2>
+        <!-- Volume IV -->
+        <h2 style="text-align: center; font-variant: small-caps; letter-spacing: 0.15em; margin: 3rem 0 1rem; color: #8b4513;">Volume IV · Forks and Futures</h2>
 
         <section class="toc-section">
             <h3>Part XI · Fork Theory and History</h3>
@@ -601,8 +591,8 @@
             <p class="toc-desc">Timewarp attack · 64-byte transaction vulnerability · Merkle tree CVE · Legacy validation costs · Proposed fixes</p>
         </section>
 
-        <!-- Volume V (Draft) -->
-        <h2 style="text-align: center; font-variant: small-caps; letter-spacing: 0.15em; margin: 3rem 0 1rem; color: #2f4f4f;">Volume V · The Path to a Sustainable Future <span style="background: #fff3cd; color: #c87f0a; padding: 0.2rem 0.6rem; border-radius: 4px; font-size: 0.6em; vertical-align: middle;">DRAFT</span></h2>
+        <!-- Volume V -->
+        <h2 style="text-align: center; font-variant: small-caps; letter-spacing: 0.15em; margin: 3rem 0 1rem; color: #2f4f4f;">Volume V · The Path to a Sustainable Future</h2>
 
         <section class="toc-section">
             <h3>Part XVI · Long-Term Security</h3>
@@ -676,9 +666,6 @@
         <p>Elementary Bitcoin · Volumes I–V</p>
         <p style="font-style: italic; margin-top: 1rem;">
             "We build understanding link by link, block by block."
-        </p>
-        <p style="margin-top: 1rem; font-size: 0.8rem; color: #aaa;">
-            Volumes IV & V are drafts undergoing revision
         </p>
     </footer>
 </body>


### PR DESCRIPTION
Volumes IV-V have been through two deep review rounds, the figure pass, the Volume I voice pass (PR #168), and a seam verification read (PR #170) — they are now held to the same standard as the rest of the book.

Removed:
- Homepage volume-overview DRAFT tags (the epistemic-status descriptions remain: "the contested present, positions attributed" / "disciplined speculation, labeled as such" — those carry the honest signal without the discount-this badge)
- TOC volume-header DRAFT badges
- Colophon "Volumes IV & V are drafts undergoing revision" line
- Now-unused .vol-draft CSS rule
- "(Draft)" suffix on all 15 Vol IV/V chapter footers

Untouched: BIP-status "Draft" entries in Ch 30's proposal table and Ch 33's lifecycle figure (content, not status markers).

Fixes #171