### PR TITLE
Structural batch 1: theorem deflation, double-spend consolidation, Ch 15 refactor, Ch 5/9 dedup

### DIFF
--- a/chapters/05-secp256k1.html
+++ b/chapters/05-secp256k1.html
@@ -405,60 +405,21 @@ FD17B448 A6855419 9C47D08F FB10D4B8</pre>
         </section>
 
         <section>
-            <h2 id="s5-7">5.7 Private and Public Keys</h2>
+            <h2 id="s5-7">5.7 From Parameters to Keys</h2>
 
             <p>
-                With the curve parameters established, we can now precisely define what
-                constitutes a Bitcoin private key and public key.
+                With the curve parameters established, the objects at the heart of Bitcoin's
+                cryptography are one step away. A private key is an integer
+                <span class="math">d</span> with <span class="math">1 ≤ d ≤ n − 1</span>, and
+                the corresponding public key is the point <span class="math">P = dG</span>;
+                these objects, their byte encodings, and the address formats built on them
+                are the subject of Chapter 9. Here we record only what the parameters
+                themselves determine about them.
             </p>
 
-            <div class="definition">
-                <p class="definition-title">Definition 5.5 (Private Key)</p>
-                <p>
-                    A <strong>private key</strong> is an integer <span class="math">d</span> satisfying:
-                </p>
-                <p style="text-align: center; font-size: 1.1em;">
-                    <span class="math">1 ≤ d ≤ n − 1</span>
-                </p>
-                <p>
-                    In Bitcoin, this is typically a 256-bit random number. The private key must
-                    be kept secret; anyone who knows it can spend the associated funds.
-                </p>
-            </div>
-
-            <div class="definition">
-                <p class="definition-title">Definition 5.6 (Public Key)</p>
-                <p>
-                    Given a private key <span class="math">d</span>, the <strong>public key</strong>
-                    is the point:
-                </p>
-                <p style="text-align: center; font-size: 1.1em;">
-                    <span class="math">P = dG = (x, y)</span>
-                </p>
-                <p>
-                    This point can be shared publicly. The security of the system relies on
-                    the infeasibility of computing <span class="math">d</span> from <span class="math">P</span>
-                    and <span class="math">G</span>.
-                </p>
-            </div>
-
-            <div class="example">
-                <p class="example-title">Example 5.2 (A Simple Private Key)</p>
-                <p>
-                    Let the private key be <span class="math">d = 1</span>. Then the public key is:
-                </p>
-                <p style="text-align: center;">
-                    <span class="math">P = 1 × G = G</span>
-                </p>
-                <p>
-                    So the public key is simply the generator point itself. While this is
-                    mathematically valid, it would be a catastrophically weak key in practice.
-                </p>
-                <p>
-                    For <span class="math">d = 2</span>, the public key is <span class="math">P = 2G</span>,
-                    computed via point doubling.
-                </p>
-            </div>
+            <p>
+                First, the size of <span class="math">n</span> fixes the size of the key space.
+            </p>
 
             <div class="remark">
                 <p class="remark-title">Key Space Size</p>
@@ -476,64 +437,17 @@ FD17B448 A6855419 9C47D08F FB10D4B8</pre>
                     of collision with any other key ever generated.
                 </p>
             </div>
-        </section>
-
-        <section>
-            <h2 id="s5-8">5.8 Public Key Encoding</h2>
 
             <p>
-                A public key is a point <span class="math">(x, y)</span> on the curve. There
-                are several ways to encode this point as a byte sequence (throughout,
-                <span class="math">||</span> denotes concatenation of byte strings).
+                Second, the special form of <span class="math">p</span> has a practical
+                consequence for how public keys can be stored. Since the curve equation is
+                quadratic in <span class="math">y</span>, a point is determined by its
+                <span class="math">x</span>-coordinate together with one bit selecting between
+                the two roots <span class="math">y</span> and <span class="math">p − y</span>
+                (which have opposite parities, as <span class="math">p</span> is odd). Because
+                <span class="math">p ≡ 3 (mod 4)</span>, the required square root can be
+                computed by a single exponentiation.
             </p>
-
-            <div class="definition">
-                <p class="definition-title">Definition 5.7 (Public Key Formats)</p>
-                <p><strong>Uncompressed format (65 bytes):</strong></p>
-                <p style="font-family: monospace; margin-left: 2rem;">
-                    04 || x (32 bytes) || y (32 bytes)
-                </p>
-                <p>The prefix <code>04</code> indicates uncompressed format.</p>
-
-                <p><strong>Compressed format (33 bytes):</strong></p>
-                <p style="font-family: monospace; margin-left: 2rem;">
-                    (02 or 03) || x (32 bytes)
-                </p>
-                <p>
-                    The prefix is <code>02</code> if <span class="math">y</span> is even,
-                    <code>03</code> if <span class="math">y</span> is odd.
-                </p>
-            </div>
-
-            <figure>
-                <svg class="diagram" width="500" height="200" viewBox="0 0 500 200">
-                    <text x="250" y="25" text-anchor="middle" font-family="Georgia" font-size="14" font-weight="bold">Public Key Encoding Formats</text>
-
-                    <!-- Uncompressed -->
-                    <g transform="translate(90, 50)">
-                        <text x="0" y="15" font-family="Georgia" font-size="12" font-weight="bold">Uncompressed (65 bytes):</text>
-                        <rect x="0" y="25" width="30" height="30" fill="#f8f5f0" stroke="#8b4513" stroke-width="1"/>
-                        <text x="15" y="45" text-anchor="middle" font-family="monospace" font-size="11">04</text>
-                        <rect x="35" y="25" width="140" height="30" fill="#f0f5f8" stroke="#4a90d9" stroke-width="1"/>
-                        <text x="105" y="45" text-anchor="middle" font-family="Georgia" font-size="11">x (32 bytes)</text>
-                        <rect x="180" y="25" width="140" height="30" fill="#f5f8f0" stroke="#5a8f5a" stroke-width="1"/>
-                        <text x="250" y="45" text-anchor="middle" font-family="Georgia" font-size="11">y (32 bytes)</text>
-                    </g>
-
-                    <!-- Compressed -->
-                    <g transform="translate(90, 120)">
-                        <text x="0" y="15" font-family="Georgia" font-size="12" font-weight="bold">Compressed (33 bytes):</text>
-                        <rect x="0" y="25" width="45" height="30" fill="#f8f5f0" stroke="#8b4513" stroke-width="1"/>
-                        <text x="22" y="45" text-anchor="middle" font-family="monospace" font-size="11">02/03</text>
-                        <rect x="50" y="25" width="140" height="30" fill="#f0f5f8" stroke="#4a90d9" stroke-width="1"/>
-                        <text x="120" y="45" text-anchor="middle" font-family="Georgia" font-size="11">x (32 bytes)</text>
-
-                        <!-- Recovery note -->
-                        <text x="210" y="45" font-family="Georgia" font-size="10" fill="#666">y recovered from x</text>
-                    </g>
-                </svg>
-                <figcaption>Figure 5.4: Uncompressed and compressed public key formats.</figcaption>
-            </figure>
 
             <div class="theorem">
                 <p class="theorem-title">Proposition 5.2 (Point Recovery)</p>
@@ -544,7 +458,7 @@ FD17B448 A6855419 9C47D08F FB10D4B8</pre>
                 <ol>
                     <li>Compute <span class="math">y² = x³ + 7 mod p</span></li>
                     <li>Compute <span class="math">y = (y²)^((p+1)/4) mod p</span> (valid since <span class="math">p ≡ 3 (mod 4)</span>)</li>
-                    <li>If the parity of <span class="math">y</span> does not match the prefix, use <span class="math">p − y</span></li>
+                    <li>If the parity of <span class="math">y</span> does not match the required parity, use <span class="math">p − y</span></li>
                 </ol>
                 <p>
                     Step 2 works by Euler's criterion: a nonzero <span class="math">a</span> is a
@@ -556,18 +470,16 @@ FD17B448 A6855419 9C47D08F FB10D4B8</pre>
                 </p>
             </div>
 
-            <div class="remark">
-                <p class="remark-title">Compression Benefits</p>
-                <p>
-                    Compressed public keys save 32 bytes per key. In Bitcoin transactions,
-                    this reduces transaction size and hence fees. Modern Bitcoin software
-                    uses compressed keys by default.
-                </p>
-            </div>
+            <p>
+                This proposition is what makes the compressed public key encoding of
+                Chapter 9 possible: a public key can be transmitted as 33 bytes (the
+                <span class="math">x</span>-coordinate plus a parity prefix) rather than
+                65, and the receiver recovers <span class="math">y</span> exactly.
+            </p>
         </section>
 
         <section>
-            <h2 id="s5-9">5.9 Why Satoshi Chose secp256k1</h2>
+            <h2 id="s5-8">5.8 Why Satoshi Chose secp256k1</h2>
 
             <p>
                 When Satoshi Nakamoto designed Bitcoin, he chose secp256k1 over the more
@@ -610,7 +522,7 @@ FD17B448 A6855419 9C47D08F FB10D4B8</pre>
         </section>
 
         <section>
-            <h2 id="s5-10">5.10 Security Analysis</h2>
+            <h2 id="s5-9">5.9 Security Analysis</h2>
 
             <p>
                 The security of secp256k1 has been extensively analyzed. The main conclusion:
@@ -660,7 +572,7 @@ FD17B448 A6855419 9C47D08F FB10D4B8</pre>
                     <!-- Annotation -->
                     <text x="225" y="115" text-anchor="middle" font-family="Georgia" font-size="10" fill="#666">Best attack: ~2¹²⁸ operations (computationally infeasible)</text>
                 </svg>
-                <figcaption>Figure 5.5: secp256k1 provides approximately 128 bits of security.</figcaption>
+                <figcaption>Figure 5.4: secp256k1 provides approximately 128 bits of security.</figcaption>
             </figure>
 
             <p>

--- a/chapters/09-keys-addresses.html
+++ b/chapters/09-keys-addresses.html
@@ -58,7 +58,8 @@
 
             <p>
                 A Bitcoin private key is, at its core, simply a number. But not just any number&mdash;it
-                must be chosen with extreme care.
+                must be chosen with extreme care. Chapter 5 introduced private and public keys
+                alongside the curve parameters; we now define them as protocol objects.
             </p>
 
             <div class="definition">
@@ -226,8 +227,9 @@
                     04 || x || y
                 </p>
                 <p>
-                    where <code>04</code> is a single prefix byte, and <span class="math">x</span> and
-                    <span class="math">y</span> are each encoded as 32-byte big-endian integers.
+                    where <code>04</code> is a single prefix byte, <span class="math">x</span> and
+                    <span class="math">y</span> are each encoded as 32-byte big-endian integers,
+                    and <span class="math">||</span> denotes concatenation of byte strings.
                 </p>
             </div>
 
@@ -294,23 +296,17 @@
                 resistance, and scripting flexibility.
             </p>
 
-            <div class="definition">
-                <p class="definition-title">Definition 9.5 (HASH160)</p>
-                <p>
-                    The <strong>HASH160</strong> function is the composition:
-                </p>
-                <p class="math-block">
-                    HASH160(x) = RIPEMD160(SHA256(x))
-                </p>
-                <p>
-                    This produces a 160-bit (20-byte) digest from an arbitrary input.
-                </p>
-            </div>
-
             <p>
-                The use of two different hash functions (SHA-256 followed by RIPEMD-160) provides
-                defense in depth: if either function is found to have weaknesses, the composition
-                may still be secure.
+                Recall the composite hash function HASH160 (Definition 6.4):
+            </p>
+            <p class="math-block">
+                HASH160(x) = RIPEMD160(SHA256(x))
+            </p>
+            <p>
+                It produces a 160-bit (20-byte) digest from an arbitrary input. As discussed in
+                Chapter 6, the use of two different hash functions (SHA-256 followed by RIPEMD-160)
+                provides defense in depth: if either function is found to have weaknesses, the
+                composition may still be secure.
             </p>
 
             <figure>
@@ -363,7 +359,7 @@
             <h3 id="s9-4-1">9.4.1 The Base58 Alphabet</h3>
 
             <div class="definition">
-                <p class="definition-title">Definition 9.6 (Base58 Alphabet)</p>
+                <p class="definition-title">Definition 9.5 (Base58 Alphabet)</p>
                 <p>
                     The <strong>Base58</strong> alphabet consists of 58 characters:
                 </p>
@@ -383,7 +379,7 @@
             <h3 id="s9-4-2">9.4.2 Adding the Checksum</h3>
 
             <div class="definition">
-                <p class="definition-title">Definition 9.7 (Base58Check)</p>
+                <p class="definition-title">Definition 9.6 (Base58Check)</p>
                 <p>
                     <strong>Base58Check</strong> encoding of data <span class="math">d</span> with
                     version byte <span class="math">v</span> is:
@@ -477,7 +473,7 @@
             </p>
 
             <div class="definition">
-                <p class="definition-title">Definition 9.8 (P2PKH Address)</p>
+                <p class="definition-title">Definition 9.7 (P2PKH Address)</p>
                 <p>
                     A <strong>Pay-to-Public-Key-Hash (P2PKH)</strong> address is the Base58Check
                     encoding of:
@@ -556,7 +552,7 @@
             </p>
 
             <div class="definition">
-                <p class="definition-title">Definition 9.9 (P2SH Address)</p>
+                <p class="definition-title">Definition 9.8 (P2SH Address)</p>
                 <p>
                     A <strong>Pay-to-Script-Hash (P2SH)</strong> address is the Base58Check
                     encoding of:
@@ -610,7 +606,7 @@
             <h3 id="s9-7-1">9.7.1 The Bech32 Alphabet</h3>
 
             <div class="definition">
-                <p class="definition-title">Definition 9.10 (Bech32 Alphabet)</p>
+                <p class="definition-title">Definition 9.9 (Bech32 Alphabet)</p>
                 <p>
                     The <strong>Bech32</strong> alphabet consists of 32 lowercase alphanumeric characters:
                 </p>
