### PR TITLE
Fix invisible code blocks: light parchment pre theme

### DIFF
--- a/chapters/27-historical-forks.html
+++ b/chapters/27-historical-forks.html
@@ -46,7 +46,7 @@
                     only by the 32 MB network message limit, then set to 1 MB in 2010
                     (commit 172f006):
                 </p>
-                <pre style="background: #f5f5f5; padding: 1rem; font-family: monospace; font-size: 0.9rem; overflow-x: auto;">
+                <pre>
 if (block.GetSerializeSize() > MAX_BLOCK_SIZE)
     return error("CheckBlock(): size limits failed");</pre>
                 <p>
@@ -283,7 +283,7 @@ if (block.GetSerializeSize() > MAX_BLOCK_SIZE)
                     The <strong>Emergency Difficulty Adjustment</strong> reduced difficulty by
                     20% if fewer than 6 blocks were mined in 12 hours:
                 </p>
-                <pre style="background: #f5f5f5; padding: 1rem; font-family: monospace; font-size: 0.85rem;">
+                <pre style="font-size: 0.85rem;">
 if (timeSince6Blocks > 12 hours):
     difficulty = difficulty * 0.8</pre>
             </div>

--- a/chapters/28-segwit-deep-dive.html
+++ b/chapters/28-segwit-deep-dive.html
@@ -119,7 +119,7 @@
                     An ECDSA signature is a pair <span class="math">(r, s)</span> where <span class="math">s</span> can be replaced with <span class="math">n − s</span>
                     <span class="math">(mod n)</span> to produce an equivalent valid signature:
                 </p>
-                <pre style="background: #f5f5f5; padding: 1rem; font-family: monospace; font-size: 0.85rem;">
+                <pre style="font-size: 0.85rem;">
 Original:  sig = (r, s)       where s < n/2
 Malleated: sig = (r, n − s)   where n − s > n/2
 
@@ -172,7 +172,7 @@ Since R'.x = R.x (negation preserves x), both pass.</pre>
                 <p>
                     A SegWit transaction has the following serialization:
                 </p>
-                <pre style="background: #f5f5f5; padding: 1rem; font-family: monospace; font-size: 0.85rem;">
+                <pre style="font-size: 0.85rem;">
 [version]     4 bytes
 [marker]      1 byte  (0x00) - indicates SegWit
 [flag]        1 byte  (0x01)
@@ -285,7 +285,7 @@ Since R'.x = R.x (negation preserves x), both pass.</pre>
                 <p>
                     A <strong>witness program</strong> is a scriptPubKey of the form:
                 </p>
-                <pre style="background: #f5f5f5; padding: 1rem; font-family: monospace; font-size: 0.85rem;">
+                <pre style="font-size: 0.85rem;">
 OP_n &lt;data&gt;
 
 where:
@@ -520,7 +520,7 @@ where:
                     The <strong>witness commitment</strong> is placed in an OP_RETURN output
                     of the coinbase transaction:
                 </p>
-                <pre style="background: #f5f5f5; padding: 1rem; font-family: monospace; font-size: 0.85rem;">
+                <pre style="font-size: 0.85rem;">
 OP_RETURN &lt;commitment&gt;
 
 commitment = SHA256(SHA256(witness_root || witness_nonce))
@@ -691,7 +691,7 @@ commitment = SHA256(SHA256(witness_root || witness_nonce))
                 <p>
                     For SegWit inputs, the sighash is computed as:
                 </p>
