### PR TITLE
Authorship + CC BY-SA 4.0 colophon, Ch 40 appendix nav handoff

### DIFF
--- a/chapters/01-groups.html
+++ b/chapters/01-groups.html
@@ -774,6 +774,7 @@
 
     <footer>
         <p><a href="../index.html">Elementary Bitcoin</a> · A Mathematical Introduction</p>
+        <p style="font-size: 0.85em;"><a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a> &middot; <a href="https://github.com/elementarybitcoin/elementarybitcoin.github.io">contribute</a></p>
     </footer>
 </body>
 </html>

--- a/chapters/02-finite-fields.html
+++ b/chapters/02-finite-fields.html
@@ -895,6 +895,7 @@ function power_mod(a, k, n):
 
     <footer>
         <p><a href="../index.html">Elementary Bitcoin</a> · A Mathematical Introduction</p>
+        <p style="font-size: 0.85em;"><a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a> &middot; <a href="https://github.com/elementarybitcoin/elementarybitcoin.github.io">contribute</a></p>
     </footer>
 </body>
 </html>

--- a/chapters/03-elliptic-curves-real.html
+++ b/chapters/03-elliptic-curves-real.html
@@ -804,6 +804,7 @@ function scalar_multiply(n, P):
 
     <footer>
         <p><a href="../index.html">Elementary Bitcoin</a> · A Mathematical Introduction</p>
+        <p style="font-size: 0.85em;"><a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a> &middot; <a href="https://github.com/elementarybitcoin/elementarybitcoin.github.io">contribute</a></p>
     </footer>
 </body>
 </html>

--- a/chapters/04-elliptic-curves-finite.html
+++ b/chapters/04-elliptic-curves-finite.html
@@ -701,6 +701,7 @@
 
     <footer>
         <p><a href="../index.html">Elementary Bitcoin</a> · A Mathematical Introduction</p>
+        <p style="font-size: 0.85em;"><a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a> &middot; <a href="https://github.com/elementarybitcoin/elementarybitcoin.github.io">contribute</a></p>
     </footer>
 </body>
 </html>

--- a/chapters/05-secp256k1.html
+++ b/chapters/05-secp256k1.html
@@ -735,6 +735,7 @@ FD17B448 A6855419 9C47D08F FB10D4B8</pre>
 
     <footer>
         <p><a href="../index.html">Elementary Bitcoin</a> · A Mathematical Introduction</p>
+        <p style="font-size: 0.85em;"><a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a> &middot; <a href="https://github.com/elementarybitcoin/elementarybitcoin.github.io">contribute</a></p>
     </footer>
 </body>
 </html>

--- a/chapters/06-hash-functions.html
+++ b/chapters/06-hash-functions.html
@@ -573,6 +573,7 @@
 
     <footer>
         <p><a href="../index.html">Elementary Bitcoin</a> · A Mathematical Introduction</p>
+        <p style="font-size: 0.85em;"><a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a> &middot; <a href="https://github.com/elementarybitcoin/elementarybitcoin.github.io">contribute</a></p>
     </footer>
 </body>
 </html>

--- a/chapters/07-ecdsa.html
+++ b/chapters/07-ecdsa.html
@@ -722,6 +722,7 @@ Verify(P, m, (r, s)):
 
     <footer>
         <p><a href="../index.html">Elementary Bitcoin</a> · A Mathematical Introduction</p>
+        <p style="font-size: 0.85em;"><a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a> &middot; <a href="https://github.com/elementarybitcoin/elementarybitcoin.github.io">contribute</a></p>
     </footer>
 </body>
 </html>

--- a/chapters/08-schnorr.html
+++ b/chapters/08-schnorr.html
@@ -780,6 +780,7 @@ Verify(pk, m, sig):
 
     <footer>
         <p><a href="../index.html">Elementary Bitcoin</a> · A Mathematical Introduction</p>
+        <p style="font-size: 0.85em;"><a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a> &middot; <a href="https://github.com/elementarybitcoin/elementarybitcoin.github.io">contribute</a></p>
     </footer>
 </body>
 </html>

--- a/chapters/09-keys-addresses.html
+++ b/chapters/09-keys-addresses.html
@@ -1000,6 +1000,7 @@
 
     <footer>
         <p>Elementary Bitcoin · Volume II: Protocol Architecture</p>
+        <p style="font-size: 0.85em;"><a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a> &middot; <a href="https://github.com/elementarybitcoin/elementarybitcoin.github.io">contribute</a></p>
     </footer>
 </body>
 </html>

