### PR TITLE
Figure sweep: every plotted curve verified against its equation

### DIFF
--- a/chapters/04-elliptic-curves-finite.html
+++ b/chapters/04-elliptic-curves-finite.html
@@ -95,100 +95,106 @@
                 <svg class="diagram" width="500" height="500" viewBox="0 0 500 500">
                     <text x="250" y="25" text-anchor="middle" font-family="Georgia" font-size="14" font-weight="bold">E(𝔽₂₃): y² = x³ + x + 1</text>
 
-                    <!-- Grid -->
+                    <!-- Lattice grid: one line per field element, x_px = 60 + 17x, y_px = 433 − 17y -->
                     <g stroke="#eee" stroke-width="1">
-                        <!-- Vertical lines -->
-                        <line x1="50" y1="50" x2="50" y2="450"/>
-                        <line x1="70" y1="50" x2="70" y2="450"/>
-                        <line x1="90" y1="50" x2="90" y2="450"/>
-                        <line x1="110" y1="50" x2="110" y2="450"/>
-                        <line x1="130" y1="50" x2="130" y2="450"/>
-                        <line x1="150" y1="50" x2="150" y2="450"/>
-                        <line x1="170" y1="50" x2="170" y2="450"/>
-                        <line x1="190" y1="50" x2="190" y2="450"/>
-                        <line x1="210" y1="50" x2="210" y2="450"/>
-                        <line x1="230" y1="50" x2="230" y2="450"/>
-                        <line x1="250" y1="50" x2="250" y2="450"/>
-                        <line x1="270" y1="50" x2="270" y2="450"/>
-                        <line x1="290" y1="50" x2="290" y2="450"/>
-                        <line x1="310" y1="50" x2="310" y2="450"/>
-                        <line x1="330" y1="50" x2="330" y2="450"/>
-                        <line x1="350" y1="50" x2="350" y2="450"/>
-                        <line x1="370" y1="50" x2="370" y2="450"/>
-                        <line x1="390" y1="50" x2="390" y2="450"/>
-                        <line x1="410" y1="50" x2="410" y2="450"/>
-                        <line x1="430" y1="50" x2="430" y2="450"/>
-                        <line x1="450" y1="50" x2="450" y2="450"/>
-                        <!-- Horizontal lines -->
-                        <line x1="50" y1="50" x2="450" y2="50"/>
-                        <line x1="50" y1="70" x2="450" y2="70"/>
-                        <line x1="50" y1="90" x2="450" y2="90"/>
-                        <line x1="50" y1="110" x2="450" y2="110"/>
-                        <line x1="50" y1="130" x2="450" y2="130"/>
-                        <line x1="50" y1="150" x2="450" y2="150"/>
-                        <line x1="50" y1="170" x2="450" y2="170"/>
-                        <line x1="50" y1="190" x2="450" y2="190"/>
-                        <line x1="50" y1="210" x2="450" y2="210"/>
-                        <line x1="50" y1="230" x2="450" y2="230"/>
-                        <line x1="50" y1="250" x2="450" y2="250"/>
-                        <line x1="50" y1="270" x2="450" y2="270"/>
-                        <line x1="50" y1="290" x2="450" y2="290"/>
-                        <line x1="50" y1="310" x2="450" y2="310"/>
-                        <line x1="50" y1="330" x2="450" y2="330"/>
-                        <line x1="50" y1="350" x2="450" y2="350"/>
-                        <line x1="50" y1="370" x2="450" y2="370"/>
-                        <line x1="50" y1="390" x2="450" y2="390"/>
-                        <line x1="50" y1="410" x2="450" y2="410"/>
-                        <line x1="50" y1="430" x2="450" y2="430"/>
-                        <line x1="50" y1="450" x2="450" y2="450"/>
+                        <!-- Vertical lines x = 0..22 -->
+                        <line x1="60" y1="59" x2="60" y2="433"/>
+                        <line x1="77" y1="59" x2="77" y2="433"/>
+                        <line x1="94" y1="59" x2="94" y2="433"/>
+                        <line x1="111" y1="59" x2="111" y2="433"/>
+                        <line x1="128" y1="59" x2="128" y2="433"/>
+                        <line x1="145" y1="59" x2="145" y2="433"/>
+                        <line x1="162" y1="59" x2="162" y2="433"/>
+                        <line x1="179" y1="59" x2="179" y2="433"/>
+                        <line x1="196" y1="59" x2="196" y2="433"/>
+                        <line x1="213" y1="59" x2="213" y2="433"/>
+                        <line x1="230" y1="59" x2="230" y2="433"/>
+                        <line x1="247" y1="59" x2="247" y2="433"/>
+                        <line x1="264" y1="59" x2="264" y2="433"/>
+                        <line x1="281" y1="59" x2="281" y2="433"/>
+                        <line x1="298" y1="59" x2="298" y2="433"/>
+                        <line x1="315" y1="59" x2="315" y2="433"/>
+                        <line x1="332" y1="59" x2="332" y2="433"/>
+                        <line x1="349" y1="59" x2="349" y2="433"/>
+                        <line x1="366" y1="59" x2="366" y2="433"/>
+                        <line x1="383" y1="59" x2="383" y2="433"/>
+                        <line x1="400" y1="59" x2="400" y2="433"/>
+                        <line x1="417" y1="59" x2="417" y2="433"/>
+                        <line x1="434" y1="59" x2="434" y2="433"/>
+                        <!-- Horizontal lines y = 0..22 -->
+                        <line x1="60" y1="433" x2="434" y2="433"/>
+                        <line x1="60" y1="416" x2="434" y2="416"/>
+                        <line x1="60" y1="399" x2="434" y2="399"/>
+                        <line x1="60" y1="382" x2="434" y2="382"/>
+                        <line x1="60" y1="365" x2="434" y2="365"/>
+                        <line x1="60" y1="348" x2="434" y2="348"/>
+                        <line x1="60" y1="331" x2="434" y2="331"/>
+                        <line x1="60" y1="314" x2="434" y2="314"/>
+                        <line x1="60" y1="297" x2="434" y2="297"/>
+                        <line x1="60" y1="280" x2="434" y2="280"/>
+                        <line x1="60" y1="263" x2="434" y2="263"/>
+                        <line x1="60" y1="246" x2="434" y2="246"/>
+                        <line x1="60" y1="229" x2="434" y2="229"/>
+                        <line x1="60" y1="212" x2="434" y2="212"/>
+                        <line x1="60" y1="195" x2="434" y2="195"/>
+                        <line x1="60" y1="178" x2="434" y2="178"/>
+                        <line x1="60" y1="161" x2="434" y2="161"/>
+                        <line x1="60" y1="144" x2="434" y2="144"/>
+                        <line x1="60" y1="127" x2="434" y2="127"/>
+                        <line x1="60" y1="110" x2="434" y2="110"/>
+                        <line x1="60" y1="93" x2="434" y2="93"/>
+                        <line x1="60" y1="76" x2="434" y2="76"/>
+                        <line x1="60" y1="59" x2="434" y2="59"/>
                     </g>
 