@@ -634,7 +630,7 @@
             </ol>
 
             <div class="definition">
-                <p class="definition-title">Definition 9.11 (P2WPKH Address)</p>
+                <p class="definition-title">Definition 9.10 (P2WPKH Address)</p>
                 <p>
                     A <strong>Pay-to-Witness-Public-Key-Hash (P2WPKH)</strong> address encodes:
                 </p>
@@ -686,6 +682,32 @@
                     1 in 10⁹.
                 </p>
             </div>
+
+            <div class="proof">
+                <p class="proof-title">Proof sketch.</p>
+                <p>
+                    Interpret each character of the address as an element of the finite field
+                    <span class="math">𝔽₃₂</span> of 32 elements (Chapter 2), so that a string
+                    becomes the coefficient sequence of a polynomial. The six-character checksum
+                    is chosen so that this polynomial leaves a fixed residue modulo a fixed
+                    degree-6 generator polynomial; for a given length and human-readable part,
+                    the valid strings therefore form a coset of a linear code over
+                    <span class="math">𝔽₃₂</span>,
+                    and an error goes undetected exactly when the error pattern (the character-wise
+                    difference of two valid strings) is a nonzero codeword. A nonzero codeword has
+                    weight at least the minimum distance of the code, and the Bech32 generator was
+                    selected by exhaustive search over BCH codes so that this minimum distance is
+                    at least 5 for all lengths up to 90 characters: hence every error pattern
+                    touching at most 4 character positions is detected, which subsumes single
+                    substitutions and adjacent transpositions (the latter alter at most 2
+                    positions). For arbitrary corruption, the checksum carries
+                    <span class="math">6 × 5 = 30</span> bits, so a random invalid string passes
+                    verification with probability about <span class="math">2⁻³⁰ &lt; 10⁻⁹</span>.
+                    The minimum-distance computation itself is an exhaustive verification; the
+                    code construction and its design notes are specified in BIP-173.
+                    <span class="qed"></span>
+                </p>
+            </div>
         </section>
 
         <section>
@@ -697,7 +719,7 @@
             </p>
 
             <div class="definition">
-                <p class="definition-title">Definition 9.12 (P2TR Address)</p>
+                <p class="definition-title">Definition 9.11 (P2TR Address)</p>
                 <p>
                     A <strong>Pay-to-Taproot (P2TR)</strong> address encodes:
                 </p>
@@ -770,7 +792,7 @@
             </p>
 
             <div class="definition">
-                <p class="definition-title">Definition 9.13 (WIF Encoding)</p>
+                <p class="definition-title">Definition 9.12 (WIF Encoding)</p>
                 <p>
                     The <strong>Wallet Import Format</strong> of a private key <span class="math">d</span> is:
                 </p>

--- a/chapters/10-transactions.html
+++ b/chapters/10-transactions.html
@@ -126,10 +126,10 @@
                 </p>
             </div>
 
-            <div class="theorem">
-                <p class="theorem-title">Theorem 10.1 (Conservation of Value)</p>
+            <div class="remark">
+                <p class="remark-title">Remark 10.2 (Protocol Rule: Conservation of Value)</p>
                 <p>
-                    For any valid non-coinbase transaction:
+                    Consensus requires that for any valid non-coinbase transaction:
                 </p>
                 <p class="math-block">
                     Σ(input values) ≥ Σ(output values)
@@ -138,7 +138,9 @@
                     The difference <span class="math">Σ(inputs) − Σ(outputs)</span> is the
                     <strong>transaction fee</strong>, claimed by the miner who includes the
                     transaction in a block (blocks and mining are developed in
-                    Chapters 13 and 14).
+                    Chapters 13 and 14). This is a consensus rule, enforced because
+                    every validating node rejects transactions that violate it (see
+                    the rule catalog in Appendix D), not a mathematical theorem.
                 </p>
             </div>
         </section>
@@ -781,10 +783,11 @@ efcdab78563412...f6e5d4c3b2a1
                 </ul>
             </div>
 
-            <div class="theorem">
-                <p class="theorem-title">Theorem 10.2 (Coinbase Constraint)</p>
+            <div class="remark">
+                <p class="remark-title">Remark 10.3 (Protocol Rule: Coinbase Constraint)</p>
                 <p>
-                    The total output value of a coinbase transaction must not exceed:
+                    Consensus requires that the total output value of a coinbase
+                    transaction not exceed:
                 </p>
                 <p class="math-block">
                     subsidy + Σ(fees of all transactions in the block)
@@ -794,7 +797,9 @@ efcdab78563412...f6e5d4c3b2a1
                     defined in Chapter 15.)
                 </p>
                 <p>
-                    Any value not claimed is permanently lost (burned).
+                    Any value not claimed is permanently lost (burned). Like value
+                    conservation, this is a consensus rule enforced by every validating
+                    node (Appendix D).
                 </p>
             </div>
 

--- a/chapters/12-merkle-trees.html
+++ b/chapters/12-merkle-trees.html
@@ -593,26 +593,17 @@ H(CD) = SHA256(SHA256(1c8d...2e3f || 9a4b...5c6d))</pre>
                 client can verify transaction inclusion without downloading full blocks.
             </p>
 
-            <div class="theorem">
-                <p class="theorem-title">Theorem 12.3 (SPV Verification)</p>
-                <p>
-                    Given:
-                </p>
-                <ul>
-                    <li>A transaction <span class="math">tx</span></li>
-                    <li>A Merkle proof <span class="math">π</span></li>
-                    <li>A block header <span class="math">H</span> (from the chain with the most work&mdash;block headers and chain selection are defined in Chapter 13)</li>
-                </ul>
-                <p>
-                    An SPV client can verify that <span class="math">tx</span> is included in the
-                    block represented by <span class="math">H</span> by checking that
-                    <span class="math">π</span> is valid for the Merkle root in <span class="math">H</span>.
-                </p>
-            </div>
-
             <p>
-                The SPV security model assumes the most-work chain (Chapter 13) represents
-                honest consensus. We will examine this assumption critically in Volume III.
+                Given a transaction <span class="math">tx</span>, a Merkle proof
+                <span class="math">π</span>, and a block header <span class="math">H</span>
+                from the most-work chain (block headers and chain selection are defined in
+                Chapter 13), a client can verify that <span class="math">tx</span> is
+                included in the block represented by <span class="math">H</span> by checking
+                <span class="math">π</span> against the Merkle root in
+                <span class="math">H</span>. The precise statement and its security
+                hypotheses are Theorem 17.1, where the SPV model is the subject; the
+                assumption that the most-work chain represents honest consensus is examined
+                critically throughout Volume III.
             </p>
 
             <div class="example">

--- a/chapters/13-blocks.html
+++ b/chapters/13-blocks.html
@@ -255,23 +255,45 @@
             <h3 id="s13-2-4">13.2.4 Timestamp</h3>
 
             <div class="definition">
-                <p class="definition-title">Definition 13.5 (Block Timestamp)</p>
+                <p class="definition-title">Definition 13.5 (Block Timestamp and Median Time Past)</p>
                 <p>
                     The <strong>timestamp</strong> is a 32-bit unsigned integer representing seconds
-                    since the Unix epoch (January 1, 1970 00:00:00 UTC).
+                    since the Unix epoch (January 1, 1970 00:00:00 UTC). The
+                    <strong>median time past (MTP)</strong> of a block is the median of the
+                    timestamps of the previous 11 blocks.
+                </p>
+                <p>
+                    A valid block's timestamp must be strictly greater than the block's MTP,
+                    and must not exceed network-adjusted time plus 2 hours (both rules appear
+                    in the consensus catalog of Appendix D).
                 </p>
             </div>
 
-            <div class="theorem">
-                <p class="theorem-title">Theorem 13.1 (Timestamp Constraints)</p>
-                <p>
-                    A valid block timestamp must satisfy:
-                </p>
-                <ul>
-                    <li>Greater than the median of the previous 11 blocks (MTP)</li>
-                    <li>Less than 2 hours in the future (network-adjusted time)</li>
-                </ul>
-            </div>
+            <figure>
+                <svg class="diagram" width="480" height="120" viewBox="0 0 480 120">
+                    <!-- Timeline -->
+                    <line x1="40" y1="60" x2="440" y2="60" stroke="#666" stroke-width="1.5"/>
+
+                    <!-- MTP marker -->
+                    <rect x="100" y="45" width="80" height="30" rx="4" fill="#ffe8e8" stroke="#c44"/>
+                    <text x="140" y="65" text-anchor="middle" font-family="Georgia" font-size="10">MTP</text>
+                    <text x="140" y="90" text-anchor="middle" font-family="Georgia" font-size="9" fill="#c44">minimum</text>
+
+                    <!-- Valid range -->
+                    <rect x="185" y="45" width="150" height="30" rx="4" fill="#f5f8f0" stroke="#5a8f5a"/>
+                    <text x="260" y="65" text-anchor="middle" font-family="Georgia" font-size="10" fill="#5a8f5a">Valid Range</text>
+
+                    <!-- Future limit -->
+                    <rect x="340" y="45" width="90" height="30" rx="4" fill="#ffe8e8" stroke="#c44"/>
+                    <text x="385" y="65" text-anchor="middle" font-family="Georgia" font-size="10">Now + 2h</text>
+                    <text x="385" y="90" text-anchor="middle" font-family="Georgia" font-size="9" fill="#c44">maximum</text>
+
+                    <!-- Labels -->
+                    <text x="40" y="110" font-family="Georgia" font-size="9" fill="#666">Past</text>
+                    <text x="440" y="110" text-anchor="end" font-family="Georgia" font-size="9" fill="#666">Future</text>
+                </svg>
+                <figcaption>Figure 13.3: Valid block timestamp range is between MTP and network-adjusted time + 2 hours.</figcaption>
+            </figure>
 
             <h3 id="s13-2-5">13.2.5 Bits (Difficulty Target)</h3>
 
@@ -377,11 +399,11 @@ target = 0x00ffff × 256^(29-3)
                         </marker>
                     </defs>
                 </svg>
-                <figcaption>Figure 13.3: Blocks form a chain through hash references.</figcaption>
+                <figcaption>Figure 13.4: Blocks form a chain through hash references.</figcaption>
             </figure>
 
             <div class="theorem">
-                <p class="theorem-title">Theorem 13.2 (Chain Integrity)</p>
+                <p class="theorem-title">Theorem 13.1 (Chain Integrity)</p>
                 <p>
                     If block <span class="math">Bₙ</span> contains <code>prev_hash = H(B[n-1])</code>,
                     then any modification to <span class="math">Bₙ₋₁</span> (including its transactions)
@@ -641,7 +663,7 @@ target = 0x00ffff × 256^(29-3)
                     <path d="M 265 105 L 265 120 L 435 120 L 435 105" stroke="#c44" stroke-width="1.5" fill="none"/>
                     <text x="350" y="135" text-anchor="middle" font-family="Georgia" font-size="10" fill="#c44">3 confirmations</text>
                 </svg>
-                <figcaption>Figure 13.4: A transaction at height n has 3 confirmations when the chain tip is at n+2.</figcaption>
+                <figcaption>Figure 13.5: A transaction at height n has 3 confirmations when the chain tip is at n+2.</figcaption>
             </figure>
         </section>
 
@@ -700,7 +722,7 @@ target = 0x00ffff × 256^(29-3)
                     <!-- Labels -->
                     <text x="320" y="45" text-anchor="middle" font-family="Georgia" font-size="10" fill="#5a8f5a">Main chain (most work)</text>
                 </svg>
-                <figcaption>Figure 13.5: Block n+1' is valid but stale&mdash;the main chain extended differently.</figcaption>
+                <figcaption>Figure 13.6: Block n+1' is valid but stale&mdash;the main chain extended differently.</figcaption>
             </figure>
         </section>
 
@@ -734,6 +756,21 @@ target = 0x00ffff × 256^(29-3)
                 Fast propagation reduces stale block rates and improves mining fairness.
                 Modern optimizations achieve sub-second propagation for most blocks.
             </p>
+
+            <div class="remark">
+                <p class="remark-title">Network Protocol Constants</p>
+                <p>
+                    The peer-to-peer layer has constants of its own: the default mainnet
+                    port (8333; testnet uses 18333), the four "magic" bytes that prefix
+                    every message (<code>0xF9BEB4D9</code> on mainnet), and caps on message
+                    size (4 MB) and on entries per <code>inv</code> announcement (50,000).
+                    None of these is a consensus parameter in the sense of Definition 16.1:
+                    a node that changes them can still validate, and follow, the same chain.
+                    We record them here, with the networking machinery, to keep that
+                    distinction sharp; the consensus constants proper are the subject of
+                    Chapter 15.
+                </p>
+            </div>
         </section>
 
         <section>

--- a/chapters/14-proof-of-work.html
+++ b/chapters/14-proof-of-work.html
@@ -277,6 +277,9 @@
                 </p>
                 <p>
                     where <span class="math">expected_time = 2016 × 10 minutes = 1,209,600 seconds</span>.
+                    The ratio <span class="math">actual_time / expected_time</span> is clamped to the
+                    interval <span class="math">[0.25, 4]</span>: difficulty can at most quadruple
+                    or quarter in a single adjustment period.
                 </p>
             </div>
 
@@ -289,19 +292,6 @@
                     which spans only 2015 inter-block intervals rather than 2016. This makes
                     difficulty systematically ~0.05% too low. The bug has been preserved
                     for consensus compatibility.
-                </p>
-            </div>
-
-            <div class="theorem">
-                <p class="theorem-title">Theorem 14.2 (Adjustment Bounds)</p>
-                <p>
-                    The difficulty adjustment is clamped to prevent extreme changes:
-                </p>
-                <p class="math-block">
-                    0.25 ≤ adjustment_factor ≤ 4.0
-                </p>
-                <p>
-                    Difficulty can at most quadruple or quarter in a single adjustment period.
                 </p>
             </div>
 