--- a/chapters/10-transactions.html
+++ b/chapters/10-transactions.html
@@ -859,6 +859,7 @@ efcdab78563412...f6e5d4c3b2a1
 
     <footer>
         <p>Elementary Bitcoin · Volume II: Protocol Architecture</p>
+        <p style="font-size: 0.85em;"><a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a> &middot; <a href="https://github.com/elementarybitcoin/elementarybitcoin.github.io">contribute</a></p>
     </footer>
 </body>
 </html>

--- a/chapters/11-script.html
+++ b/chapters/11-script.html
@@ -943,6 +943,7 @@ OP_2 OP_NUMEQUAL</pre>
 
     <footer>
         <p>Elementary Bitcoin · Volume II: Protocol Architecture</p>
+        <p style="font-size: 0.85em;"><a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a> &middot; <a href="https://github.com/elementarybitcoin/elementarybitcoin.github.io">contribute</a></p>
     </footer>
 </body>
 </html>

--- a/chapters/12-merkle-trees.html
+++ b/chapters/12-merkle-trees.html
@@ -763,6 +763,7 @@ E: 7e8f9a0b</pre>
 
     <footer>
         <p>Elementary Bitcoin · Volume II: Protocol Architecture</p>
+        <p style="font-size: 0.85em;"><a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a> &middot; <a href="https://github.com/elementarybitcoin/elementarybitcoin.github.io">contribute</a></p>
     </footer>
 </body>
 </html>

--- a/chapters/13-blocks.html
+++ b/chapters/13-blocks.html
@@ -893,6 +893,7 @@ nonce: 1dac2b7c</pre>
 
     <footer>
         <p>Elementary Bitcoin · Volume II: Protocol Architecture</p>
+        <p style="font-size: 0.85em;"><a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a> &middot; <a href="https://github.com/elementarybitcoin/elementarybitcoin.github.io">contribute</a></p>
     </footer>
 </body>
 </html>

--- a/chapters/14-proof-of-work.html
+++ b/chapters/14-proof-of-work.html
@@ -793,6 +793,7 @@ Daily profit = $3.60 - $3.60 = $0.00</pre>
 
     <footer>
         <p>Elementary Bitcoin · Volume II: Protocol Architecture</p>
+        <p style="font-size: 0.85em;"><a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a> &middot; <a href="https://github.com/elementarybitcoin/elementarybitcoin.github.io">contribute</a></p>
     </footer>
 </body>
 </html>

--- a/chapters/15-consensus-parameters.html
+++ b/chapters/15-consensus-parameters.html
@@ -800,6 +800,7 @@ Time between halvings: 210,000 × 10 min = 2,100,000 min
 
     <footer>
         <p>Elementary Bitcoin · Volume II: Protocol Architecture</p>
+        <p style="font-size: 0.85em;"><a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a> &middot; <a href="https://github.com/elementarybitcoin/elementarybitcoin.github.io">contribute</a></p>
     </footer>
 </body>
 </html>

--- a/chapters/16-soft-forks.html
+++ b/chapters/16-soft-forks.html
@@ -732,6 +732,7 @@
 
     <footer>
         <p>Elementary Bitcoin · Volume II: Protocol Architecture</p>
+        <p style="font-size: 0.85em;"><a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a> &middot; <a href="https://github.com/elementarybitcoin/elementarybitcoin.github.io">contribute</a></p>
     </footer>
 </body>
 </html>

--- a/chapters/17-spv-theory.html
+++ b/chapters/17-spv-theory.html
@@ -826,6 +826,7 @@
 
     <footer>
         <p>Elementary Bitcoin · Volume III: Scaling and Verification</p>
+        <p style="font-size: 0.85em;"><a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a> &middot; <a href="https://github.com/elementarybitcoin/elementarybitcoin.github.io">contribute</a></p>
     </footer>
 </body>
 </html>

--- a/chapters/18-bloom-filters.html
+++ b/chapters/18-bloom-filters.html
@@ -1121,6 +1121,7 @@
 
     <footer>
         <p>Elementary Bitcoin &mdash; Volume III: Scaling and Verification</p>
+        <p style="font-size: 0.85em;"><a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a> &middot; <a href="https://github.com/elementarybitcoin/elementarybitcoin.github.io">contribute</a></p>
     </footer>
 </body>
 </html>

--- a/chapters/19-compact-filters.html
+++ b/chapters/19-compact-filters.html
@@ -1154,6 +1154,7 @@
 
     <footer>
         <p>Elementary Bitcoin &mdash; Volume III: Scaling and Verification</p>
