### PR TITLE
Remove stale current-volume highlight

### DIFF
--- a/index.html
+++ b/index.html
@@ -105,9 +105,6 @@
             color: #888;
             margin-left: 1rem;
         }
-        .current-volume {
-            background: #fff8f0;
-        }
         .preface {
             max-width: 600px;
             margin: 3rem auto;
@@ -203,7 +200,7 @@
         <section class="volume-overview">
             <h3>The Complete Work</h3>
             <ul class="volume-list">
-                <li class="current-volume">
+                <li>
                     <span class="vol-num">Volume I:</span>
                     <span class="vol-title">Mathematical Foundations</span>
                     <span class="vol-status">— complete · proved</span>


### PR DESCRIPTION
The Volume I row in The Complete Work list carried a 'current-volume' cream highlight from when the homepage presented Vol I as the current volume of a work in progress. All five volumes are complete; the highlight now reads as unexplained emphasis. Class and CSS rule removed; all five rows render identically.