-                    <!-- Axes -->
-                    <line x1="50" y1="250" x2="450" y2="250" stroke="#999" stroke-width="1.5"/>
-                    <line x1="50" y1="50" x2="50" y2="450" stroke="#999" stroke-width="1.5"/>
+                    <!-- Axes: y-axis (x = 0) and x-axis (y = 0) -->
+                    <line x1="60" y1="59" x2="60" y2="433" stroke="#999" stroke-width="1.5"/>
+                    <line x1="60" y1="433" x2="434" y2="433" stroke="#999" stroke-width="1.5"/>
 
-                    <!-- Axis labels -->
-                    <text x="250" y="475" text-anchor="middle" font-family="Georgia" font-size="12" font-style="italic">x</text>
-                    <text x="30" y="250" text-anchor="middle" font-family="Georgia" font-size="12" font-style="italic">y</text>
+                    <!-- Axis labels and ticks -->
+                    <text x="446" y="437" font-family="Georgia" font-size="12" font-style="italic">x</text>
+                    <text x="49" y="48" font-family="Georgia" font-size="12" font-style="italic">y</text>
+                    <text x="52" y="448" text-anchor="middle" font-family="Georgia" font-size="10" fill="#666">0</text>
+                    <text x="434" y="448" text-anchor="middle" font-family="Georgia" font-size="10" fill="#666">22</text>
+                    <text x="52" y="63" text-anchor="end" font-family="Georgia" font-size="10" fill="#666">22</text>
 