+        <p style="font-size: 0.85em;"><a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a> &middot; <a href="https://github.com/elementarybitcoin/elementarybitcoin.github.io">contribute</a></p>
     </footer>
 </body>
 </html>

--- a/chapters/20-light-clients.html
+++ b/chapters/20-light-clients.html
@@ -1351,6 +1351,7 @@ Response:
 
     <footer>
         <p>Elementary Bitcoin — Volume III: Scaling and Verification</p>
+        <p style="font-size: 0.85em;"><a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a> &middot; <a href="https://github.com/elementarybitcoin/elementarybitcoin.github.io">contribute</a></p>
     </footer>
 </body>
 </html>

--- a/chapters/21-node-optimizations.html
+++ b/chapters/21-node-optimizations.html
@@ -1038,6 +1038,7 @@ prune=550</code></pre>
 
     <footer>
         <p>Elementary Bitcoin — Volume III: Scaling and Verification</p>
+        <p style="font-size: 0.85em;"><a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a> &middot; <a href="https://github.com/elementarybitcoin/elementarybitcoin.github.io">contribute</a></p>
     </footer>
 </body>
 </html>

--- a/chapters/22-client-side-validation.html
+++ b/chapters/22-client-side-validation.html
@@ -914,6 +914,7 @@
 
     <footer>
         <p>Elementary Bitcoin — Volume III: Scaling and Verification</p>
+        <p style="font-size: 0.85em;"><a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a> &middot; <a href="https://github.com/elementarybitcoin/elementarybitcoin.github.io">contribute</a></p>
     </footer>
 </body>
 </html>

--- a/chapters/23-payment-channels.html
+++ b/chapters/23-payment-channels.html
@@ -867,6 +867,7 @@ OP_ENDIF</code></pre>
 
     <footer>
         <p>Elementary Bitcoin — Volume III: Scaling and Verification</p>
+        <p style="font-size: 0.85em;"><a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a> &middot; <a href="https://github.com/elementarybitcoin/elementarybitcoin.github.io">contribute</a></p>
     </footer>
 </body>
 </html>

--- a/chapters/24-lightning.html
+++ b/chapters/24-lightning.html
@@ -867,6 +867,7 @@ lnbc1pvjluezsp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygspp5qqqsyqcyq5
 
     <footer>
         <p>Elementary Bitcoin — Volume III: Scaling and Verification</p>
+        <p style="font-size: 0.85em;"><a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a> &middot; <a href="https://github.com/elementarybitcoin/elementarybitcoin.github.io">contribute</a></p>
     </footer>
 </body>
 </html>

--- a/chapters/25-debunking-myths.html
+++ b/chapters/25-debunking-myths.html
@@ -1240,6 +1240,7 @@
         <p style="font-style: italic; margin-top: 1rem;">
             "We build understanding link by link, block by block."
         </p>
+        <p style="font-size: 0.85em;"><a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a> &middot; <a href="https://github.com/elementarybitcoin/elementarybitcoin.github.io">contribute</a></p>
     </footer>
 </body>
 </html>

--- a/chapters/26-fork-theory.html
+++ b/chapters/26-fork-theory.html
@@ -866,6 +866,7 @@
 
     <footer>
         <p>Elementary Bitcoin · Volume IV: Forks and Futures</p>
+        <p style="font-size: 0.85em;"><a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a> &middot; <a href="https://github.com/elementarybitcoin/elementarybitcoin.github.io">contribute</a></p>
     </footer>
 </body>
 </html>

--- a/chapters/27-historical-forks.html
+++ b/chapters/27-historical-forks.html
@@ -883,6 +883,7 @@ if (timeSince6Blocks > 12 hours):
 
     <footer>
         <p>Elementary Bitcoin · Volume IV: Forks and Futures</p>
+        <p style="font-size: 0.85em;"><a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a> &middot; <a href="https://github.com/elementarybitcoin/elementarybitcoin.github.io">contribute</a></p>
     </footer>
 </body>
 </html>

--- a/chapters/28-segwit-deep-dive.html
+++ b/chapters/28-segwit-deep-dive.html
@@ -944,6 +944,7 @@ witness:      &lt;sig&gt; &lt;pubkey&gt;</pre>
 
     <footer>
         <p>Elementary Bitcoin · Volume IV: Forks and Futures</p>
+        <p style="font-size: 0.85em;"><a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a> &middot; <a href="https://github.com/elementarybitcoin/elementarybitcoin.github.io">contribute</a></p>
     </footer>
 </body>
 </html>