@@ -471,12 +461,15 @@ new_difficulty = old_difficulty / 0.857
                 </p>
             </div>
 
-            <div class="theorem">
-                <p class="theorem-title">Theorem 14.3 (Heaviest Chain Rule)</p>
+            <div class="remark">
+                <p class="remark-title">Remark 14.2 (Protocol Rule: Heaviest-Chain Selection)</p>
                 <p>
                     Bitcoin nodes follow the chain with the most cumulative work, not necessarily
                     the longest chain. In practice, these usually coincide, but work is the
-                    correct metric.
+                    correct metric. This is a protocol rule that every node implements rather
+                    than a theorem: it is stated formally as the Nakamoto fork choice rule
+                    in Definition 26.10, and its security consequences under an honest
+                    majority are analyzed in Section 14.8.
                 </p>
             </div>
         </section>
@@ -558,21 +551,32 @@ Daily profit = $3.60 - $3.60 = $0.00</pre>
             </div>
 
             <div class="theorem">
-                <p class="theorem-title">Theorem 14.4 (Attack Success Probability)</p>
+                <p class="theorem-title">Theorem 14.2 (Attack Success Probability)</p>
                 <p>
-                    An attacker with fraction <span class="math">q</span> of total hash power
-                    attempting to reverse a transaction with <span class="math">z</span> confirmations
-                    has success probability:
+                    An attacker with fraction <span class="math">q</span> of total hash power,
+                    where <span class="math">q &lt; p = 1 − q</span>, attempting to reverse a
+                    transaction with <span class="math">z</span> confirmations has success probability:
                 </p>
                 <p class="math-block">
                     P(success) ≈ 1 − Σₖ₌₀ᶻ [λᵏe^(−λ)/k! × (1 − (q/p)^(z−k))]
                 </p>
                 <p>
-                    where <span class="math">λ = z(q/p)</span> and <span class="math">p = 1 − q</span>.
-                    (This is Nakamoto's Poisson approximation of the attacker's progress; the
-                    exact distribution is negative binomial, but the difference is small.)
+                    where <span class="math">λ = z(q/p)</span>. For <span class="math">q ≥ p</span>,
+                    the attack succeeds with probability 1.
+                </p>
+                <p>
+                    The formula is Nakamoto's (2008, whitepaper section 11), with the attacker's
+                    progress approximated as Poisson; the exact distribution is negative binomial,
+                    but the difference is small. We state it here without proof and derive it in
+                    Chapter 26 (Theorem 26.3) by a gambler's-ruin argument.
                 </p>
             </div>
+
+            <p>
+                The following table evaluates the formula at representative attacker shares
+                and confirmation depths. It is referenced throughout the book (Chapters 17,
+                26, and 36).
+            </p>
 
             <table class="data-table">
                 <thead>
@@ -581,6 +585,7 @@ Daily profit = $3.60 - $3.60 = $0.00</pre>
                         <th>1 conf</th>
                         <th>3 conf</th>
                         <th>6 conf</th>
+                        <th>12 conf</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -589,34 +594,46 @@ Daily profit = $3.60 - $3.60 = $0.00</pre>
                         <td>20.5%</td>
                         <td>1.3%</td>
                         <td>0.02%</td>
+                        <td>~0%</td>
                     </tr>
                     <tr>
                         <td>25%</td>
                         <td>52.2%</td>
                         <td>19.6%</td>
                         <td>5.0%</td>
+                        <td>0.4%</td>
                     </tr>
                     <tr>
                         <td>33%</td>
                         <td>69.0%</td>
                         <td>41.7%</td>
                         <td>21.3%</td>
+                        <td>6.0%</td>
+                    </tr>
+                    <tr>
+                        <td>40%</td>
+                        <td>82.9%</td>
+                        <td>66.4%</td>
+                        <td>50.4%</td>
+                        <td>30.6%</td>
                     </tr>
                     <tr>
                         <td>45%</td>
                         <td>92.0%</td>
                         <td>84.4%</td>
                         <td>76.6%</td>
+                        <td>65.1%</td>
                     </tr>
                 </tbody>
             </table>
 
             <h3 id="s14-8-2">14.8.2 The 51% Attack</h3>
 
-            <div class="theorem">
-                <p class="theorem-title">Theorem 14.5 (Majority Attack)</p>
+            <div class="remark">
+                <p class="remark-title">Remark 14.3 (Capabilities of a Majority Attacker)</p>
                 <p>
-                    An attacker controlling more than 50% of hash power can:
+                    An attacker controlling more than 50% of hash power can
+                    (the <span class="math">q ≥ p</span> case of Theorem 14.2):
                 </p>
                 <ul>
                     <li>Reverse any past transaction (given enough time)</li>
@@ -629,14 +646,14 @@ Daily profit = $3.60 - $3.60 = $0.00</pre>
                 <ul>
                     <li>Create coins out of nothing</li>
                     <li>Spend coins they do not own</li>
-                    <li>Change consensus rules (nodes still validate)</li>
+                    <li>Change consensus rules (nodes still validate; Definition 13.18)</li>
                 </ul>
             </div>
 
             <h3 id="s14-8-3">14.8.3 Selfish Mining</h3>
 
             <div class="remark">
-                <p class="remark-title">Remark 14.2 (Selfish Mining)</p>
+                <p class="remark-title">Remark 14.4 (Selfish Mining)</p>
                 <p>
                     Eyal and Sirer (2014) showed that miners with >33% hash power can gain
                     disproportionate rewards by strategically withholding blocks. This reduces
@@ -654,7 +671,7 @@ Daily profit = $3.60 - $3.60 = $0.00</pre>
             </p>
 
             <div class="remark">
-                <p class="remark-title">Remark 14.3 (Energy Consumption)</p>
+                <p class="remark-title">Remark 14.5 (Energy Consumption)</p>
                 <p>
                     Bitcoin's energy consumption is integral to its security model, not an
                     inefficiency of it: the energy spent mining represents a real-world cost
@@ -669,7 +686,7 @@ Daily profit = $3.60 - $3.60 = $0.00</pre>
             </div>
 
             <div class="remark">
-                <p class="remark-title">Remark 14.4 (Security Budget)</p>
+                <p class="remark-title">Remark 14.6 (Security Budget)</p>
                 <p>
                     As a first-order heuristic, the cost to attack Bitcoin scales with
                     mining revenue:

--- a/chapters/15-consensus-parameters.html
+++ b/chapters/15-consensus-parameters.html
@@ -4,20 +4,20 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Chapter 15: Consensus Parameters | Elementary Bitcoin</title>
-    <meta name="description" content="Chapter 15: Consensus Parameters - 21 million cap, halvings, timing parameters, economic design">
+    <meta name="description" content="Chapter 15: Consensus Parameters - 21 million cap, halvings, inflation schedule, timing parameters">
 
     <!-- Open Graph -->
     <meta property="og:type" content="article">
     <meta property="og:site_name" content="Elementary Bitcoin">
     <meta property="og:title" content="Chapter 15: Consensus Parameters | Elementary Bitcoin">
-    <meta property="og:description" content="21 million cap, halvings, timing parameters, economic design">
+    <meta property="og:description" content="21 million cap, halvings, inflation schedule, timing parameters">
     <meta property="og:url" content="https://elementarybitcoin.org/chapters/15-consensus-parameters.html">
     <meta property="og:image" content="https://elementarybitcoin.org/og-image.png">
 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Chapter 15: Consensus Parameters | Elementary Bitcoin">
-    <meta name="twitter:description" content="21 million cap, halvings, timing parameters, economic design">
+    <meta name="twitter:description" content="21 million cap, halvings, inflation schedule, timing parameters">
     <meta name="twitter:image" content="https://elementarybitcoin.org/og-image.png">
 
     <link rel="stylesheet" href="../style.css">
@@ -38,16 +38,21 @@
     <main class="chapter-content">
         <section>
             <p class="chapter-intro">
-                Bitcoin's behavior is determined by a set of fixed parameters embedded in every
-                node's software. These consensus parameters define the supply schedule, timing,
-                and constraints that make Bitcoin what it is. Understanding these constants&mdash;and
-                why they were chosen&mdash;illuminates both the technical and economic design of the system.
+                Bitcoin's monetary policy is not a promise; it is a theorem of the system's
+                constants. A handful of integers embedded in every node's validation code&mdash;an
+                initial subsidy of 50 BTC, a halving interval of 210,000 blocks, a target block
+                time of 600 seconds&mdash;determine the currency's famous properties by elementary
+                arithmetic: the 21 million cap (Theorem 15.1), the end of new issuance around
+                2140 (Theorem 15.2), and an inflation rate that falls toward zero
+                (Theorem 15.3). This chapter derives these monetary theorems first, then
+                surveys the remaining consensus constants.
             </p>
 
             <p>
                 Some parameters were carefully calculated; others were pragmatic choices that
-                became fixed through network effects. Together, they form the constitution
-                of Bitcoin.
+                became fixed through network effects. Together they form the constitution of
+                Bitcoin: Section 15.7 examines why changing any of them amounts to founding
+                a different network.
             </p>
         </section>
 
@@ -253,338 +258,38 @@
                     truncate to 0.
                 </p>
             </div>
-        </section>
 
-        <section>
-            <h2 id="s15-3">15.3 Block Timing Parameters</h2>
-
-            <div class="definition">
-                <p class="definition-title">Definition 15.3 (Target Block Time)</p>
+            <div class="proof">
+                <p class="proof-title">Proof.</p>
                 <p>
-                    The <strong>target block interval</strong> is:
-                </p>
-                <p class="math-block">
-                    T_block = 600 seconds = 10 minutes
-                </p>
-            </div>
-
-            <div class="definition">
-                <p class="definition-title">Definition 15.4 (Difficulty Adjustment Period)</p>
-                <p>
-                    Difficulty adjusts every:
-                </p>
-                <p class="math-block">
-                    2016 blocks ≈ 2016 × 10 minutes ≈ 2 weeks
-                </p>
-            </div>
-
-            <div class="remark">
-                <p class="remark-title">Remark 15.2 (Why 10 Minutes?)</p>
-                <p>
-                    Satoshi chose 10 minutes as a balance between:
-                </p>
-                <ul>
-                    <li><strong>Faster:</strong> Better user experience, but more orphan blocks,
-                        wasted work, and centralization pressure</li>
-                    <li><strong>Slower:</strong> Fewer orphans, but worse user experience and
-                        slower finality</li>
-                </ul>
-                <p>
-                    Ten minutes allows global propagation before the next block, minimizing
-                    the disadvantage to honest miners.
-                </p>
-            </div>
-
-            <div class="example">
-                <p class="example-title">Example 15.1 (Timing Calculations)</p>
-                <pre class="code-block">Blocks per hour:    6
-Blocks per day:     144
-Blocks per week:    1,008
-Blocks per year:    ~52,560
-
-Time between halvings: 210,000 × 10 min = 2,100,000 min
-                     = 35,000 hours
-                     ≈ 1,458 days
-                     ≈ 4 years</pre>
-            </div>
-        </section>
-
-        <section>
-            <h2 id="s15-4">15.4 Block Size and Weight Limits</h2>
-
-            <div class="definition">
-                <p class="definition-title">Definition 15.5 (Block Weight Limit)</p>
-                <p>
-                    The maximum block weight is:
-                </p>
-                <p class="math-block">
-                    W_max = 4,000,000 weight units (4 MWU)
-                </p>
-                <p>
-                    For legacy transactions (no witness discount), this equals the original
-                    1 MB limit.
-                </p>
-            </div>
-
-            <div class="definition">
-                <p class="definition-title">Definition 15.6 (Sigop Limits)</p>
-                <p>
-                    Blocks are also limited by signature operations:
-                </p>
-                <ul>
-                    <li>Legacy: 20,000 sigops per block</li>
-                    <li>SegWit: 80,000 sigops (weighted)</li>
-                </ul>
-            </div>
-
-            <table class="data-table">
-                <thead>
-                    <tr>
-                        <th>Parameter</th>
-                        <th>Value</th>
-                        <th>Purpose</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr>
-                        <td>Max block weight</td>
-                        <td>4,000,000 WU</td>
-                        <td>Limit resource usage</td>
-                    </tr>
-                    <tr>
-                        <td>Max block size (legacy)</td>
-                        <td>1,000,000 bytes</td>
-                        <td>Backward compatibility</td>
-                    </tr>
-                    <tr>
-                        <td>Max transaction size (policy)</td>
-                        <td>400,000 weight units (~100 kvB)</td>
-                        <td>Prevent abuse</td>
-                    </tr>
-                    <tr>
-                        <td>Min transaction size (policy)</td>
-                        <td>65 non-witness bytes</td>
-                        <td>Prevent CVE-2017-12842 (64-byte txs)</td>
-                    </tr>
-                </tbody>
-            </table>
-        </section>
-
-        <section>
-            <h2 id="s15-5">15.5 Coinbase Maturity</h2>
-
-            <div class="definition">
-                <p class="definition-title">Definition 15.7 (Coinbase Maturity)</p>
-                <p>
-                    Coinbase outputs cannot be spent until the block has received:
-                </p>
-                <p class="math-block">
-                    100 confirmations
-                </p>
-                <p>
-                    This is approximately 16.7 hours at average block times.
-                </p>
-            </div>
-
-            <div class="remark">
-                <p class="remark-title">Remark 15.3 (Why 100 Blocks?)</p>
-                <p>
-                    Coinbase maturity prevents issues if a block is later orphaned:
-                </p>
-                <ul>
-                    <li>The coinbase reward would disappear</li>
-                    <li>Any transactions spending those coins would become invalid</li>
-                    <li>This could cascade through many dependent transactions</li>
-                </ul>
-                <p>
-                    One hundred blocks makes deep reorganizations (which would orphan a mature coinbase)
-                    extremely unlikely.
+                    In era <span class="math">n</span> the subsidy is
+                    <span class="math">⌊5 × 10⁹ / 2ⁿ⁻¹⌋</span> satoshis. For
+                    <span class="math">n = 33</span> this is
+                    <span class="math">⌊5 × 10⁹ / 2³²⌋ = ⌊1.164...⌋ = 1</span>, while for
+                    <span class="math">n = 34</span> it is
+                    <span class="math">⌊5 × 10⁹ / 2³³⌋ = 0</span>, since
+                    <span class="math">2³³ ≈ 8.59 × 10⁹ &gt; 5 × 10⁹</span>; the subsidy
+                    remains 0 in every later era. □
                 </p>
             </div>
         </section>
 
         <section>