-                    <!-- Scale: x_px = 50 + x·400/22, y_px = 250 + (11.5−y)·400/23 -->
+                    <!-- Symmetry line y = 11.5 -->
+                    <line x1="60" y1="237.5" x2="434" y2="237.5" stroke="#8b4513" stroke-width="1" stroke-dasharray="5,4"/>
+                    <text x="438" y="241" font-family="Georgia" font-size="10" fill="#8b4513">y = 11.5</text>
+
                     <!-- All 27 affine points on y² = x³ + x + 1 mod 23 -->
-
                     <g fill="#4a90d9">
-                        <circle cx="50"  cy="433" r="5"/>  <!-- (0, 1) -->
-                        <circle cx="50"  cy="67"  r="5"/>  <!-- (0, 22) -->
-                        <circle cx="68"  cy="328" r="5"/>  <!-- (1, 7) -->
-                        <circle cx="68"  cy="172" r="5"/>  <!-- (1, 16) -->
-                        <circle cx="105" cy="276" r="5"/>  <!-- (3, 10) -->
-                        <circle cx="105" cy="224" r="5"/>  <!-- (3, 13) -->
-                        <circle cx="123" cy="450" r="5"/>  <!-- (4, 0) -->
-                        <circle cx="141" cy="380" r="5"/>  <!-- (5, 4) -->
-                        <circle cx="141" cy="120" r="5"/>  <!-- (5, 19) -->
-                        <circle cx="159" cy="380" r="5"/>  <!-- (6, 4) -->
-                        <circle cx="159" cy="120" r="5"/>  <!-- (6, 19) -->
-                        <circle cx="177" cy="259" r="5"/>  <!-- (7, 11) -->
-                        <circle cx="177" cy="241" r="5"/>  <!-- (7, 12) -->
-                        <circle cx="214" cy="328" r="5"/>  <!-- (9, 7) -->
-                        <circle cx="214" cy="172" r="5"/>  <!-- (9, 16) -->
-                        <circle cx="250" cy="398" r="5"/>  <!-- (11, 3) -->
-                        <circle cx="250" cy="102" r="5"/>  <!-- (11, 20) -->
-                        <circle cx="268" cy="380" r="5"/>  <!-- (12, 4) -->
-                        <circle cx="268" cy="120" r="5"/>  <!-- (12, 19) -->
-                        <circle cx="286" cy="328" r="5"/>  <!-- (13, 7) -->
-                        <circle cx="286" cy="172" r="5"/>  <!-- (13, 16) -->
-                        <circle cx="359" cy="398" r="5"/>  <!-- (17, 3) -->
-                        <circle cx="359" cy="102" r="5"/>  <!-- (17, 20) -->
-                        <circle cx="377" cy="398" r="5"/>  <!-- (18, 3) -->
-                        <circle cx="377" cy="102" r="5"/>  <!-- (18, 20) -->
-                        <circle cx="395" cy="363" r="5"/>  <!-- (19, 5) -->
-                        <circle cx="395" cy="137" r="5"/>  <!-- (19, 18) -->
+                        <circle cx="60" cy="416" r="5"/>  <!-- (0, 1) -->
+                        <circle cx="60" cy="59" r="5"/>  <!-- (0, 22) -->
+                        <circle cx="77" cy="314" r="5"/>  <!-- (1, 7) -->
+                        <circle cx="77" cy="161" r="5"/>  <!-- (1, 16) -->
+                        <circle cx="111" cy="263" r="5"/>  <!-- (3, 10) -->
+                        <circle cx="111" cy="212" r="5"/>  <!-- (3, 13) -->
+                        <circle cx="128" cy="433" r="5"/>  <!-- (4, 0) -->
+                        <circle cx="145" cy="365" r="5"/>  <!-- (5, 4) -->
+                        <circle cx="145" cy="110" r="5"/>  <!-- (5, 19) -->
+                        <circle cx="162" cy="365" r="5"/>  <!-- (6, 4) -->
+                        <circle cx="162" cy="110" r="5"/>  <!-- (6, 19) -->
+                        <circle cx="179" cy="246" r="5"/>  <!-- (7, 11) -->
+                        <circle cx="179" cy="229" r="5"/>  <!-- (7, 12) -->
+                        <circle cx="213" cy="314" r="5"/>  <!-- (9, 7) -->
+                        <circle cx="213" cy="161" r="5"/>  <!-- (9, 16) -->
+                        <circle cx="247" cy="382" r="5"/>  <!-- (11, 3) -->
+                        <circle cx="247" cy="93" r="5"/>  <!-- (11, 20) -->
+                        <circle cx="264" cy="365" r="5"/>  <!-- (12, 4) -->
+                        <circle cx="264" cy="110" r="5"/>  <!-- (12, 19) -->
+                        <circle cx="281" cy="314" r="5"/>  <!-- (13, 7) -->
+                        <circle cx="281" cy="161" r="5"/>  <!-- (13, 16) -->
+                        <circle cx="349" cy="382" r="5"/>  <!-- (17, 3) -->
+                        <circle cx="349" cy="93" r="5"/>  <!-- (17, 20) -->
+                        <circle cx="366" cy="382" r="5"/>  <!-- (18, 3) -->
+                        <circle cx="366" cy="93" r="5"/>  <!-- (18, 20) -->
+                        <circle cx="383" cy="348" r="5"/>  <!-- (19, 5) -->
+                        <circle cx="383" cy="127" r="5"/>  <!-- (19, 18) -->
                     </g>
 
                     <!-- Note -->
                     <text x="350" y="470" text-anchor="middle" font-family="Georgia" font-size="10" fill="#666">27 finite points + 𝒪 = 28 total</text>