--- a/chapters/29-taproot-architecture.html
+++ b/chapters/29-taproot-architecture.html
@@ -732,6 +732,7 @@ Stack after:  [n] (or [n+1] if valid)
 
     <footer>
         <p>Elementary Bitcoin · Volume IV: Forks and Futures</p>
+        <p style="font-size: 0.85em;"><a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a> &middot; <a href="https://github.com/elementarybitcoin/elementarybitcoin.github.io">contribute</a></p>
     </footer>
 </body>
 </html>

--- a/chapters/30-covenants.html
+++ b/chapters/30-covenants.html
@@ -746,6 +746,7 @@ Stack: [1 if valid]</pre>
 
     <footer>
         <p>Elementary Bitcoin · Volume IV: Forks and Futures</p>
+        <p style="font-size: 0.85em;"><a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a> &middot; <a href="https://github.com/elementarybitcoin/elementarybitcoin.github.io">contribute</a></p>
     </footer>
 </body>
 </html>

--- a/chapters/31-sidechains.html
+++ b/chapters/31-sidechains.html
@@ -608,6 +608,7 @@
 
     <footer>
         <p>Elementary Bitcoin · Volume IV: Forks and Futures</p>
+        <p style="font-size: 0.85em;"><a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a> &middot; <a href="https://github.com/elementarybitcoin/elementarybitcoin.github.io">contribute</a></p>
     </footer>
 </body>
 </html>

--- a/chapters/32-beyond-lightning.html
+++ b/chapters/32-beyond-lightning.html
@@ -502,6 +502,7 @@
 
     <footer>
         <p>Elementary Bitcoin · Volume IV: Forks and Futures</p>
+        <p style="font-size: 0.85em;"><a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a> &middot; <a href="https://github.com/elementarybitcoin/elementarybitcoin.github.io">contribute</a></p>
     </footer>
 </body>
 </html>

--- a/chapters/33-governance.html
+++ b/chapters/33-governance.html
@@ -859,6 +859,7 @@
 
     <footer>
         <p>Elementary Bitcoin · Volume IV: Forks and Futures</p>
+        <p style="font-size: 0.85em;"><a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a> &middot; <a href="https://github.com/elementarybitcoin/elementarybitcoin.github.io">contribute</a></p>
     </footer>
 </body>
 </html>

--- a/chapters/34-scaling-verification.html
+++ b/chapters/34-scaling-verification.html
@@ -987,6 +987,7 @@
 
     <footer>
         <p>Elementary Bitcoin · Volume IV: Forks and Futures</p>
+        <p style="font-size: 0.85em;"><a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a> &middot; <a href="https://github.com/elementarybitcoin/elementarybitcoin.github.io">contribute</a></p>
     </footer>
 </body>
 </html>

--- a/chapters/35-consensus-cleanup.html
+++ b/chapters/35-consensus-cleanup.html
@@ -528,6 +528,7 @@ Different blocks, same merkle root → attack vector</pre>
 
     <footer>
         <p>Elementary Bitcoin · Volume IV: Forks and Futures</p>
+        <p style="font-size: 0.85em;"><a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a> &middot; <a href="https://github.com/elementarybitcoin/elementarybitcoin.github.io">contribute</a></p>
     </footer>
 </body>
 </html>

--- a/chapters/36-security-threats.html
+++ b/chapters/36-security-threats.html
@@ -541,6 +541,7 @@
 
     <footer>
         <p>Elementary Bitcoin · Volume V: The Path to a Sustainable Future</p>
+        <p style="font-size: 0.85em;"><a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a> &middot; <a href="https://github.com/elementarybitcoin/elementarybitcoin.github.io">contribute</a></p>
     </footer>
 </body>
 </html>

--- a/chapters/37-defense-mechanisms.html
+++ b/chapters/37-defense-mechanisms.html
@@ -626,6 +626,7 @@ nMinimumChainWork = 0x0000000000000000000000000000000000000000
 
     <footer>
         <p>Elementary Bitcoin · Volume V: The Path to a Sustainable Future</p>
+        <p style="font-size: 0.85em;"><a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a> &middot; <a href="https://github.com/elementarybitcoin/elementarybitcoin.github.io">contribute</a></p>
     </footer>
 </body>
 </html>

--- a/chapters/38-security-budget.html
+++ b/chapters/38-security-budget.html
@@ -1157,6 +1157,7 @@ Security Budget Timeline:
 
     <footer>
         <p>Elementary Bitcoin · Volume V: The Path to a Sustainable Future</p>
+        <p style="font-size: 0.85em;"><a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a> &middot; <a href="https://github.com/elementarybitcoin/elementarybitcoin.github.io">contribute</a></p>
     </footer>
 </body>
 </html>