-            <h2 id="s15-6">15.6 Timestamp Rules</h2>
-
-            <div class="definition">
-                <p class="definition-title">Definition 15.8 (Median Time Past)</p>
-                <p>
-                    The <strong>Median Time Past (MTP)</strong> of a block is the median timestamp
-                    of the previous 11 blocks. Block timestamps must be strictly greater than MTP.
-                </p>
-            </div>
-
-            <div class="definition">
-                <p class="definition-title">Definition 15.9 (Future Limit)</p>
-                <p>
-                    Block timestamps must not exceed:
-                </p>
-                <p class="math-block">
-                    network_adjusted_time + 2 hours
-                </p>
-                <p>
-                    where network-adjusted time is derived from peer clocks.
-                </p>
-            </div>
-
-            <figure>
-                <svg class="diagram" width="480" height="120" viewBox="0 0 480 120">
-                    <!-- Timeline -->
-                    <line x1="40" y1="60" x2="440" y2="60" stroke="#666" stroke-width="1.5"/>
-
-                    <!-- MTP marker -->
-                    <rect x="100" y="45" width="80" height="30" rx="4" fill="#ffe8e8" stroke="#c44"/>
-                    <text x="140" y="65" text-anchor="middle" font-family="Georgia" font-size="10">MTP</text>
-                    <text x="140" y="90" text-anchor="middle" font-family="Georgia" font-size="9" fill="#c44">minimum</text>
-
-                    <!-- Valid range -->
-                    <rect x="185" y="45" width="150" height="30" rx="4" fill="#f5f8f0" stroke="#5a8f5a"/>
-                    <text x="260" y="65" text-anchor="middle" font-family="Georgia" font-size="10" fill="#5a8f5a">Valid Range</text>
-
-                    <!-- Future limit -->
-                    <rect x="340" y="45" width="90" height="30" rx="4" fill="#ffe8e8" stroke="#c44"/>
-                    <text x="385" y="65" text-anchor="middle" font-family="Georgia" font-size="10">Now + 2h</text>
-                    <text x="385" y="90" text-anchor="middle" font-family="Georgia" font-size="9" fill="#c44">maximum</text>
-
-                    <!-- Labels -->
-                    <text x="40" y="110" font-family="Georgia" font-size="9" fill="#666">Past</text>
-                    <text x="440" y="110" text-anchor="end" font-family="Georgia" font-size="9" fill="#666">Future</text>
-                </svg>
-                <figcaption>Figure 15.2: Valid block timestamp range is between MTP and current time + 2 hours.</figcaption>
-            </figure>
-        </section>
-
-        <section>
-            <h2 id="s15-7">15.7 Script and Transaction Limits</h2>
-
-            <table class="data-table">
-                <thead>
-                    <tr>
-                        <th>Parameter</th>
-                        <th>Value</th>
-                        <th>Introduced</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr>
-                        <td>Max script size</td>
-                        <td>10,000 bytes</td>
-                        <td>Original</td>
-                    </tr>
-                    <tr>
-                        <td>Max stack size</td>
-                        <td>1,000 elements</td>
-                        <td>Original</td>
-                    </tr>
-                    <tr>
-                        <td>Max element size</td>
-                        <td>520 bytes</td>
-                        <td>Original</td>
-                    </tr>
-                    <tr>
-                        <td>Max ops per script</td>
-                        <td>201</td>
-                        <td>Original</td>
-                    </tr>
-                    <tr>
-                        <td>Max pubkeys in multisig</td>
-                        <td>20</td>
-                        <td>Original</td>
-                    </tr>
-                    <tr>
-                        <td>Max P2SH redeem script</td>
-                        <td>520 bytes</td>
-                        <td>BIP-16</td>
-                    </tr>
-                    <tr>
-                        <td>Max witness stack items</td>
-                        <td>100</td>
-                        <td>SegWit</td>
-                    </tr>
-                    <tr>
-                        <td>Max witness script size</td>
-                        <td>10,000 bytes</td>
-                        <td>SegWit</td>
-                    </tr>
-                    <tr>
-                        <td>Max Tapscript size</td>
-                        <td>None (policy only)</td>
-                        <td>Taproot</td>
-                    </tr>
-                </tbody>
-            </table>
-        </section>
-
-        <section>
-            <h2 id="s15-8">15.8 Network Protocol Constants</h2>
-
-            <div class="definition">
-                <p class="definition-title">Definition 15.10 (Protocol Version)</p>
-                <p>
-                    Protocol versions indicate feature support. As of 2024, common versions
-                    are 70015&ndash;70016.
-                </p>
-            </div>
-
-            <table class="data-table">
-                <thead>
-                    <tr>
-                        <th>Parameter</th>
-                        <th>Value</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr>
-                        <td>Default port (mainnet)</td>
-                        <td>8333</td>
-                    </tr>
-                    <tr>
-                        <td>Default port (testnet)</td>
-                        <td>18333</td>
-                    </tr>
-                    <tr>
-                        <td>Default port (signet)</td>
-                        <td>38333</td>
-                    </tr>
-                    <tr>
-                        <td>Magic bytes (mainnet)</td>
-                        <td>0xF9BEB4D9</td>
-                    </tr>
-                    <tr>
-                        <td>Max message size</td>
-                        <td>4 MB</td>
-                    </tr>
-                    <tr>
-                        <td>Max headers per message</td>
-                        <td>2000</td>
-                    </tr>
-                    <tr>
-                        <td>Max inv per message</td>
-                        <td>50,000</td>
-                    </tr>
-                </tbody>
-            </table>
-        </section>
-
-        <section>
-            <h2 id="s15-9">15.9 Economic Design Rationale</h2>
+            <h2 id="s15-3">15.3 The Inflation Schedule</h2>
 
             <p>
-                The parameters were chosen to create specific economic properties.
+                The supply schedule of Section 15.2 fixes not only the eventual total
+                but the rate of issuance at every height.
             </p>
 
-            <h3 id="s15-9-1">15.9.1 Scarcity</h3>
-
             <div class="remark">
-                <p class="remark-title">Remark 15.4 (Digital Scarcity)</p>
+                <p class="remark-title">Remark 15.2 (Digital Scarcity)</p>
                 <p>
                     The 21 million cap creates absolute digital scarcity. Unlike gold (where
                     more can be mined) or fiat (where more can be printed), Bitcoin's supply
                     is mathematically fixed and verifiable by any node.
                 </p>
             </div>
-
-            <h3 id="s15-9-2">15.9.2 Diminishing Inflation</h3>
 
             <div class="theorem">
                 <p class="theorem-title">Theorem 15.3 (Inflation Rate)</p>
@@ -596,6 +301,21 @@ Time between halvings: 210,000 × 10 min = 2,100,000 min
                 </p>
                 <p>
                     This decreases with each halving, approaching zero.
+                </p>
+            </div>
+
+            <div class="proof">
+                <p class="proof-title">Proof.</p>
+                <p>
+                    At the 600-second target interval the network produces
+                    <span class="math">6 × 24 × 365 = 52,560</span> blocks per year, each adding
+                    <span class="math">subsidy(h)</span> to the supply. The relative annual
+                    increase is therefore <span class="math">52,560 × subsidy(h) / supply(h)</span>,
+                    exact up to the variation of subsidy and supply within the year and the
+                    deviation of realized block times from the target. Since
+                    <span class="math">subsidy(h)</span> halves every era while
+                    <span class="math">supply(h)</span> increases, the ratio decreases toward
+                    zero. □
                 </p>
             </div>
 
@@ -636,10 +356,8 @@ Time between halvings: 210,000 × 10 min = 2,100,000 min
                 </tbody>
             </table>
 
-            <h3 id="s15-9-3">15.9.3 Security Budget Transition</h3>
-
             <div class="remark">
-                <p class="remark-title">Remark 15.5 (Fee Transition)</p>
+                <p class="remark-title">Remark 15.3 (Fee Transition)</p>
                 <p>
                     As subsidy decreases, network security must increasingly rely on transaction
                     fees. This transition is gradual (100+ years), giving the ecosystem time
@@ -649,27 +367,161 @@ Time between halvings: 210,000 × 10 min = 2,100,000 min
         </section>
 
         <section>
-            <h2 id="s15-10">15.10 Parameter Immutability</h2>
+            <h2 id="s15-4">15.4 Block Timing Parameters</h2>
+
+            <div class="definition">
+                <p class="definition-title">Definition 15.3 (Target Block Time)</p>
+                <p>
+                    The <strong>target block interval</strong> is:
+                </p>
+                <p class="math-block">
+                    T_block = 600 seconds = 10 minutes
+                </p>
+            </div>
+
+            <p>
+                The target is maintained by the difficulty adjustment: every 2016 blocks
+                (about two weeks) each node recomputes the proof-of-work target from the
+                time the previous window took. The algorithm, its clamping to a factor
+                of 4, and its off-by-one quirk are treated in Section 14.4
+                (Definition 14.4); here we record only that the 600-second constant is
+                the value the adjustment steers toward.
+            </p>
+
+            <div class="remark">
+                <p class="remark-title">Remark 15.4 (Why 10 Minutes?)</p>
+                <p>
+                    Satoshi chose 10 minutes as a balance between:
+                </p>
+                <ul>
+                    <li><strong>Faster:</strong> Better user experience, but more orphan blocks,
+                        wasted work, and centralization pressure</li>
+                    <li><strong>Slower:</strong> Fewer orphans, but worse user experience and
+                        slower finality</li>
+                </ul>
+                <p>
+                    Ten minutes allows global propagation before the next block, minimizing
+                    the disadvantage to honest miners.
+                </p>
+            </div>
+
+            <div class="example">
+                <p class="example-title">Example 15.1 (Timing Calculations)</p>
+                <pre class="code-block">Blocks per hour:    6
+Blocks per day:     144
+Blocks per week:    1,008
+Blocks per year:    ~52,560
+
+Time between halvings: 210,000 × 10 min = 2,100,000 min
+                     = 35,000 hours
+                     ≈ 1,458 days
+                     ≈ 4 years</pre>
+            </div>
+        </section>
+
+        <section>
+            <h2 id="s15-5">15.5 Block, Timestamp, and Script Limits</h2>
+
+            <p>
+                Several consensus limits constrain block contents rather than money. Each
+                is defined in the chapter that introduces the underlying structure; we
+                collect the cross-references here, together with the one limit not stated
+                elsewhere.
+            </p>
+
+            <p>
+                <strong>Block size.</strong> The block weight limit of 4,000,000 weight
+                units (Definition 13.9), equivalent to the original 1 MB size limit for
+                witness-free blocks (Definition 13.8), is discussed with block structure
+                in Section 13.4.
+            </p>
+
+            <p>
+                <strong>Timestamps.</strong> A block's timestamp must exceed its median
+                time past and may run at most 2 hours ahead of network-adjusted time
+                (Definition 13.5, Section 13.2.4); Appendix D states both rules in
+                catalog form.
+            </p>
+
+            <p>
+                <strong>Script limits.</strong> The 10,000-byte script size, 1,000-element
+                stack, 520-byte element, and 201-opcode bounds guarantee that script
+                validation terminates in bounded time and space (Section 11.12,
+                Theorem 11.1). Later script versions add limits of their own: at most 20
+                public keys in a CHECKMULTISIG, a 520-byte P2SH redeem script (BIP-16),
+                and at most 100 witness stack items with 10,000-byte witness scripts under
+                SegWit; Tapscript replaces most per-script limits with policy-only ones.
+                Policy limits in general (for example, the 400,000-weight-unit standardness
+                cap on transactions) are not consensus rules; Appendix D.6 catalogs them.
+            </p>
+
+            <div class="definition">
+                <p class="definition-title">Definition 15.4 (Sigop Limits)</p>
+                <p>
+                    Blocks are also limited by signature operations:
+                </p>
+                <ul>
+                    <li>Legacy: 20,000 sigops per block</li>
+                    <li>SegWit: 80,000 sigops (weighted)</li>
+                </ul>
+            </div>
+        </section>
+
+        <section>
+            <h2 id="s15-6">15.6 Coinbase Maturity</h2>
+
+            <div class="definition">
+                <p class="definition-title">Definition 15.5 (Coinbase Maturity)</p>
+                <p>
+                    Coinbase outputs cannot be spent until the block has received:
+                </p>
+                <p class="math-block">
+                    100 confirmations
+                </p>
+                <p>
+                    This is approximately 16.7 hours at average block times.
+                </p>
+            </div>
+
+            <div class="remark">
+                <p class="remark-title">Remark 15.5 (Why 100 Blocks?)</p>
+                <p>
+                    Coinbase maturity prevents issues if a block is later orphaned:
+                </p>
+                <ul>
+                    <li>The coinbase reward would disappear</li>
+                    <li>Any transactions spending those coins would become invalid</li>
+                    <li>This could cascade through many dependent transactions</li>
+                </ul>
+                <p>
+                    One hundred blocks makes deep reorganizations (which would orphan a mature coinbase)
+                    extremely unlikely.
+                </p>
+            </div>
+        </section>
+
+        <section>
+            <h2 id="s15-7">15.7 Parameter Immutability</h2>
 
             <p>
                 Consensus parameters are not merely difficult to change&mdash;altering them would
                 create a new, incompatible network.
             </p>
 