-
-                    <!-- Symmetry line -->
-                    <text x="453" y="243" font-family="Georgia" font-size="10" fill="#8b4513">y = 11.5</text>
                 </svg>
                 <figcaption>Figure 4.1: The elliptic curve E(𝔽₂₃) shown as discrete points. Note the symmetry about y = 11.5 (since 22 + 1 = 23).</figcaption>
             </figure>

--- a/chapters/05-secp256k1.html
+++ b/chapters/05-secp256k1.html
@@ -561,12 +561,14 @@ FD17B448 A6855419 9C47D08F FB10D4B8</pre>
                     <!-- Scale bar -->
                     <rect x="50" y="50" width="350" height="30" rx="4" fill="none" stroke="#2f4f4f" stroke-width="2"/>
 
-                    <!-- Filled portion representing security -->
-                    <rect x="50" y="50" width="350" height="30" rx="4" fill="#5a8f5a" fill-opacity="0.3"/>
+                    <!-- Filled portion representing security: 128 of 256 bits = half the bar -->
+                    <rect x="50" y="50" width="175" height="30" rx="4" fill="#5a8f5a" fill-opacity="0.3"/>
+                    <line x1="225" y1="44" x2="225" y2="86" stroke="#5a8f5a" stroke-width="1.5" stroke-dasharray="4,3"/>
 
                     <!-- Labels -->
                     <text x="50" y="100" text-anchor="start" font-family="Georgia" font-size="10">0 bits</text>
-                    <text x="225" y="70" text-anchor="middle" font-family="Georgia" font-size="14" font-weight="bold" fill="#2f4f4f">128-bit security</text>
+                    <text x="137.5" y="70" text-anchor="middle" font-family="Georgia" font-size="13" font-weight="bold" fill="#2f4f4f">128-bit security</text>
+                    <text x="225" y="100" text-anchor="middle" font-family="Georgia" font-size="10" fill="#5a8f5a">128 bits</text>
                     <text x="400" y="100" text-anchor="end" font-family="Georgia" font-size="10">256 bits</text>
 
                     <!-- Annotation -->

--- a/chapters/15-consensus-parameters.html
+++ b/chapters/15-consensus-parameters.html
@@ -133,24 +133,30 @@
                     <text x="350" y="195" text-anchor="middle" font-family="Georgia" font-size="9">2080</text>
                     <text x="430" y="195" text-anchor="middle" font-family="Georgia" font-size="9">2140</text>
 