-                <pre style="background: #f5f5f5; padding: 1rem; font-family: monospace; font-size: 0.85rem;">
+                <pre style="font-size: 0.85rem;">
 SHA256d(
     nVersion           ||
     hashPrevouts       ||  ← SHA256d of all input outpoints
@@ -747,7 +747,7 @@ SHA256d(
                 <p>
                     <strong>P2SH-P2WPKH</strong> wraps a SegWit program in P2SH:
                 </p>
-                <pre style="background: #f5f5f5; padding: 1rem; font-family: monospace; font-size: 0.85rem;">
+                <pre style="font-size: 0.85rem;">
 scriptPubKey: OP_HASH160 &lt;hash&gt; OP_EQUAL
 redeemScript: OP_0 &lt;20-byte-key-hash&gt;
 witness:      &lt;sig&gt; &lt;pubkey&gt;</pre>

--- a/chapters/29-taproot-architecture.html
+++ b/chapters/29-taproot-architecture.html
@@ -316,7 +316,7 @@
                 <p>
                     To spend via script path, the witness includes a <strong>control block</strong>:
                 </p>
-                <pre style="background: #f5f5f5; padding: 1rem; font-family: monospace; font-size: 0.85rem;">
+                <pre style="font-size: 0.85rem;">
 control_block = leaf_version | parity_bit || internal_pubkey || merkle_path
 
 where:
@@ -389,7 +389,7 @@ where:
                 <p>
                     <strong>OP_CHECKSIGADD</strong> enables efficient threshold signatures:
                 </p>
-                <pre style="background: #f5f5f5; padding: 1rem; font-family: monospace; font-size: 0.85rem;">
+                <pre style="font-size: 0.85rem;">
 Stack before (top → bottom): [pubkey] [n] [signature]
 Operation:    if sig valid for pubkey: n = n + 1
 Stack after:  [n] (or [n+1] if valid)

--- a/chapters/30-covenants.html
+++ b/chapters/30-covenants.html
@@ -142,7 +142,7 @@
                 <p>
                     The template hash is computed as:
                 </p>
-                <pre style="background: #f5f5f5; padding: 1rem; font-family: monospace; font-size: 0.85rem;">
+                <pre style="font-size: 0.85rem;">
 DefaultCheckTemplateVerifyHash(tx, input_index):
     return SHA256(
         nVersion ||
@@ -266,7 +266,7 @@ DefaultCheckTemplateVerifyHash(tx, input_index):
                 <p>
                     A basic vault with CTV:
                 </p>
-                <pre style="background: #f5f5f5; padding: 1rem; font-family: monospace; font-size: 0.85rem;">
+                <pre style="font-size: 0.85rem;">
 Vault Output (CTV-only; no key can spend it directly):
   &lt;ctv_hash&gt; CTV               // Can only go to the staged withdrawal
 
@@ -322,7 +322,7 @@ during which the owner claws the funds back to cold storage.</pre>
                 <p>
                     <strong>OP_CAT</strong> concatenates two stack elements:
                 </p>
-                <pre style="background: #f5f5f5; padding: 1rem; font-family: monospace; font-size: 0.85rem;">
+                <pre style="font-size: 0.85rem;">
 Stack before: [x] [y]
 OP_CAT
 Stack after:  [x || y]</pre>
@@ -355,7 +355,7 @@ Stack after:  [x || y]</pre>
                 <p>
                     Using CAT to verify transaction outputs:
                 </p>
-                <pre style="background: #f5f5f5; padding: 1rem; font-family: monospace; font-size: 0.85rem;">
+                <pre style="font-size: 0.85rem;">
 // Conceptual (simplified)
 &lt;expected_output_script&gt;
 &lt;actual_output_from_witness&gt;
@@ -534,7 +534,7 @@ OP_CHECKSIG</pre>
                     <strong>OP_CHECKSIGFROMSTACK</strong> verifies a signature against arbitrary
                     data (not the transaction sighash):
                 </p>
-                <pre style="background: #f5f5f5; padding: 1rem; font-family: monospace; font-size: 0.85rem;">
+                <pre style="font-size: 0.85rem;">
 Stack: [signature] [message] [pubkey]
 OP_CHECKSIGFROMSTACK
 Stack: [1 if valid]</pre>

--- a/chapters/35-consensus-cleanup.html
+++ b/chapters/35-consensus-cleanup.html
@@ -116,7 +116,7 @@
                 <p>
                     Bitcoin adjusts difficulty every 2016 blocks:
                 </p>
-                <pre style="background: #f5f5f5; padding: 1rem; font-family: monospace; font-size: 0.85rem;">
+                <pre style="font-size: 0.85rem;">
 new_target = old_target × (actual_time / expected_time)
 
 where:
@@ -203,7 +203,7 @@ where:
                     <em>retarget period</em> specifically (not all blocks, since MTP rules
                     already constrain non-boundary blocks):
                 </p>
-                <pre style="background: #f5f5f5; padding: 1rem; font-family: monospace; font-size: 0.85rem;">
+                <pre style="font-size: 0.85rem;">
 // New rule for retarget boundary: block at height h where h % 2016 == 0:
 timestamp(block[h]) >= timestamp(block[h-1]) - 2 hours</pre>
                 <p>
@@ -300,7 +300,7 @@ timestamp(block[h]) >= timestamp(block[h-1]) - 2 hours</pre>
                 <p>
                     Ban transactions that serialize to exactly 64 bytes:
                 </p>
-                <pre style="background: #f5f5f5; padding: 1rem; font-family: monospace; font-size: 0.85rem;">
+                <pre style="font-size: 0.85rem;">
 // New consensus rule:
 if (tx.GetSerializeSize() == 64)
     return Invalid("64-byte-tx")</pre>
@@ -327,7 +327,7 @@ if (tx.GetSerializeSize() == 64)
 
             <div class="example">
                 <p class="example-title">Example 35.1 (CVE-2012-2459)</p>
-                <pre style="background: #f5f5f5; padding: 1rem; font-family: monospace; font-size: 0.85rem;">
+                <pre style="font-size: 0.85rem;">
 Block with txs: [A, B, C]
 Merkle construction:
   Level 0: [H(A), H(B), H(C), H(C)]  // C duplicated

--- a/chapters/37-defense-mechanisms.html
+++ b/chapters/37-defense-mechanisms.html
@@ -197,7 +197,7 @@
                 <p>
                     Bitcoin Core historically included checkpoints:
                 </p>
-                <pre style="background: #f5f5f5; padding: 1rem; font-family: monospace; font-size: 0.85rem;">
+                <pre style="font-size: 0.85rem;">
 // From chainparams.cpp (historical)
 checkpointData = {
     {11111,  "0x0000000069e244f73d78e8fd29ba2fd2..."},
@@ -251,7 +251,7 @@ checkpointData = {
                     <strong>nMinimumChainWork</strong> is a hardcoded minimum cumulative
                     proof-of-work a chain must have to be considered valid:
                 </p>
-                <pre style="background: #f5f5f5; padding: 1rem; font-family: monospace; font-size: 0.85rem;">
+                <pre style="font-size: 0.85rem;">
 // Approximate minimum chain work (increases with each release)
 nMinimumChainWork = 0x0000000000000000000000000000000000000000
                     7f0000000000000000000000;</pre>

--- a/style.css
+++ b/style.css
@@ -252,8 +252,9 @@ code {
 }
 
 pre {
-    background: #2d2d2d;
-    color: #f8f8f2;
+    background: #f8f8f5;
+    color: #2f4f4f;
+    border: 1px solid #ddd;
     padding: 1rem;
     border-radius: 4px;
     overflow-x: auto;


### PR DESCRIPTION
Author-spotted: ~21 pre blocks across Ch 27/28/29/30/35/37 rendered as blank boxes — inline style overrode the dark theme's background (#2d2d2d→#f5f5f5) but not its near-white text (#f8f8f2), giving white-on-white. Reviews never caught it because agents read source, not pixels. Fix: global pre theme switched to light parchment (background #f8f8f5, ink #2f4f4f, 1px border — book convention, not terminal convention), all 21 background-bearing inline overrides stripped. Rendered proof: BIP-143 sighash block (Def 28.10) now fully legible with correct field order. Every other pre book-wide (Ch 2/3/5/7/8/14/18/23/24/39…) switches from dark to light with it.