### PR TITLE
Fix content of formerly-invisible code blocks

### DIFF
--- a/chapters/27-historical-forks.html
+++ b/chapters/27-historical-forks.html
@@ -284,8 +284,12 @@ if (block.GetSerializeSize() > MAX_BLOCK_SIZE)
                     20% if fewer than 6 blocks were mined in 12 hours:
                 </p>
                 <pre style="font-size: 0.85rem;">
-if (timeSince6Blocks > 12 hours):
-    difficulty = difficulty * 0.8</pre>
+if (MTP(tip) − MTP(tip − 6) > 12 hours):
+    difficulty = difficulty × 0.8</pre>
+                <p>
+                    The trigger compared median-time-past values (Definition 13.5), not
+                    raw timestamps.
+                </p>
             </div>
 
             <div class="remark">

--- a/chapters/28-segwit-deep-dive.html
+++ b/chapters/28-segwit-deep-dive.html
@@ -521,11 +521,13 @@ where:
                     of the coinbase transaction:
                 </p>
                 <pre style="font-size: 0.85rem;">
-OP_RETURN &lt;commitment&gt;
+scriptPubKey = 0x6a 0x24 0xaa21a9ed || commitment
+               │    │    │
+               │    │    └─ 4-byte commitment header
+               │    └─ push of 36 bytes
+               └─ OP_RETURN
 
-commitment = SHA256(SHA256(witness_root || witness_nonce))
-            |
-            0x6a24aa21a9ed  (commitment header)</pre>
+commitment = SHA256(SHA256(witness_root || witness_reserved_value))</pre>
             </div>
 
             <figure>

--- a/chapters/29-taproot-architecture.html
+++ b/chapters/29-taproot-architecture.html
@@ -391,10 +391,11 @@ where:
                 </p>
                 <pre style="font-size: 0.85rem;">
 Stack before (top → bottom): [pubkey] [n] [signature]
-Operation:    if sig valid for pubkey: n = n + 1
-Stack after:  [n] (or [n+1] if valid)
+Operation:    valid signature        → push n + 1
+              empty signature        → push n
+              invalid (non-empty)    → script fails immediately
 
-2-of-3 Tapscript:
+2-of-3 Tapscript (non-signers provide an empty signature):
   &lt;sig_C&gt; &lt;sig_B&gt; &lt;sig_A&gt;
   &lt;pk_A&gt; OP_CHECKSIG
   &lt;pk_B&gt; OP_CHECKSIGADD

--- a/chapters/30-covenants.html
+++ b/chapters/30-covenants.html
@@ -535,9 +535,11 @@ OP_CHECKSIG</pre>
                     data (not the transaction sighash):
                 </p>
                 <pre style="font-size: 0.85rem;">
-Stack: [signature] [message] [pubkey]
+Stack before (top → bottom): [pubkey] [message] [signature]
 OP_CHECKSIGFROMSTACK
-Stack: [1 if valid]</pre>
+Stack after:  valid signature     → [1]
+              empty signature     → [0]
+              invalid (non-empty) → script fails</pre>
                 <p>
                     Enables oracles, delegation, and complex covenant constructions.
                 </p>

--- a/chapters/35-consensus-cleanup.html
+++ b/chapters/35-consensus-cleanup.html
@@ -298,11 +298,13 @@ timestamp(block[h]) >= timestamp(block[h-1]) - 2 hours</pre>
             <div class="remark">
                 <p class="remark-title">Remark 35.4 (Proposed Fix: 64-Byte Transactions)</p>
                 <p>
-                    Ban transactions that serialize to exactly 64 bytes:
+                    Ban transactions whose witness-stripped serialization is exactly
+                    64 bytes (the stripped form is what feeds the txid and the Merkle
+                    leaf):
                 </p>
                 <pre style="font-size: 0.85rem;">
 // New consensus rule:
-if (tx.GetSerializeSize() == 64)
+if (tx.GetSerializeSize(WITHOUT_WITNESS) == 64)
     return Invalid("64-byte-tx")</pre>
                 <p>
                     No legitimate use of 64-byte transactions is known.

--- a/chapters/37-defense-mechanisms.html
+++ b/chapters/37-defense-mechanisms.html
@@ -252,9 +252,10 @@ checkpointData = {
                     proof-of-work a chain must have to be considered valid:
                 </p>
                 <pre style="font-size: 0.85rem;">
-// Approximate minimum chain work (increases with each release)
-nMinimumChainWork = 0x0000000000000000000000000000000000000000
-                    7f0000000000000000000000;</pre>
+// Approximate minimum chain work (increases with each release;
+// shown at its mid-2026 magnitude, roughly 8.5 × 10²⁸)
+nMinimumChainWork = 0x0000000000000000000000000000000000000001
+                    128750f82f4c366153a3a030;</pre>
                 <p>
                     Chains below this threshold are rejected without full validation.
                 </p>


### PR DESCRIPTION
The 21 pre blocks made visible in PR #197 had never been visually proofread; a spec-verification pass (against BIP-141/143/144/341/342/119/347/348/54, Core chainparams, the BCH EDA rule) found 14 clean — including the BIP-143 preimage order, CTV template hash, control block format, and all four checkpoint hashes byte-for-byte — and 6 needing fixes, now applied:

1. Def 29.6 (CHECKSIGADD): 'or n+1 if valid' implied an invalid signature pushes n; per BIP-342 only an EMPTY signature pushes n — a non-empty invalid signature fails the script. Also noted non-signers provide empty signatures.
2. Def 28.9 (witness commitment): OP_RETURN was double-counted (0x6a24aa21a9ed labeled 'commitment header' alongside 'OP_RETURN <commitment>'); layout now annotated byte-by-byte: 0x6a = OP_RETURN, 0x24 = push-36, 0xaa21a9ed = header; witness_nonce renamed witness_reserved_value per BIP-141.
3. Rem 35.4 (64-byte rule): 'witness-stripped' qualifier added per BIP-54 (the stripped form feeds the txid/Merkle leaf).
4. Def 37.2 (nMinimumChainWork): refreshed to mid-2026 magnitude (~8.5e28).
5. Def 27.3 (EDA): trigger stated as MTP comparison (Definition 13.5 ref verified).
6. Def 30.8 (CSFS): top-to-bottom stack annotation + empty/invalid signature behavior per BIP-348.

Tag balance verified on all six files.