-                    <!-- Supply curve (logarithmic approach to 21M) -->
+                    <!-- Supply curve: piecewise-linear in time, vertices at halvings,
+                         computed from S(k) = 21M(1 - 2^-k); x-axis piecewise per tick labels -->
                     <path d="M 50 180
-                             Q 80 140 100 120
-                             Q 120 100 140 90
-                             Q 170 75 200 65
-                             Q 250 56 300 54
-                             Q 350 53 400 52
-                             L 450 51"
+                             L 77.3 115.5
+                             L 113.6 83.2
+                             L 150 67.1
+                             L 170 59.1
+                             L 190 55.0
+                             L 210 53.0
+                             L 230 52.0
+                             L 250 51.5
+                             L 270 51.1
+                             L 300 51.0
+                             L 450 51.0"
                           stroke="#4a90d9" stroke-width="2.5" fill="none"/>
 
                     <!-- 21M asymptote -->
-                    <line x1="50" y1="48" x2="450" y2="48" stroke="#c44" stroke-width="1" stroke-dasharray="5,3"/>
-                    <text x="460" y="52" font-family="Georgia" font-size="9" fill="#c44">21M</text>
+                    <line x1="50" y1="50.5" x2="450" y2="50.5" stroke="#c44" stroke-width="1" stroke-dasharray="5,3"/>
+                    <text x="460" y="53" font-family="Georgia" font-size="9" fill="#c44">21M</text>
 
-                    <!-- Halving markers -->
-                    <line x1="80" y1="175" x2="80" y2="185" stroke="#5a8f5a" stroke-width="2"/>
-                    <line x1="110" y1="175" x2="110" y2="185" stroke="#5a8f5a" stroke-width="2"/>
-                    <line x1="140" y1="175" x2="140" y2="185" stroke="#5a8f5a" stroke-width="2"/>
+                    <!-- Halving markers (2012, 2016, 2020, 2024) -->
+                    <line x1="77" y1="175" x2="77" y2="185" stroke="#5a8f5a" stroke-width="2"/>
+                    <line x1="114" y1="175" x2="114" y2="185" stroke="#5a8f5a" stroke-width="2"/>
+                    <line x1="150" y1="175" x2="150" y2="185" stroke="#5a8f5a" stroke-width="2"/>
                     <line x1="170" y1="175" x2="170" y2="185" stroke="#5a8f5a" stroke-width="2"/>
 
                     <text x="125" y="170" text-anchor="middle" font-family="Georgia" font-size="9" fill="#5a8f5a">halvings</text>

--- a/chapters/36-security-threats.html
+++ b/chapters/36-security-threats.html
@@ -280,11 +280,12 @@
 
                     <!-- Honest mining line -->
                     <line x1="80" y1="140" x2="420" y2="40" stroke="#5a8f5a" stroke-width="2"/>
-                    <text x="428" y="45" font-family="Georgia" font-size="9" fill="#5a8f5a">Honest</text>
+                    <text x="320" y="90" text-anchor="middle" font-family="Georgia" font-size="9" fill="#5a8f5a">Honest</text>
 
-                    <!-- Selfish mining curve (simplified) -->
-                    <path d="M 80 140 Q 200 130 250 100 T 420 30" stroke="#c44" stroke-width="2" fill="none"/>
-                    <text x="428" y="32" font-family="Georgia" font-size="9" fill="#c44">Selfish</text>
+                    <!-- Selfish mining revenue (Eyal-Sirer 2014, gamma = 0):
+                         below honest line for q < 1/3, crosses at q = 1/3, reaches 1 at q = 1/2 -->
+                    <path d="M 80 140 L 97 139.1 L 114 136.4 L 131 132.4 L 148 127 L 165 120.5 L 182 112.7 L 199 103.3 L 216 91.6 L 226.2 82.5 L 236.4 70.2 L 243.2 58.4 L 246.6 50.4 L 250 40 L 420 40" stroke="#c44" stroke-width="2" fill="none"/>
+                    <text x="300" y="33" text-anchor="middle" font-family="Georgia" font-size="9" fill="#c44">Selfish</text>
 
                     <!-- Threshold marker -->
                     <line x1="193" y1="40" x2="193" y2="140" stroke="#8b4513" stroke-width="1" stroke-dasharray="4,2"/>