-            <div class="theorem">
-                <p class="theorem-title">Theorem 15.4 (Consensus Incompatibility)</p>
+            <div class="remark">
+                <p class="remark-title">Remark 15.6 (Protocol Rule: Consensus Incompatibility)</p>
                 <p>
-                    If a consensus parameter change <em>expands</em> the set of valid
-                    blocks (for example, raising the block weight limit or altering the
-                    supply schedule):
+                    A change that <em>expands</em> the set of valid blocks (for example,
+                    raising the block weight limit or altering the supply schedule) is a
+                    hard fork in the sense of Definition 26.5:
                 </p>
                 <ul>
                     <li>Nodes running old software reject the new blocks</li>
                     <li>The network can split into incompatible chains</li>
                 </ul>
                 <p>
-                    This is a <strong>hard fork</strong>, potentially creating a new
-                    currency. By contrast, <em>tightening</em> a parameter is a soft fork:
+                    The result is potentially a new currency. By contrast,
+                    <em>tightening</em> a parameter is a soft fork:
                     old nodes still accept the new, stricter blocks (Chapter 16).
                 </p>
             </div>
@@ -692,7 +544,7 @@ Time between halvings: 210,000 × 10 min = 2,100,000 min
         </section>
 
         <section>
-            <h2 id="s15-11">15.11 Summary of Key Constants</h2>
+            <h2 id="s15-8">15.8 Summary of Key Constants</h2>
 
             <table class="data-table">
                 <thead>

--- a/chapters/16-soft-forks.html
+++ b/chapters/16-soft-forks.html
@@ -451,16 +451,21 @@
                 see as valid (often "anyone can spend") to have new meaning.
             </p>
 
-            <div class="theorem">
-                <p class="theorem-title">Theorem 16.2 (Soft Fork Template)</p>
+            <div class="remark">
+                <p class="remark-title">Remark 16.6 (Design Pattern: The Soft Fork Template)</p>
                 <p>
-                    A rule change is a valid soft fork if it can be expressed as:
+                    A rule change can be deployed as a soft fork if it can be expressed as:
                 </p>
                 <ol>
                     <li>Identify a class of currently valid transactions</li>
                     <li>Add constraints that make some of them invalid</li>
                     <li>Ensure the constraints are enforceable by upgraded nodes</li>
                 </ol>
+                <p>
+                    This is a design recipe, not a theorem: any such change only restricts
+                    the valid set, which is exactly the soft fork condition of
+                    Definition 16.4.
+                </p>
             </div>
 
             <figure>
@@ -531,7 +536,7 @@
             </div>
 
             <div class="remark">
-                <p class="remark-title">Remark 16.6 (Standardness Changes)</p>
+                <p class="remark-title">Remark 16.7 (Standardness Changes)</p>
                 <p>
                     Notable standardness changes that were <em>not</em> soft forks:
                 </p>
@@ -552,8 +557,8 @@
 
             <h3 id="s16-7-1">16.7.1 Chain Split Risk</h3>
 
-            <div class="theorem">
-                <p class="theorem-title">Theorem 16.3 (Soft Fork Split Conditions)</p>
+            <div class="remark">
+                <p class="remark-title">Remark 16.8 (Soft Fork Split Conditions)</p>
                 <p>
                     A soft fork can cause a chain split if:
                 </p>
@@ -571,7 +576,7 @@
             <h3 id="s16-7-2">16.7.2 Coordination Challenges</h3>
 
             <div class="remark">
-                <p class="remark-title">Remark 16.7 (Upgrade Coordination)</p>
+                <p class="remark-title">Remark 16.9 (Upgrade Coordination)</p>
                 <p>
                     Soft fork deployment requires coordinating:
                 </p>
@@ -650,7 +655,7 @@
             </p>
 
             <div class="remark">
-                <p class="remark-title">Remark 16.8 (Consensus Beyond Code)</p>
+                <p class="remark-title">Remark 16.10 (Consensus Beyond Code)</p>
                 <p>
                     "Consensus" in Bitcoin has two meanings:
                 </p>

--- a/chapters/17-spv-theory.html
+++ b/chapters/17-spv-theory.html
@@ -150,24 +150,18 @@
                 <figcaption>Figure 17.1: An SPV client stores orders of magnitude less data than a full node.</figcaption>
             </figure>
 
-            <div class="theorem">
-                <p class="theorem-title">Theorem 17.1 (Header Chain Size)</p>
+            <div class="remark">
+                <p class="remark-title">Remark 17.1 (Header Chain Size)</p>
                 <p>
-                    The size of the complete header chain grows linearly with blockchain height:
+                    Since each block has exactly one 80-byte header, the size of the
+                    complete header chain grows linearly with blockchain height:
                 </p>
                 <p class="math-block">
                     size = 80 × height bytes
                 </p>
                 <p>
-                    At height 800,000: approximately 64 MB. Annual growth: ~4.2 MB/year.
-                </p>
-            </div>
-
-            <div class="proof">
-                <p class="proof-title">Proof.</p>
-                <p>
-                    Each block has exactly one 80-byte header. At ~52,560 blocks per year,
-                    annual growth = 52,560 × 80 = 4,204,800 bytes ≈ 4.2 MB. □
+                    At height 800,000: approximately 64 MB. At ~52,560 blocks per year,
+                    annual growth is 52,560 × 80 = 4,204,800 bytes ≈ 4.2 MB.
                 </p>
             </div>
         </section>
@@ -181,7 +175,7 @@
             </p>
 
             <div class="theorem">
-                <p class="theorem-title">Theorem 17.2 (SPV Inclusion Proof)</p>
+                <p class="theorem-title">Theorem 17.1 (SPV Inclusion Proof)</p>
                 <p>
                     Given:
                 </p>
@@ -281,8 +275,8 @@
                 SPV cannot verify.
             </p>
 
-            <div class="theorem">
-                <p class="theorem-title">Theorem 17.3 (SPV Limitations)</p>
+            <div class="remark">
+                <p class="remark-title">Remark 17.2 (SPV Limitations)</p>
                 <p>
                     An SPV client <strong>cannot independently verify</strong>:
                 </p>
@@ -293,27 +287,18 @@
                     <li>That the block's other transactions are valid</li>
                     <li>That consensus rules were followed</li>
                 </ol>
-            </div>
-
-            <div class="proof">
-                <p class="proof-title">Proof.</p>
                 <p>
-                    Each verification requires data the SPV client does not have:
-                </p>
-                <ol>
-                    <li>UTXO validation requires the UTXO set (not stored)</li>
-                    <li>Signature validation requires scripts from spent outputs (not stored)</li>
-                    <li>Double-spend detection requires transaction history (not stored)</li>
-                    <li>Block validation requires all transactions (not stored)</li>
-                    <li>Consensus validation requires full chain state (not stored)</li>
-                </ol>
-                <p>
-                    The SPV client has only headers and Merkle proofs. □
+                    The reason is that each check requires data the SPV client does not
+                    hold: UTXO validation requires the UTXO set; signature validation
+                    requires the scripts of the spent outputs; double-spend detection
+                    requires transaction history; block validation requires all
+                    transactions; consensus validation requires full chain state. The
+                    SPV client has only headers and Merkle proofs.
                 </p>
             </div>
 
             <div class="remark">
-                <p class="remark-title">Remark 17.1 (The Trust Assumption)</p>
+                <p class="remark-title">Remark 17.3 (The Trust Assumption)</p>
                 <p>
                     SPV works by <em>delegating</em> validation to miners. The reasoning is:
                 </p>
@@ -350,8 +335,8 @@
                 </ul>
             </div>
 
-            <div class="theorem">
-                <p class="theorem-title">Theorem 17.4 (SPV Security)</p>
+            <div class="remark">
+                <p class="remark-title">Remark 17.4 (SPV Attack Vectors)</p>
                 <p>
                     Under the honest majority assumption, an SPV client accepting a transaction
                     with <span class="math">k</span> confirmations faces two attack vectors:
@@ -370,8 +355,8 @@
                 Can an attacker fool an SPV client with a fake transaction?
             </p>
 
-            <div class="theorem">
-                <p class="theorem-title">Theorem 17.5 (Fabrication Cost)</p>
+            <div class="remark">
+                <p class="remark-title">Remark 17.5 (Fabrication Cost)</p>
                 <p>
                     To fabricate a transaction with <span class="math">k</span> confirmations,
                     an attacker must:
@@ -387,7 +372,7 @@
             </div>
 
             <div class="remark">
-                <p class="remark-title">Remark 17.2 (The Catch)</p>
+                <p class="remark-title">Remark 17.6 (The Catch)</p>
                 <p>
                     The fabricated chain will be shorter (less work) than the honest chain.
                     An SPV client that correctly identifies the most-work chain will reject it.
@@ -424,7 +409,7 @@
             </div>
 
             <div class="remark">
-                <p class="remark-title">Remark 17.3 (The Difficulty Caveat)</p>
+                <p class="remark-title">Remark 17.7 (The Difficulty Caveat)</p>
                 <p>
                     Example 17.1's arithmetic silently assumes the client verifies that each
                     header's difficulty target follows the adjustment rules (Phase 1 of the
@@ -501,7 +486,7 @@
             </p>
 
             <div class="theorem">
-                <p class="theorem-title">Theorem 17.6 (Confirmation Security)</p>
+                <p class="theorem-title">Theorem 17.2 (Confirmation Security)</p>
                 <p>
                     For an attacker with hash power fraction <span class="math">q < 0.5</span>,
                     the probability of reversing a transaction with <span class="math">k</span>
@@ -514,7 +499,7 @@
                     where <span class="math">λ = k(q/p)</span> and <span class="math">p = 1 − q</span>
                     (the Nakamoto formula from Section 11 of the Bitcoin whitepaper; here
                     <span class="math">k</span> counts confirmations, playing the role of
-                    <span class="math">z</span> in Theorem 14.4).
+                    <span class="math">z</span> in Theorem 14.2).
                 </p>
             </div>
 
@@ -556,7 +541,7 @@
             </table>
 
             <div class="remark">
-                <p class="remark-title">Remark 17.4 (Same Security as Full Nodes)</p>
+                <p class="remark-title">Remark 17.8 (Same Security as Full Nodes)</p>
                 <p>
                     Importantly, these probabilities are <em>identical</em> for SPV clients and
                     full nodes. The confirmation security against double-spends depends only on
@@ -590,7 +575,7 @@
             </div>
 
             <div class="remark">
