### PR TITLE
Fix epigraph: replace Poincaré misquote with Cantor

### DIFF
--- a/index.html
+++ b/index.html
@@ -190,9 +190,8 @@
     </div>
 
     <div class="epigraph">
-        <p>"The mathematician does not study pure mathematics because it is useful;
-        he studies it because he delights in it and he delights in it because it is beautiful."</p>
-        <p class="attribution">— Henri Poincaré</p>
+        <p>"The essence of mathematics lies entirely in its freedom."</p>
+        <p class="attribution">— Georg Cantor, <em>Grundlagen einer allgemeinen Mannigfaltigkeitslehre</em> (1883)</p>
     </div>
 
     <main class="table-of-contents">


### PR DESCRIPTION
## Summary

Fixes #202

The homepage epigraph attributed a quote to Poincaré that has no traceable source in his writings. The *Science et méthode* (1908) original uses "scientist" and "nature"; the "mathematician / pure mathematics" variant is a widely circulated paraphrase, not a quotation.

Replaced with a confirmed, well-sourced line from Georg Cantor's *Grundlagen einer allgemeinen Mannigfaltigkeitslehre* (1883):

> "The essence of mathematics lies entirely in its freedom."

Cantor wrote this in response to Kronecker's opposition to set theory, asserting the freedom to pursue any internally consistent mathematical theory. Thematically apt for a book that treats Bitcoin as a mathematical object.

## Test plan

- [ ] Render index.html and confirm epigraph displays correctly with italic source title
- [ ] Verify no layout shift from shorter quote