--- a/chapters/37-defense-mechanisms.html
+++ b/chapters/37-defense-mechanisms.html
@@ -135,13 +135,15 @@
                     <text x="250" y="159" text-anchor="middle" font-family="Georgia" font-size="9">Confirmations</text>
                     <text x="60" y="85" text-anchor="middle" font-family="Georgia" font-size="9" transform="rotate(-90, 60, 85)">P(reversal)</text>
 
-                    <!-- Curve for q=25% -->
-                    <path d="M 80 50 Q 120 80 160 100 T 280 120 T 400 128" stroke="#c44" stroke-width="2" fill="none"/>
-                    <text x="420" y="125" font-family="Georgia" font-size="9" fill="#c44">q=25%</text>
+                    <!-- Curve for q=25%: Nakamoto formula (Theorem 14.2),
+                         P(k) = 1, 0.5223, 0.3154, 0.1961, 0.1235, 0.0784, 0.0499 -->
+                    <path d="M 80 50 L 136 88.2 L 192 104.8 L 248 114.3 L 304 120.1 L 360 123.7 L 416 126" stroke="#c44" stroke-width="2" fill="none"/>
+                    <text x="150" y="84" font-family="Georgia" font-size="9" fill="#c44">q=25%</text>
 
-                    <!-- Curve for q=10% -->
-                    <path d="M 80 50 C 95 100, 110 118, 130 124 S 170 129, 200 129" stroke="#8b4513" stroke-width="2" fill="none"/>
-                    <text x="110" y="100" font-family="Georgia" font-size="9" fill="#8b4513">q=10%</text>
+                    <!-- Curve for q=10%: Nakamoto formula (Theorem 14.2),
+                         P(k) = 1, 0.2046, 0.0510, 0.0132, 0.0035, 0.0009, 0.0002 -->
+                    <path d="M 80 50 L 136 113.6 L 192 125.9 L 248 128.9 L 304 129.5 L 360 129.5 L 416 129.5" stroke="#8b4513" stroke-width="2" fill="none"/>
+                    <text x="92" y="120" font-family="Georgia" font-size="9" fill="#8b4513">q=10%</text>
 
                     <!-- Markers -->
                     <text x="80" y="143" font-family="Georgia" font-size="9">0</text>


### PR DESCRIPTION
Follow-up to the Figure 5.2 catch (PR #191): two agents extracted every mathematical plot from the SVGs, inferred the pixel mappings, and recomputed against the stated equations.

VERIFIED EXACT (the high-stakes ones): Ch 3's chord-and-tangent constructions — all marked points on-curve within 0.05px, chords collinear through −R, drawn tangent slope matches implicit differentiation to 3 decimal places; Fig 3.1's three curves (447 path points, worst residual 0.26px); Fig 4.1's 27 points = exhaustive enumeration of E(F23); Fig 34.2's payoff geometry; Fig 38.1's log-scale staircase (every halving exactly 24px); Fig 38.3's model anchors.

FIXED (5):
- Fig 4.1: points were correct but floated between grid lines (grid pitch ≠ lattice pitch); regenerated with exact integer mapping — all 27 points on grid intersections.
- Fig 5.4: 128-bit security fill spanned the full 256-bit bar; now exactly half, with marker.
- Fig 15.1: supply curve qualitatively too slow (~35px low through 2009-2020; half the supply exists by 2012); regenerated from S(k) = 21M(1−2^−k) on the figure's piecewise axis; halving ticks moved to true years.
- Fig 36.2: drawn selfish curve crossed honest at q≈0.64, contradicting its own 33% marker; regenerated from the Eyal-Sirer γ=0 revenue formula — crosses exactly at 1/3, reaches 1 at 1/2.
- Fig 37.1: q=10% curve at k=1 drawn at ~0.04 where Theorem 14.2 gives 0.2046; both curves regenerated through the exact computed values, full k=0-6 range, starting at P=1.

All changed figures re-rendered and visually inspected; tag balance OK; no captions or numbering touched.

Fixes #192