-                <p class="remark-title">Remark 17.5 (Fraud Proofs Don't Exist Yet)</p>
+                <p class="remark-title">Remark 17.9 (Fraud Proofs Don't Exist Yet)</p>
                 <p>
                     Despite years of research, general-purpose fraud proofs for Bitcoin do not
                     exist. The problem is that proving a transaction is invalid requires proving
@@ -673,7 +658,7 @@
             </p>
 
             <div class="remark">
-                <p class="remark-title">Remark 17.6 (SPV Use Cases)</p>
+                <p class="remark-title">Remark 17.10 (SPV Use Cases)</p>
                 <p>
                     <strong>SPV is appropriate when:</strong>
                 </p>
@@ -709,7 +694,7 @@
             </p>
 
             <div class="remark">
-                <p class="remark-title">Remark 17.7 (SPV in Practice)</p>
+                <p class="remark-title">Remark 17.11 (SPV in Practice)</p>
                 <p>
                     The original SPV concept assumed:
                 </p>
@@ -731,7 +716,7 @@
             <div class="example">
                 <p class="example-title">Example 17.2 (July 2015: The Assumption Fails Without an Attacker)</p>
                 <p>
-                    The honest-majority assumption of Theorem 17.4 failed observably once, and
+                    The honest-majority assumption of Definition 17.3 failed observably once, and
                     no adversary was needed. When the BIP-66 soft fork activated in early July
                     2015, a substantial fraction of the network's hashrate&mdash;by
                     contemporaneous estimates, roughly half&mdash;was engaged in
@@ -750,7 +735,7 @@
                     confirmations for large payments.
                 </p>
                 <p>
-                    The lesson sharpens the theorem's hypothesis: SPV security rests not on a
+                    The lesson sharpens the assumption itself: SPV security rests not on a
                     majority of hashrate being <em>honest</em>, but on a majority being honest
                     <em>and validating</em>. Hashrate that follows headers without checking
                     blocks counts toward proof of work but not toward the enforcement of

--- a/chapters/18-bloom-filters.html
+++ b/chapters/18-bloom-filters.html
@@ -217,7 +217,7 @@
                     </g>
                 </svg>
                 <figcaption>
-                    <strong>Figure 18.1</strong>&mdash;Bloom filter operations with k=3 hash functions.
+                    <strong>Figure 18.1:</strong> Bloom filter operations with k=3 hash functions.
                     Red cells indicate bits set to 1. A query returns "possibly in set" only if
                     all k bits are set.
                 </figcaption>
@@ -478,7 +478,7 @@
                     </g>
                 </svg>
                 <figcaption>
-                    <strong>Figure 18.2</strong>&mdash;A merkleblock message contains just enough
+                    <strong>Figure 18.2:</strong> A merkleblock message contains just enough
                     Merkle tree nodes to prove that matched transactions are included in the block.
                     The client receives TX B in full, plus hashes H(A) and H(CD) to verify inclusion.
                 </figcaption>
@@ -541,26 +541,20 @@
 
             <h3>Attack 1: Direct Address Extraction</h3>
 
-            <div class="theorem">
-                <p><strong>Theorem 18.2</strong> (Filter Analysis Attack)</p>
+            <div class="remark">
+                <p><strong>Remark 18.1</strong> (Filter Analysis Attack)</p>
                 <p>
                     Given a Bloom filter with parameters (<span class="math">m</span>, <span class="math">k</span>, <code>nTweak</code>),
-                    an attacker can test arbitrary addresses against the filter locally. By testing
-                    all addresses that have ever appeared on the blockchain, the attacker recovers
-                    the wallet's address set with high probability.
-                </p>
-            </div>
-
-            <div class="proof">
-                <p><strong>Proof sketch.</strong></p>
-                <p>
-                    The attacker knows the hash function construction (Algorithm 18.1). For each
-                    candidate address <span class="math">a</span>, they compute <span class="math">h₀(a), h₁(a), ..., hₖ₋₁(a)</span>
-                    and check if all corresponding bits are set. True positives (actual wallet
-                    addresses) will always match. False positives occur at rate <span class="math">p</span>, but with
-                    millions of blockchain addresses and typical filter sizes, the number of
-                    false positives is small and can often be distinguished through blockchain
-                    graph analysis. ∎
+                    an attacker can test arbitrary addresses against the filter locally: the
+                    hash function construction (Algorithm 18.1) is public, so for each
+                    candidate address <span class="math">a</span> the attacker computes
+                    <span class="math">h₀(a), h₁(a), ..., hₖ₋₁(a)</span> and checks whether all
+                    corresponding bits are set. True positives (actual wallet addresses)
+                    always match; false positives occur at rate <span class="math">p</span>, and the survivors
+                    can often be distinguished through blockchain graph analysis. By testing
+                    all addresses that have ever appeared on the blockchain, the attacker
+                    recovers the wallet's address set with high probability; Gervais et al.
+                    (2014) demonstrated this empirically (Example 18.2).
                 </p>
             </div>
 
@@ -612,14 +606,14 @@
                     </defs>
                 </svg>
                 <figcaption>
-                    <strong>Figure 18.3</strong>&mdash;When a client updates their filter (e.g., after
+                    <strong>Figure 18.3:</strong> When a client updates their filter (e.g., after
                     generating new addresses), the intersection of matched addresses across filter
                     versions eliminates false positives and reveals true wallet addresses.
                 </figcaption>
             </figure>
 
             <div class="theorem">
-                <p><strong>Theorem 18.3</strong> (Intersection Attack)</p>
+                <p><strong>Proposition 18.1</strong> (Intersection Attack)</p>
                 <p>
                     If a client sends filter versions <span class="math">F₁</span> and <span class="math">F₂</span> with different tweaks or sizes,
                     the intersection of matching addresses has vastly reduced false positive rate:
@@ -629,6 +623,20 @@
                 </div>
                 <p>
                     After just 3 filter versions with <span class="math">p = 0.001</span>, the false positive rate drops to <span class="math">10⁻⁹</span>.
+                </p>
+            </div>
+
+            <div class="proof">
+                <p><strong>Proof.</strong></p>
+                <p>
+                    A true wallet address matches every filter version, so it survives the
+                    intersection with probability 1. For an address <em>not</em> in the
+                    wallet, matching <span class="math">F₁</span> is an event of probability
+                    <span class="math">p₁</span> and matching <span class="math">F₂</span> one of probability <span class="math">p₂</span>; because the
+                    tweaks (or sizes) differ, the two filters probe different hash values,
+                    and under the same independence heuristic used in Theorem 18.1 the two
+                    events are independent. The probability of surviving both is therefore
+                    approximately <span class="math">p₁ · p₂</span>, and <span class="math">pᵏ</span> for <span class="math">k</span> independent versions. ∎
                 </p>
             </div>
 
@@ -660,7 +668,7 @@
             <h3>Quantifying the Privacy Loss</h3>
 
             <div class="remark">
-                <p><strong>Remark 18.1</strong> (Practical Privacy Bound)</p>
+                <p><strong>Remark 18.2</strong> (Practical Privacy Bound)</p>
                 <p>
                     Empirically, under realistic conditions (persistent connections, repeated
                     queries, filter updates), a malicious node identifies all wallet addresses
@@ -692,8 +700,8 @@
 
             <h3>Computational Asymmetry</h3>
 
-            <div class="theorem">
-                <p><strong>Theorem 18.4</strong> (DoS Amplification)</p>
+            <div class="remark">
+                <p><strong>Remark 18.3</strong> (DoS Amplification)</p>
                 <p>
                     Processing a Bloom filter request against a block requires:
                 </p>
@@ -911,7 +919,7 @@
                     </defs>
                 </svg>
                 <figcaption>
-                    <strong>Figure 18.4</strong>&mdash;Complete BIP-37 protocol flow showing filter
+                    <strong>Figure 18.4:</strong> Complete BIP-37 protocol flow showing filter
                     submission, filtered block requests, and optional filter updates.
                 </figcaption>
             </figure>

--- a/chapters/19-compact-filters.html
+++ b/chapters/19-compact-filters.html
@@ -185,7 +185,7 @@
                     </defs>
                 </svg>
                 <figcaption>
-                    <strong>Figure 19.1</strong>&mdash;The fundamental difference: BIP-37 has clients
+                    <strong>Figure 19.1:</strong> The fundamental difference: BIP-37 has clients
                     send filters to servers (privacy leak); BIP-157/158 has servers publish
                     filters that clients test locally (privacy preserved).
                 </figcaption>
@@ -383,7 +383,7 @@
                     </defs>
                 </svg>
                 <figcaption>
-                    <strong>Figure 19.2</strong>&mdash;GCS construction: hash elements to numeric range,
+                    <strong>Figure 19.2:</strong> GCS construction: hash elements to numeric range,
                     sort, compute deltas, Golomb-Rice encode. The result is highly compact.
                 </figcaption>
             </figure>
@@ -729,7 +729,7 @@
                     </defs>
                 </svg>
                 <figcaption>
-                    <strong>Figure 19.3</strong>&mdash;Filter header chain: each header commits to
+                    <strong>Figure 19.3:</strong> Filter header chain: each header commits to
                     the current filter and all previous headers, forming a verifiable chain.
                 </figcaption>
             </figure>
@@ -804,7 +804,7 @@
                     </defs>
                 </svg>
                 <figcaption>
-                    <strong>Figure 19.4</strong>&mdash;Three-phase sync: (1) download checkpoints for
+                    <strong>Figure 19.4:</strong> Three-phase sync: (1) download checkpoints for
                     coarse verification, (2) download headers to verify filter chain, (3) download
                     and process individual filters.
                 </figcaption>

--- a/chapters/20-light-clients.html
+++ b/chapters/20-light-clients.html
@@ -405,8 +405,8 @@ script_hash (little-endian hex) = 56f4de...23c1ab</code></pre>
 
             <h3>What the Server Learns</h3>
 
-            <div class="theorem">
-                <p><strong>Theorem 20.1</strong> (Electrum Privacy Leakage)</p>
+            <div class="remark">
+                <p><strong>Remark 20.1</strong> (Electrum Privacy Leakage)</p>
                 <p>
                     When a client connects to an Electrum server, the server learns:
                 </p>
@@ -419,16 +419,13 @@ script_hash (little-endian hex) = 56f4de...23c1ab</code></pre>
                     <li>Client IP address (without Tor)</li>
                     <li>Wallet software and version (from protocol negotiation)</li>
                 </ol>
-            </div>
-
-            <div class="proof">
-                <p><strong>Proof.</strong></p>
                 <p>
-                    The Electrum protocol requires the client to send scriptPubKey hashes
-                    to query address history. The server must store and respond to these
-                    queries, necessarily learning the queried addresses. Subscription
-                    requests explicitly reveal ongoing interest. Transaction broadcasts
-                    reveal spending before the transaction propagates through the P2P network. ∎
+                    This leakage is structural, not accidental: the Electrum protocol
+                    requires the client to send scriptPubKey hashes to query address
+                    history, so the server necessarily learns the queried addresses.
+                    Subscription requests explicitly reveal ongoing interest, and
+                    transaction broadcasts reveal spending before the transaction
+                    propagates through the P2P network.
                 </p>
             </div>
 
@@ -514,8 +511,8 @@ Response:
 
             <h3>Trust Model</h3>
 
-            <div class="theorem">
-                <p><strong>Theorem 20.2</strong> (API Trust Requirements)</p>
+            <div class="remark">
+                <p><strong>Remark 20.2</strong> (API Trust Requirements)</p>
                 <p>
                     When using a third-party API:
                 </p>
@@ -861,7 +858,7 @@ Response:
             </p>
 
             <div class="theorem">
-                <p><strong>Theorem 20.3</strong> (Fraud Proof Coverage)</p>
+                <p><strong>Theorem 20.1</strong> (Fraud Proof Coverage)</p>
                 <p>
                     Given a distribution mechanism for fraud proofs and assuming data
                     availability (that is, block data is accessible to at least one

--- a/chapters/22-client-side-validation.html
+++ b/chapters/22-client-side-validation.html
@@ -521,8 +521,8 @@
                 </ul>
             </div>
 
-            <div class="theorem">
-                <p><strong>Theorem 22.2</strong> (RGB Validation Completeness)</p>
+            <div class="remark">
+                <p><strong>Remark 22.2</strong> (RGB Validation Completeness)</p>
                 <p>
                     Given a valid consignment, a receiver can independently verify:
                 </p>
@@ -530,10 +530,13 @@
                     <li>The genesis contract is valid</li>
                     <li>Every state transition follows contract rules</li>
                     <li>Every anchor exists in a confirmed Bitcoin block</li>
-                    <li>No seal was closed twice (via Bitcoin UTXO uniqueness)</li>
+                    <li>No seal was closed twice (via Bitcoin UTXO uniqueness, Theorem 22.1)</li>
                 </ol>
                 <p>
-                    The receiver needs no trusted third party: verification is purely mathematical.
+                    The receiver needs no trusted third party for these checks. This is a
+                    design property of the protocol, not a proved theorem: it holds only
+                    insofar as the validation code correctly implements the contract
+                    schema, and a precise security analysis is beyond this section.
                 </p>
             </div>
 
@@ -702,8 +705,8 @@
 
             <h3>On-Chain Footprint</h3>
 
-            <div class="theorem">
-                <p><strong>Theorem 22.3</strong> (CSV On-Chain Scaling)</p>
+            <div class="remark">
+                <p><strong>Remark 22.3</strong> (CSV On-Chain Scaling)</p>
                 <p>
                     For <span class="math">N</span> client-side validation transfers, the blockchain footprint is:
                 </p>
@@ -720,8 +723,8 @@
 
             <h3>Validation Cost</h3>
 
-            <div class="theorem">
-                <p><strong>Theorem 22.4</strong> (Validation Scaling)</p>
+            <div class="remark">
+                <p><strong>Remark 22.4</strong> (Validation Scaling)</p>
                 <p>
                     Receiver validation cost is <span class="math">O(history_length)</span>, not <span class="math">O(all_transfers)</span>:
                 </p>

--- a/chapters/23-payment-channels.html
+++ b/chapters/23-payment-channels.html
@@ -119,8 +119,8 @@
                 solutions move transactions off-chain while preserving Bitcoin's security:
             </p>
 
-            <div class="theorem">
-                <p><strong>Theorem 23.1</strong> (Payment Channel Scaling)</p>
+            <div class="remark">
+                <p><strong>Remark 23.1</strong> (Payment Channel Scaling)</p>
                 <p>
                     A payment channel between two parties requires:
                 </p>
@@ -129,7 +129,9 @@
                     <li><strong>Off-chain:</strong> Unlimited transactions between parties</li>
                 </ul>
                 <p>
-                    If a channel supports <span class="math">N</span> off-chain payments, throughput multiplies by <span class="math">N/2</span>.
+                    If a channel supports <span class="math">N</span> off-chain payments, the two on-chain
+                    transactions stand in for <span class="math">N</span> payments: a multiplier of <span class="math">N/2</span> in
+                    payments per unit of block space.
                 </p>
             </div>
         </section>
@@ -250,8 +252,8 @@
 
             <h3>Security Analysis</h3>
 
-            <div class="theorem">
-                <p><strong>Theorem 23.2</strong> (Unidirectional Channel Security)</p>
+            <div class="remark">
+                <p><strong>Remark 23.2</strong> (Unidirectional Channel Security)</p>
                 <p>
                     In a unidirectional channel:
                 </p>
@@ -260,6 +262,11 @@
                     <li><strong>Alice's guarantee:</strong> Bob can only claim what Alice signed</li>
                     <li><strong>Problem:</strong> Alice cannot recover uncommitted funds if Bob disappears</li>
                 </ul>
+                <p>
+                    We state these guarantees informally: a precise security analysis,
+                    accounting for timelock expiry, fee dynamics, and blockchain
+                    congestion, is beyond this section.
+                </p>
             </div>
 
             <h3>Adding Timelocks</h3>
@@ -527,8 +534,8 @@ OP_ENDIF</code></pre>
                 </ol>
             </div>
 
-            <div class="theorem">
-                <p><strong>Theorem 23.3</strong> (LN-Penalty Security)</p>
+            <div class="remark">
+                <p><strong>Remark 23.3</strong> (LN-Penalty Security)</p>
                 <p>
                     In an LN-Penalty channel:
                 </p>
@@ -537,6 +544,12 @@ OP_ENDIF</code></pre>
                     <li><strong>Cheating attempt:</strong> Cheater loses all funds to counterparty</li>
                     <li><strong>Requirement:</strong> Honest party must be online during timelock</li>
                 </ul>
+                <p>
+                    As with Remark 23.2, these are the intended guarantees of the
+                    construction rather than proved theorems; a rigorous treatment must
+                    model timelocks, fees, and chain access, and is beyond this section
+                    (Exercise 23.2 develops the incentive argument).
+                </p>
             </div>
         </section>
 
@@ -759,10 +772,11 @@ OP_ENDIF</code></pre>
 
             <h3>Watchtower Privacy</h3>
 
-            <div class="theorem">
-                <p><strong>Theorem 23.4</strong> (Watchtower Privacy)</p>
+            <div class="remark">
+                <p><strong>Remark 23.4</strong> (Watchtower Privacy)</p>
                 <p>
-                    Watchtowers can operate without learning channel balances:
+                    Watchtowers can operate without learning channel balances. The design
+                    pattern:
                 </p>
                 <ul>
                     <li>Client provides encrypted blob keyed to commitment txid</li>

--- a/chapters/26-fork-theory.html
+++ b/chapters/26-fork-theory.html
@@ -302,7 +302,8 @@
                     Thus, the chain built by the majority (enforcing <span class="math">R<sub>new</sub></span>) is accepted
                     by all nodes. A chain violating <span class="math">R<sub>new</sub></span> can only be extended by the minority
                     (fraction <span class="math">1 − f &lt; 0.5</span>). The work race between the two chains is a biased
-                    random walk: by the gambler's-ruin argument of Theorem 14.4, the enforcing
+                    random walk: by the gambler's-ruin argument of Section 26.7 (proof of
+                    Theorem 26.3), the enforcing
                     majority's chain takes and keeps the cumulative-work lead with probability 1.
                     Old nodes might temporarily follow an invalid chain (as in the 2015 BIP-66
                     incident), but converge once the valid chain has more work. □
@@ -586,14 +587,21 @@
                 </p>
             </div>
 
+            <p>
+                The next theorem makes the exponential decay precise. Its statement is the
+                double-spend formula of Section 14.8, which Chapter 14 cites from the
+                whitepaper without proof; the gambler's-ruin derivation below is the
+                missing argument.
+            </p>
+
             <div class="theorem">
-                <p class="theorem-title">Theorem 26.3 (Double-Spend Probability)</p>
+                <p class="theorem-title">Theorem 26.3 (Double-Spend Probability; derives Theorem 14.2)</p>
                 <p>
                     Let <span class="math">q</span> be the fraction of hash power controlled by an attacker, <span class="math">p = 1 − q</span>
                     with <span class="math">q &lt; p</span>, and <span class="math">k</span> be the number of confirmations. The probability that
                     the attacker, once <span class="math">k</span> blocks behind, ever catches up is <span class="math">(q/p)ᵏ</span>.
                     Accounting also for blocks the attacker mines during the confirmation
-                    period (Theorem 14.4), the probability of a successful double-spend is:
+                    period, the probability of a successful double-spend is:
                 </p>
                 <p class="math-block">
                     P(double-spend) = 1 − Σₘ₌₀ᵏ [λᵐe^(−λ)/m! × (1 − (q/p)^(k−m))],&nbsp;&nbsp;λ = k(q/p)
@@ -603,42 +611,54 @@
                 </p>
             </div>
 
-            <table class="data-table">
-                <thead>
-                    <tr>
-                        <th>Attacker Hash Rate</th>
-                        <th>1 conf</th>
-                        <th>3 conf</th>
-                        <th>6 conf</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr>
-                        <td>10%</td>
-                        <td>20.5%</td>
-                        <td>1.3%</td>
-                        <td>0.02%</td>
-                    </tr>
-                    <tr>
-                        <td>25%</td>
-                        <td>52.2%</td>
-                        <td>19.6%</td>
-                        <td>5.0%</td>
-                    </tr>
-                    <tr>
-                        <td>33%</td>
-                        <td>69.0%</td>
-                        <td>41.7%</td>
-                        <td>21.3%</td>
-                    </tr>
-                    <tr>
-                        <td>45%</td>
-                        <td>92.0%</td>
-                        <td>84.4%</td>
-                        <td>76.6%</td>
-                    </tr>
-                </tbody>
-            </table>
+            <div class="proof">
+                <p class="proof-title">Proof.</p>
+                <p>
+                    Model the race after the fork point as a sequence of independent block
+                    discoveries, each won by the attacker with probability <span class="math">q</span>
+                    and by the honest network with probability <span class="math">p</span>. Suppose
+                    first that the attacker is <span class="math">z ≥ 1</span> blocks behind, and let
+                    <span class="math">a<sub>z</sub></span> be the probability that the attacker ever
+                    erases the deficit: the classical gambler's-ruin probability against an
+                    opponent whose lead may grow without bound. Conditioning on who finds the
+                    next block gives the recurrence
+                </p>
+                <p class="math-block">
+                    a<sub>z</sub> = q·a<sub>z−1</sub> + p·a<sub>z+1</sub>&nbsp;&nbsp;(z ≥ 1),&nbsp;&nbsp;a₀ = 1.
+                </p>
+                <p>
+                    The characteristic equation <span class="math">p·x² − x + q = 0</span> has roots
+                    <span class="math">1</span> and <span class="math">q/p</span>, so every solution has
+                    the form <span class="math">a<sub>z</sub> = A + B·(q/p)ᶻ</span>. A deficit that grows
+                    without bound is never erased, so <span class="math">a<sub>z</sub> → 0</span> as
+                    <span class="math">z → ∞</span>, forcing <span class="math">A = 0</span>; the boundary
+                    condition <span class="math">a₀ = 1</span> then gives <span class="math">B = 1</span>.
+                    Hence <span class="math">a<sub>z</sub> = (q/p)ᶻ</span>, the catch-up probability claimed.
+                </p>
+                <p>
+                    During the victim's <span class="math">k</span> confirmations the attacker mines
+                    in secret. While the honest network finds <span class="math">k</span> blocks, the
+                    attacker's expected progress is <span class="math">λ = k(q/p)</span> blocks, and the
+                    number <span class="math">m</span> of attacker blocks is approximated as Poisson
+                    with mean <span class="math">λ</span> (the Poisson approximation of Section 14.2;
+                    the exact distribution is negative binomial). If <span class="math">m ≤ k</span>,
+                    the attacker is <span class="math">z = k − m</span> behind and catches up with
+                    probability <span class="math">(q/p)^(k−m)</span>; if <span class="math">m &gt; k</span>,
+                    the attacker already leads and succeeds outright. Summing over
+                    <span class="math">m</span>:
+                </p>
+                <p class="math-block">
+                    P = 1 − Σₘ₌₀ᵏ [λᵐe^(−λ)/m! × (1 − (q/p)^(k−m))],
+                </p>
+                <p>
+                    which is the formula stated as Theorem 14.2. □
+                </p>
+            </div>
+
+            <p>
+                Numerical values for representative attacker shares and confirmation depths
+                are given in the table of Section 14.8; we do not repeat them here.
+            </p>
 
             <div class="remark">
                 <p class="remark-title">Remark 26.8 (Deep Reorgs)</p>

--- a/chapters/34-scaling-verification.html
+++ b/chapters/34-scaling-verification.html
@@ -124,7 +124,7 @@
                         <td><span class="math">80 &times; height</span> bytes
                             <span class="math">&asymp; 72 MB</span></td>
                         <td>~12 KB/day of headers</td>
-                        <td>Theorem 17.1</td>
+                        <td>Remark 17.1</td>
                     </tr>
                     <tr>
                         <td>Neutrino (BIP-157/158)</td>
@@ -254,7 +254,7 @@
                 <strong>Headers-first sync is cacheable, verifiable state transfer.</strong>
                 The header chain of Chapter 17 is identical for every client, immutable
                 once buried, and self-authenticating: a client checks the proof-of-work
-                and the hash links itself (Theorem 17.1 prices the whole chain at
+                and the hash links itself (Remark 17.1 prices the whole chain at
                 <span class="math">80 &times; height</span> bytes). Because verification
                 travels with the data, the data can be served by <em>anyone</em>: an
                 untrusted mirror, a CDN, a peer. This is exactly the property REST's cache
@@ -276,7 +276,7 @@
             <p>
                 <strong>The layered money stack is REST's layered system.</strong>
                 Chapters 23 and 24 built payments in layers: the chain settles channel
-                opens and closes, channels carry the traffic, and Theorem 23.1 gives the
+                opens and closes, channels carry the traffic, and Remark 23.1 gives the
                 multiplier: <span class="math">N</span> payments per channel cost two
                 on-chain transactions. A Lightning payer sees only the adjacent layer; the
                 base chain neither knows nor consents. This is the layered-system
@@ -359,7 +359,7 @@
                         TCP-speaking node network must exist.</li>
                     <li><strong>Storage quotas.</strong> Persistent storage is limited and
                         evictable. The full header chain
-                        (<span class="math">&asymp; 72 MB</span>, Theorem 17.1) fits
+                        (<span class="math">&asymp; 72 MB</span>, Remark 17.1) fits
                         within typical quotas; a checkpointed anchor (shipping the
                         client with a recent header hash and syncing forward from
                         it) reduces the requirement to megabytes, at a trust cost
@@ -852,7 +852,7 @@
                     chain, and whose depositors can exit to self-custody at the cost of
                     one transaction, is constrained as no fractional-reserve bank ever
                     was; second, the alternative of placing all economic activity
-                    on-chain fails on arithmetic, since Theorem 23.1's two on-chain
+                    on-chain fails on arithmetic, since Remark 23.1's two on-chain
                     transactions per channel is already the optimistic case and Chapter
                     23's throughput analysis admits no global payment volume at the base
                     layer. Both positions are coherent; they weigh the same ladder
@@ -909,7 +909,7 @@
             <div class="exercise">
                 <p class="exercise-title">Exercise 34.1</p>
                 <p>
-                    Using Theorem 17.1, compute the size of the complete header chain at
+                    Using Remark 17.1, compute the size of the complete header chain at
                     the start of 2031. Take the height as approximately
                     <span class="math">901,000</span> in mid-2026 and assume
                     <span class="math">52,560</span> blocks per year for the intervening

--- a/chapters/36-security-threats.html
+++ b/chapters/36-security-threats.html
@@ -134,63 +134,33 @@
                 <p>
                     Let <span class="math">q</span> be attacker hashrate fraction,
                     <span class="math">p = 1 − q</span> honest hashrate, and <span class="math">k</span>
-                    the number of confirmations. The exact probability of a successful
+                    the number of confirmations. The probability of a successful
                     double-spend (Nakamoto, 2008) is:
                 </p>
                 <p class="math-block">
-                    P(success) = 1 if q ≥ 0.5<br>
-                    P(success) = 1 − Σₘ₌₀ᵏ [λᵐe^(−λ)/m! · (1 − (q/p)^(k−m))] if q &lt; 0.5
+                    P(success) = 1 if q ≥ 0.5
                 </p>
                 <p>
-                    where <span class="math">λ = k · (q/p)</span>. The simplified approximation
-                    <span class="math">(q/p)ᵏ</span>
-                    underestimates the probability because it ignores the attacker's
-                    Poisson-distributed progress during the <span class="math">k</span> confirmations; the table
-                    below uses the exact Poisson formula.
+                    and, if <span class="math">q &lt; 0.5</span>, the value given by Nakamoto's
+                    formula, stated as Theorem 14.2 and derived by the gambler's-ruin
+                    argument of Theorem 26.3. In that case the probability decreases
+                    geometrically in <span class="math">k</span>, dominated by the catch-up
+                    factor <span class="math">(q/p)ᵏ</span>.
                 </p>
             </div>
 
-            <table class="data-table">
-                <thead>
-                    <tr>
-                        <th>Attacker Hashrate</th>
-                        <th>1 conf</th>
-                        <th>3 conf</th>
-                        <th>6 conf</th>
-                        <th>12 conf</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr>
-                        <td>10%</td>
-                        <td>20%</td>
-                        <td>1%</td>
-                        <td>0.02%</td>
-                        <td>~0%</td>
-                    </tr>
-                    <tr>
-                        <td>25%</td>
-                        <td>52%</td>
-                        <td>20%</td>
-                        <td>5%</td>
-                        <td>0.4%</td>
-                    </tr>
-                    <tr>
-                        <td>40%</td>
-                        <td>83%</td>
-                        <td>66%</td>
-                        <td>50%</td>
-                        <td>31%</td>
-                    </tr>
-                    <tr>
-                        <td>50%</td>
-                        <td>100%</td>
-                        <td>100%</td>
-                        <td>100%</td>
-                        <td>100%</td>
-                    </tr>
-                </tbody>
-            </table>
+            <p>
+                Numerical values are tabulated in Section 14.8. Two readings of that table
+                matter for security policy. First, confirmations buy exponential safety
+                only against a minority attacker: at <span class="math">q = 0.10</span>,
+                six confirmations leave a success probability of about 0.02%, but at
+                <span class="math">q = 0.40</span>, even twelve confirmations leave about 31%.
+                Second, no confirmation count protects against a majority attacker:
+                the <span class="math">q ≥ 0.5</span> case of Theorem 36.1 is the formal
+                content of the term "51% attack". Exchanges and merchants therefore scale
+                confirmation requirements with the value at risk and with their estimate
+                of plausibly attainable hashrate (Chapter 37).
+            </p>
         </section>
 
         <section>

--- a/chapters/appendix-a-notation.html
+++ b/chapters/appendix-a-notation.html
@@ -105,7 +105,7 @@
                 <tr>
                     <td><span class="math">x || y</span></td>
                     <td>Concatenation of byte strings <span class="math">x</span> and <span class="math">y</span></td>
-                    <td>Ch. 5</td>
+                    <td>Ch. 9</td>
                 </tr>
             </table>
         </section>
@@ -449,17 +449,17 @@
                 <tr>
                     <td><span class="math">q</span>, <span class="math">p = 1 − q</span></td>
                     <td>The attacker's and honest network's fractions of total hashrate</td>
-                    <td>Thm. 14.4</td>
+                    <td>Thm. 14.2</td>
                 </tr>
                 <tr>
                     <td><span class="math">z</span> (or <span class="math">k</span>)</td>
                     <td>The number of confirmations a transaction has received</td>
-                    <td>Thm. 14.4, 17.6</td>
+                    <td>Thm. 14.2, 17.2</td>
                 </tr>
                 <tr>
                     <td><span class="math">λ = z(q/p)</span></td>
                     <td>The Poisson intensity in Nakamoto's double-spend analysis: the attacker's expected progress during <span class="math">z</span> confirmations</td>
-                    <td>Thm. 14.4</td>
+                    <td>Thm. 14.2</td>
                 </tr>
                 <tr>
                     <td><span class="math">E[X]</span></td>

--- a/chapters/appendix-c-index.html
+++ b/chapters/appendix-c-index.html
@@ -116,13 +116,13 @@
                 <li>CLTV delta &middot; <a href="24-lightning.html#s24-1">&sect;24.1</a></li>
                 <li>coexistence model (monetary) &middot; <a href="40-monetary-future.html#s40-9">&sect;40.9</a></li>
                 <li>cofactor &middot; <a href="04-elliptic-curves-finite.html#s4-4">&sect;4.4</a>, <a href="05-secp256k1.html#s5-5">&sect;5.5</a></li>
-                <li>coinbase maturity &middot; <a href="15-consensus-parameters.html#s15-5">&sect;15.5</a></li>
+                <li>coinbase maturity &middot; <a href="15-consensus-parameters.html#s15-6">&sect;15.6</a></li>
                 <li>coinbase transaction &middot; <a href="10-transactions.html#s10-10">&sect;10.10</a>, <a href="13-blocks.html#s13-6">&sect;13.6</a></li>
                 <li>collision resistance &middot; <a href="06-hash-functions.html#s6-1">&sect;6.1</a>, <a href="12-merkle-trees.html#s12-4">&sect;12.4</a></li>
                 <li>commitment transaction &middot; <a href="23-payment-channels.html#s23-4">&sect;23.4</a></li>
                 <li>compact block filter &middot; <a href="19-compact-filters.html#s19-3">&sect;19.3</a></li>
                 <li>compact block relay &middot; <a href="13-blocks.html#s13-9">&sect;13.9</a></li>
-                <li>compressed public key &middot; <a href="05-secp256k1.html#s5-8">&sect;5.8</a>, <a href="09-keys-addresses.html#s9-2-1">&sect;9.2.1</a></li>
+                <li>compressed public key &middot; <a href="09-keys-addresses.html#s9-2-1">&sect;9.2.1</a>, <a href="05-secp256k1.html#s5-7">&sect;5.7</a></li>
                 <li>confirmation security &middot; <a href="17-spv-theory.html#s17-6">&sect;17.6</a>, <a href="13-blocks.html#s13-7">&sect;13.7</a>, <a href="37-defense-mechanisms.html#s37-1">&sect;37.1</a></li>
                 <li>congruence &middot; <a href="02-finite-fields.html#s2-1">&sect;2.1</a></li>
                 <li>consensus rule &middot; <a href="16-soft-forks.html#s16-1">&sect;16.1</a></li>
@@ -143,7 +143,7 @@
                 <li>data availability problem &middot; <a href="20-light-clients.html#s20-6">&sect;20.6</a></li>
                 <li>DER encoding &middot; <a href="07-ecdsa.html#s7-9">&sect;7.9</a></li>
                 <li>difficulty &middot; <a href="14-proof-of-work.html#s14-3">&sect;14.3</a></li>
-                <li>difficulty adjustment &middot; <a href="14-proof-of-work.html#s14-4">&sect;14.4</a>, <a href="15-consensus-parameters.html#s15-3">&sect;15.3</a></li>
+                <li>difficulty adjustment &middot; <a href="14-proof-of-work.html#s14-4">&sect;14.4</a>, <a href="15-consensus-parameters.html#s15-4">&sect;15.4</a></li>
                 <li>difficulty death spiral &middot; <a href="26-fork-theory.html#s26-8">&sect;26.8</a>, <a href="27-historical-forks.html#s27-9">&sect;27.9</a></li>
                 <li>digital signature &middot; <a href="07-ecdsa.html#s7-1">&sect;7.1</a></li>
                 <li>discrete logarithm &middot; <a href="01-groups.html#s1-6">&sect;1.6</a></li>
@@ -163,7 +163,7 @@
                 <li>eclipse attack &middot; <a href="17-spv-theory.html#s17-5-2">&sect;17.5.2</a>, <a href="36-security-threats.html#s36-4">&sect;36.4</a></li>
                 <li>Electrum protocol &middot; <a href="20-light-clients.html#s20-2">&sect;20.2</a></li>
                 <li>elliptic curve &middot; <a href="03-elliptic-curves-real.html#s3-1">&sect;3.1</a>, <a href="04-elliptic-curves-finite.html#s4-1">&sect;4.1</a></li>
-                <li>elliptic curve discrete logarithm problem (ECDLP) &middot; <a href="04-elliptic-curves-finite.html#s4-5">&sect;4.5</a>, <a href="05-secp256k1.html#s5-10">&sect;5.10</a></li>
+                <li>elliptic curve discrete logarithm problem (ECDLP) &middot; <a href="04-elliptic-curves-finite.html#s4-5">&sect;4.5</a>, <a href="05-secp256k1.html#s5-9">&sect;5.9</a></li>
                 <li>elliptic curve group law &middot; <a href="03-elliptic-curves-real.html#s3-5">&sect;3.5</a></li>
                 <li>eltoo / LN-Symmetry &middot; <a href="32-beyond-lightning.html#s32-5">&sect;32.5</a>, <a href="24-lightning.html#s24-7">&sect;24.7</a></li>
                 <li>emergency difficulty adjustment &middot; <a href="27-historical-forks.html#s27-3-1">&sect;27.3.1</a></li>
@@ -195,7 +195,7 @@
                 <li>generator (of a group) &middot; <a href="01-groups.html#s1-4">&sect;1.4</a>, <a href="02-finite-fields.html#s2-6">&sect;2.6</a></li>
                 <li>generator point G &middot; <a href="05-secp256k1.html#s5-4">&sect;5.4</a>, <a href="04-elliptic-curves-finite.html#s4-4">&sect;4.4</a></li>
                 <li>genesis block &middot; <a href="13-blocks.html#s13-6">&sect;13.6</a></li>
-                <li>GLV endomorphism &middot; <a href="05-secp256k1.html#s5-9">&sect;5.9</a></li>
+                <li>GLV endomorphism &middot; <a href="05-secp256k1.html#s5-8">&sect;5.8</a></li>
                 <li>Golomb-coded set (GCS) &middot; <a href="19-compact-filters.html#s19-2">&sect;19.2</a></li>
                 <li>Golomb-Rice coding &middot; <a href="19-compact-filters.html#s19-2">&sect;19.2</a></li>
                 <li>gossip protocol (Lightning) &middot; <a href="24-lightning.html#s24-4">&sect;24.4</a></li>
@@ -240,7 +240,7 @@
             <h2>M</h2>
             <ul class="index-list">
                 <li>MAST &middot; <a href="29-taproot-architecture.html#s29-3">&sect;29.3</a>, <a href="12-merkle-trees.html#s12-9-2">&sect;12.9.2</a>, <a href="08-schnorr.html#s8-10">&sect;8.10</a></li>
-                <li>median time past (MTP) &middot; <a href="15-consensus-parameters.html#s15-6">&sect;15.6</a>, <a href="13-blocks.html#s13-2-4">&sect;13.2.4</a></li>
+                <li>median time past (MTP) &middot; <a href="13-blocks.html#s13-2-4">&sect;13.2.4</a>, <a href="15-consensus-parameters.html#s15-5">&sect;15.5</a></li>
                 <li>mempool &middot; <a href="13-blocks.html#s13-9">&sect;13.9</a></li>
                 <li>merged mining &middot; <a href="38-security-budget.html#s38-7-4">&sect;38.7.4</a>, <a href="31-sidechains.html#s31-8">&sect;31.8</a></li>
                 <li>Merkle mountain range &middot; <a href="12-merkle-trees.html#s12-9-1">&sect;12.9.1</a></li>
@@ -347,7 +347,7 @@
                 <li>scriptSig &middot; <a href="10-transactions.html#s10-3">&sect;10.3</a></li>
                 <li>script versioning &middot; <a href="28-segwit-deep-dive.html#s28-3">&sect;28.3</a>, <a href="16-soft-forks.html#s16-8-1">&sect;16.8.1</a></li>
                 <li>secp256k1 &middot; <a href="05-secp256k1.html#s5-2">&sect;5.2</a></li>
-                <li>security budget &middot; <a href="38-security-budget.html#s38-2">&sect;38.2</a>, <a href="15-consensus-parameters.html#s15-9-3">&sect;15.9.3</a>, <a href="25-debunking-myths.html#s25-5">&sect;25.5</a></li>
+                <li>security budget &middot; <a href="38-security-budget.html#s38-2">&sect;38.2</a>, <a href="15-consensus-parameters.html#s15-3">&sect;15.3</a>, <a href="25-debunking-myths.html#s25-5">&sect;25.5</a></li>
                 <li>SegWit &middot; <a href="10-transactions.html#s10-6">&sect;10.6</a>, <a href="16-soft-forks.html#s16-4-2">&sect;16.4.2</a>, <a href="28-segwit-deep-dive.html#s28-1">&sect;28.1</a></li>
                 <li>SegWit2x &middot; <a href="27-historical-forks.html#s27-7">&sect;27.7</a></li>
                 <li>selfish mining &middot; <a href="36-security-threats.html#s36-3">&sect;36.3</a>, <a href="14-proof-of-work.html#s14-8-3">&sect;14.8.3</a></li>

--- a/chapters/appendix-d-validation-rules.html
+++ b/chapters/appendix-d-validation-rules.html
@@ -101,7 +101,7 @@
                 <tr><td>Inputs exist</td><td>Every input references an existing unspent output in the UTXO set</td><td>Genesis</td></tr>
                 <tr><td>Coinbase maturity</td><td>Spent coinbase outputs have at least 100 confirmations</td><td>Genesis</td></tr>
                 <tr><td>Value conservation</td><td>For each transaction, total input value &ge; total output value; the difference is the fee</td><td>Genesis</td></tr>
-                <tr><td>Subsidy bound</td><td>Coinbase output total at most subsidy(height) + total fees (Theorem 10.2, Definition 15.2)</td><td>Genesis</td></tr>
+                <tr><td>Subsidy bound</td><td>Coinbase output total at most subsidy(height) + total fees (Remark 10.3, Definition 15.2)</td><td>Genesis</td></tr>
                 <tr><td>Sequence locks</td><td>Relative lock-times encoded in sequence numbers are satisfied (BIP-68)</td><td>Height 419,328</td></tr>
                 <tr><td>Script execution</td><td>Every input's script verifies under the flags active at this height (Chapter 11)</td><td>See D.5</td></tr>
             </table>

--- a/index.html
+++ b/index.html
@@ -470,7 +470,7 @@
                 <span class="ch-num">15.</span>
                 <span class="ch-title"><a href="chapters/15-consensus-parameters.html">Consensus Parameters</a></span>
             </div>
-            <p class="toc-desc">The 21 million cap · Block subsidy and halvings · Timing parameters · Block limits · Coinbase maturity · Economic design</p>
+            <p class="toc-desc">The monetary theorems: supply cap, final subsidy, inflation schedule · Timing parameters · Block, timestamp, and script limits · Coinbase maturity · Parameter immutability</p>
 
             <div class="toc-chapter">
                 <span class="ch-num">16.</span>


### PR DESCRIPTION
The four highest-priority structural fixes from the strategic audit, plus the Ch 12 duplication that fell out of them.

**Theorem deflation (Ch 10, 13-18, 20, 22-24).** "Theorem" now means proved or cited, book-wide. ~20 demotions: consensus rules → "Protocol Rule" remarks or folded into the Definitions they belong to (Conservation of Value, Coinbase Constraint, timestamp rules, adjustment bounds, heaviest-chain); trust-model bullet lists, capability lists, DoS descriptions, design patterns → titled Remarks; Theorem 17.1 (a multiplication) → Remark. One promotion: the Bloom intersection attack got a real short proof (Proposition 18.1). Kept with honest treatment: 16.1 (sketch + BIP-66 caveat), the new 17.1/17.2 (proved/cited), 18.1, 20.1 (fraud-proof coverage, refereed), 22.1, 24.1.

**Double-spend consolidation.** Was stated four times with three near-identical tables. Now: Theorem 14.2 is canonical (with the q < p hypothesis added and one extended table, all values recomputed); Chapter 26 carries the full gambler's-ruin derivation, explicitly deriving Theorem 14.2; Chapter 36 cites both and keeps only its own contribution (attack economics, confirmation policy).

**Ch 15 refactored around its thesis** (monetary policy as a theorem of the constants): Theorems 15.2/15.3 gained proofs; sections duplicating Ch 11/13/14 became cross-references; MTP now defined once (Ch 13 owns it); §15.8's ports and magic bytes — never consensus parameters — evicted to a remark in Ch 13's propagation section; sections and anchors renumbered.

**Ch 5/9 dedup.** Keys/encodings now formally defined once: Ch 9 owns keys-as-protocol-objects, Ch 5 §5.7 became connecting prose keeping its parameter analysis; HASH160 recalls Definition 6.4 instead of redefining; Bech32's Theorem 9.3 gained a refereed BCH proof sketch.

**Fallout handled:** Ch 12's Theorem 12.3 (restating SPV verification) → forward pointer; Theorem 17.1 owns it. All cross-references fixed repo-wide (Ch 17/34, Appendices A/D); index generator anchors updated for the §5/§15 renumbering; Appendix C regenerated (anchors validated); Ch 18/19 figure captions unified to the colon style; index.html Ch 15 description refreshed.

**Verification:** tag balance on all 45 pages; per-kind numbering sequential in all 40 chapters; repo-wide dangling-reference scan (definitions extracted, every reference checked): zero; every internal href#anchor resolves; double-spend table values recomputed before consolidation.

Fixes #179