--- a/chapters/39-quantum-resistance.html
+++ b/chapters/39-quantum-resistance.html
@@ -1249,6 +1249,7 @@ One Plausible Sequencing (illustrative):
 
     <footer>
         <p>Elementary Bitcoin · Volume V: The Path to a Sustainable Future</p>
+        <p style="font-size: 0.85em;"><a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a> &middot; <a href="https://github.com/elementarybitcoin/elementarybitcoin.github.io">contribute</a></p>
     </footer>
 </body>
 </html>

--- a/chapters/40-monetary-future.html
+++ b/chapters/40-monetary-future.html
@@ -1008,13 +1008,14 @@
         <nav class="chapter-navigation">
             <a href="39-quantum-resistance.html" class="prev-chapter">&#8592; Chapter 39: Quantum Resistance</a>
             <a href="../index.html">Index</a>
-            <span style="color: #999;">Volume V Complete</span>
+            <a href="appendix-a-notation.html" class="next-chapter">Appendix A: Notation Reference &#8594;</a>
         </nav>
     </main>
 
     <footer>
         <p>Elementary Bitcoin · Volume V: The Path to a Sustainable Future</p>
         <p><em>End of Volume V</em></p>
+        <p style="font-size: 0.85em;"><a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a> &middot; <a href="https://github.com/elementarybitcoin/elementarybitcoin.github.io">contribute</a></p>
     </footer>
 </body>
 </html>

--- a/chapters/appendix-a-notation.html
+++ b/chapters/appendix-a-notation.html
@@ -676,6 +676,7 @@
 
     <footer>
         <p><a href="../index.html">Elementary Bitcoin</a> · A Mathematical Introduction</p>
+        <p style="font-size: 0.85em;"><a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a> &middot; <a href="https://github.com/elementarybitcoin/elementarybitcoin.github.io">contribute</a></p>
     </footer>
 </body>
 </html>

--- a/chapters/appendix-b-references.html
+++ b/chapters/appendix-b-references.html
@@ -311,6 +311,7 @@
 
     <footer>
         <p><a href="../index.html">Elementary Bitcoin</a> · A Mathematical Introduction</p>
+        <p style="font-size: 0.85em;"><a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a> &middot; <a href="https://github.com/elementarybitcoin/elementarybitcoin.github.io">contribute</a></p>
     </footer>
 </body>
 </html>

--- a/chapters/appendix-c-index.html
+++ b/chapters/appendix-c-index.html
@@ -436,6 +436,7 @@
 
     <footer>
         <p><a href="../index.html">Elementary Bitcoin</a> &middot; A Mathematical Introduction</p>
+        <p style="font-size: 0.85em;"><a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a> &middot; <a href="https://github.com/elementarybitcoin/elementarybitcoin.github.io">contribute</a></p>
     </footer>
 </body>
 </html>

--- a/chapters/appendix-d-validation-rules.html
+++ b/chapters/appendix-d-validation-rules.html
@@ -173,6 +173,7 @@
 
     <footer>
         <p><a href="../index.html">Elementary Bitcoin</a> &middot; A Mathematical Introduction</p>
+        <p style="font-size: 0.85em;"><a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a> &middot; <a href="https://github.com/elementarybitcoin/elementarybitcoin.github.io">contribute</a></p>
     </footer>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -667,6 +667,14 @@
         <p style="font-style: italic; margin-top: 1rem;">
             "We build understanding link by link, block by block."
         </p>
+        <p style="margin-top: 1.5rem;">
+            Written by Melvin Carvalho, with contributions from the community.
+        </p>
+        <p style="margin-top: 0.5rem;">
+            Licensed <a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a>
+            &middot; Corrections and contributions welcome via
+            <a href="https://github.com/elementarybitcoin/elementarybitcoin.github.io">GitHub</a>
+        </p>
     </footer>
 </body>
 </html>


### PR DESCRIPTION
Pre-share requirements:

- **index.html colophon**: "Written by Melvin Carvalho, with contributions from the community." + CC BY-SA 4.0 license link + GitHub contribution invite. CC BY-SA chosen for the author-plus-crowd-sourced model: attribution preserved, derivatives stay open, community contributions flow back.
- **All 44 chapter/appendix footers**: one-line "CC BY-SA 4.0 · contribute" links so every page carries its license standalone.
- **Ch 40 nav**: "Volume V Complete" dead-end replaced with a forward link to Appendix A — the full reading chain is now 1→40→A→B→C→D unbroken (site-wide sweep: zero broken links/anchors).

Fixes #173