### PR TITLE
Move About This Project below the TOC

### DIFF
--- a/index.html
+++ b/index.html
@@ -353,36 +353,6 @@
         </section>
 
 
-        <section class="preface">
-            <h2>About This Project</h2>
-            <p>
-                Elementary Bitcoin is written by Melvin Carvalho and maintained as a
-                community project: the source is public, the text is licensed
-                <a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a>,
-                and corrections and contributions flow through
-                <a href="https://github.com/elementarybitcoin/elementarybitcoin.github.io">GitHub</a>.
-                This edition is dated June 2026; Volume IV dates every perishable claim
-                in place. The numerical examples have been verified computationally
-                (curve points recomputed, signatures checked, probability tables
-                re-derived) and all of its figures rendered and inspected.
-            </p>
-            <p>
-                Some subjects are deliberately out of scope: custody operations,
-                exchange engineering, price models, and implementation internals.
-                Others are planned, and contributions toward them are especially
-                welcome: mempool and fee policy, wallet mathematics (BIP-32,
-                descriptors, miniscript), mining pool economics, on-chain privacy,
-                and the peer-to-peer network layer.
-            </p>
-            <p>
-                <strong>For reviewers.</strong> Volumes II and III consist of checkable
-                claims: we ask readers to check them against running code and the cited
-                BIPs. Volume IV attributes positions to their holders: a wrong
-                attribution is an error, and we want to know about it. Disagreement
-                with the analysis is welcome too; that is what the issue tracker is for.
-            </p>
-        </section>
-
         <h2 style="text-align: center; font-variant: small-caps; letter-spacing: 0.15em; margin: 3rem 0 2rem;">Contents</h2>
 
         <!-- Volume I -->
@@ -733,6 +703,37 @@
                 <span class="ch-title"><a href="chapters/appendix-d-validation-rules.html">Consensus Validation Rules</a></span>
             </div>
             <p class="toc-desc">The validation pipeline as a rule catalog · Phase-by-phase requirements · Activation heights · Height-gated script flags</p>
+        </section>
+
+
+        <section class="preface">
+            <h2>About This Project</h2>
+            <p>
+                Elementary Bitcoin is written by Melvin Carvalho and maintained as a
+                community project: the source is public, the text is licensed
+                <a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a>,
+                and corrections and contributions flow through
+                <a href="https://github.com/elementarybitcoin/elementarybitcoin.github.io">GitHub</a>.
+                This edition is dated June 2026; Volume IV dates every perishable claim
+                in place. The numerical examples have been verified computationally
+                (curve points recomputed, signatures checked, probability tables
+                re-derived) and all of its figures rendered and inspected.
+            </p>
+            <p>
+                Some subjects are deliberately out of scope: custody operations,
+                exchange engineering, price models, and implementation internals.
+                Others are planned, and contributions toward them are especially
+                welcome: mempool and fee policy, wallet mathematics (BIP-32,
+                descriptors, miniscript), mining pool economics, on-chain privacy,
+                and the peer-to-peer network layer.
+            </p>
+            <p>
+                <strong>For reviewers.</strong> Volumes II and III consist of checkable
+                claims: we ask readers to check them against running code and the cited
+                BIPs. Volume IV attributes positions to their holders: a wrong
+                attribution is an error, and we want to know about it. Disagreement
+                with the analysis is welcome too; that is what the issue tracker is for.
+            </p>
         </section>
 
     </main>


### PR DESCRIPTION
Front matter is now Preface → Argument → Epistemic Status → How to Read → Contents; About This Project moved to end matter above the colophon. Tag balance verified.

Fixes #177